### PR TITLE
[UNO-514] RW document white labeling

### DIFF
--- a/config/block.block.common_design_subtheme_page_title.yml
+++ b/config/block.block.common_design_subtheme_page_title.yml
@@ -2,6 +2,8 @@ uuid: 6fa7c666-67ea-4132-b414-1a2982eda97d
 langcode: en
 status: true
 dependencies:
+  module:
+    - system
   theme:
     - common_design_subtheme
 _core:
@@ -17,4 +19,8 @@ settings:
   label: 'Page title'
   label_display: '0'
   provider: core
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: true
+    pages: '/press-releases/*'

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -66,6 +66,8 @@ module:
   text: 0
   token: 0
   toolbar: 0
+  unocha_reliefweb: 0
+  unocha_utility: 0
   update: 0
   user: 0
   user_display_name: 0

--- a/config/unocha_reliefweb.settings.yml
+++ b/config/unocha_reliefweb.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: '-QZ1seQJjnMsuxisbsBMiKHJsRblIyIkcMYrv5UF0yc'
+reliefweb_api_url: 'https://api.reliefweb.int/v1'
+reliefweb_api_appname: unocha.org
+reliefweb_api_cache_enabled: true
+reliefweb_api_cache_lifetime: 300
+reliefweb_api_verify_ssl: true
+reliefweb_website: 'https://reliefweb.int'
+reliefweb_document_not_found_max_age: 600

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,4 +52,5 @@ COPY --from=builder /srv/www/composer.patches.json /srv/www/composer.patches.jso
 COPY --from=builder /srv/www/composer.lock /srv/www/composer.lock
 COPY --from=builder /srv/www/patches /srv/www/patches
 COPY --from=builder /srv/www/scripts /srv/www/scripts
+COPY --from=builder /srv/www/docker/etc/nginx/custom /etc/nginx/custom/
 COPY --from=builder /srv/www/docker/etc/nginx/apps/drupal/fastcgi_drupal.conf /etc/nginx/apps/drupal/fastcgi_drupal.conf

--- a/docker/etc/nginx/custom/01_attachment_redirections.conf
+++ b/docker/etc/nginx/custom/01_attachment_redirections.conf
@@ -1,0 +1,50 @@
+## Attachments.
+location /attachments/ {
+  try_files /dev/null @reliefweb-file;
+}
+
+## Attachments previews.
+location /sites/default/files/styles/thumbnail/public/previews/ {
+  try_files /dev/null @reliefweb-file;
+}
+location /sites/default/files/styles/small/public/previews/ {
+  try_files /dev/null @reliefweb-file;
+}
+location /sites/default/files/styles/medium/public/previews/ {
+  try_files /dev/null @reliefweb-file;
+}
+location /sites/default/files/styles/large/public/previews/ {
+  try_files /dev/null @reliefweb-file;
+}
+
+## Pass the request to ReliefWeb.
+location @reliefweb-file {
+  ## Use our custom 404 handler so we can set the content disposition
+  ## to inline to prevent the browser from downloading a file with the
+  ## "404 Not Found" message.
+  error_page 404 @attachment-404;
+
+  ## Return a 404 when the connection to the docstore fails.
+  error_page 502 @attachment-404;
+
+  ## Make sure we can catch the 404 error to be able to use our handler.
+  proxy_intercept_errors on;
+
+  ## Pass the request to ReleifWeb.
+  proxy_pass https://reliefweb.int;
+
+  ## Override connection and buffer vars: do not attempt to buffer, just throw
+  ## the data out right away and close the docstore connection when done.
+  proxy_set_header Connection '';
+  proxy_buffering off;
+  tcp_nodelay on;
+  tcp_nopush off;
+}
+
+## 404 handler for attachments that prevent browsers from downloading a file
+## with the attachment file name but containing a "404 Not Found" message.
+location @attachment-404 {
+  add_header Content-Type 'text/plain' always;
+  add_header Content-Disposition 'inline' always;
+  return 404 "404 Not Found";
+}

--- a/html/modules/custom/unocha_reliefweb/README.md
+++ b/html/modules/custom/unocha_reliefweb/README.md
@@ -1,0 +1,9 @@
+UNOCHA - ReliefWeb module
+=========================
+
+This module provides integration with ReliefWeb.
+
+## Integrations
+
+- [ReliefWeb API Client](src/Services/ReliefWebApiClient.php): sercice (`reliefweb_api.client`) to retrieve data from the ReliefWeb API
+- [ReliefWeb Document Controller](src/Controller/ReliefWebDocument.php): controller to display RW documents as if unocha.org pages

--- a/html/modules/custom/unocha_reliefweb/config/install/unocha_reliefweb.settings.yml
+++ b/html/modules/custom/unocha_reliefweb/config/install/unocha_reliefweb.settings.yml
@@ -1,0 +1,14 @@
+# ReliefWeb API URL.
+reliefweb_api_url: https://api.reliefweb.int/v1
+# App name parameter to indentify the API requests.
+reliefweb_api_appname: unocha.org
+# Cache the query results.
+reliefweb_api_cache_enabled: true
+# How long to cache the query results.
+reliefweb_api_cache_lifetime: 300
+# Verify the SSL certificate of the API query performing requests.
+reliefweb_api_verify_ssl: true
+# ReliefWeb site URL.
+reliefweb_website: https://reliefweb.int
+# Max age when for a ReliefWeb document page not found response.
+reliefweb_document_not_found_max_age: 600

--- a/html/modules/custom/unocha_reliefweb/config/schema/unocha_reliefweb.schema.yml
+++ b/html/modules/custom/unocha_reliefweb/config/schema/unocha_reliefweb.schema.yml
@@ -1,0 +1,25 @@
+unocha_reliefweb.settings:
+  type: config_object
+  label: 'UNOCHA ReliefWeb integration settings'
+  mapping:
+    reliefweb_api_url:
+      type: string
+      label: 'ReliefWeb API URL'
+    reliefweb_api_appname:
+      type: string
+      label: 'App name parameter to indentify the API requests.'
+    reliefweb_api_cache_enabled:
+      type: boolean
+      label: 'Cache the API query results.'
+    reliefweb_api_cache_lifetime:
+      type: integer
+      label: 'How long to cache the API query results.'
+    reliefweb_api_verify_ssl:
+      type: boolean
+      label: 'Verify the SSL certificate of the API query performing requests.'
+    reliefweb_website:
+      type: string
+      label: 'ReliefWeb site URL.'
+    reliefweb_document_not_found_max_age:
+      type: integer
+      label: 'Max age when for a ReliefWeb document page not found response.'

--- a/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
+++ b/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Drupal\unocha_reliefweb\Controller;
+
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Http\Exception\CacheableNotFoundHttpException;
+use Drupal\unocha_reliefweb\Services\ReliefWebApiClient;
+use Drupal\unocha_utility\Helpers\DateHelper;
+use Drupal\unocha_utility\Helpers\HtmlSanitizer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Controller for page showing a document retrieved from ReliefWeb.
+ */
+class ReliefWebDocumentController extends ControllerBase {
+
+  /**
+   * ReliefWeb API config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The ReliefWeb API Client.
+   *
+   * @var \Drupal\unocha_reliefweb\Services\ReliefWebApiClient
+   */
+  protected $apiClient;
+
+  /**
+   * The parse API data for the document.
+   *
+   * @var array
+   */
+  protected $data;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   * @param \Drupal\unocha_reliefweb\Services\ReliefWebApiClient $api_client
+   *   The ReliefWeb API Client.
+   */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    RequestStack $request_stack,
+    ReliefWebApiClient $api_client
+  ) {
+    $this->config = $config_factory->get('unocha_reliefweb.settings');
+    $this->requestStack = $request_stack;
+    $this->apiClient = $api_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('request_stack'),
+      $container->get('reliefweb_api.client')
+    );
+  }
+
+  /**
+   * Get the page title.
+   *
+   * @param string $ocha_product
+   *   The type of document.
+   *
+   * @return string|\Drupal\Component\Render\MarkupInterface
+   *   Page title.
+   */
+  public function getPageTitle($ocha_product) {
+    $this->retrieveApiData($ocha_product);
+    return $this->data['title'] ?? '';
+  }
+
+  /**
+   * Get the page content.
+   *
+   * @param string $ocha_product
+   *   The type of document.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function getPageContent($ocha_product) {
+    $this->retrieveApiData($ocha_product);
+    if (empty($this->data)) {
+      return [];
+    }
+
+    $content = [];
+    if (!empty($this->data['attachments'])) {
+      $content['attachments'] = $this->renderAttachmentList($this->data['attachments']);
+    }
+    if (!empty($this->data['body'])) {
+      $content['body'] = ['#markup' => $this->data['body']];
+    }
+
+    return [
+      '#theme' => 'unocha_reliefweb_document',
+      '#title' => $this->data['title'],
+      '#date' => $this->data['date'],
+      '#content' => $content,
+    ];
+  }
+
+  /**
+   * Render a list of attachemnts.
+   *
+   * @param array $attachments
+   *   List of attachments.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function renderAttachmentList(array $attachments) {
+    if (empty($attachments)) {
+      return [];
+    }
+
+    $list = [];
+    foreach ($attachments as $attachment) {
+      $extension = $this->extractFileExtension($attachment['filename']);
+      $list[] = [
+        'url' => $attachment['url'],
+        'name' => $attachment['filename'],
+        'preview' => $this->renderAttachmentPreview($attachment),
+        'label' => $this->t('Download Attachment'),
+        'description' => '(' . implode(' | ', array_filter([
+          mb_strtoupper($extension),
+          format_size($attachment['filesize']),
+          $attachment['description'] ?? '',
+        ])) . ')',
+      ];
+    }
+
+    return [
+      '#theme' => 'unocha_reliefweb_attachment_list',
+      '#list' => $list,
+    ];
+  }
+
+  /**
+   * Render an attachment preview.
+   *
+   * @param array $attachment
+   *   The attachment data.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function renderAttachmentPreview(array $attachment) {
+    if (empty($attachment['preview'])) {
+      return [];
+    }
+
+    // @todo review when deciding on how to deal with image styles for
+    // images coming from ReliefWeb.
+    return [
+      '#theme' => 'image',
+      '#uri' => $attachment['preview']['url-small'] . '?' . $attachment['preview']['version'],
+      '#alt' => $this->t('Preview of @filename', [
+        '@filename' => $attachment['filename'],
+      ]),
+      '#attributes' => [
+        'class' => ['unocha-reliefweb-attachment-preview'],
+      ],
+    ];
+  }
+
+  /**
+   * Retrieve the data from the ReliefWeb API.
+   *
+   * @param string $ocha_product
+   *   The type of document.
+   */
+  protected function retrieveApiData($ocha_product) {
+    if (empty($ocha_product)) {
+      $this->throwNotFound();
+    }
+
+    $base_url = $this->config->get('reliefweb_website') ?? 'https://reliefweb.int';
+
+    $url = $this->requestStack->getCurrentRequest()->getRequestUri();
+    $url_parts = UrlHelper::parse($url);
+    $url_path = preg_replace('#^/?[^/]+/#', 'report/', $url_parts['path']);
+    $url_alias = $base_url . '/' . $url_path;
+
+    $payload = [
+      'filter' => [
+        'conditions' => [
+          [
+            // @todo review in case we want to use the term ID.
+            'field' => 'ocha_product.name.exact',
+            'value' => $ocha_product,
+          ],
+          [
+            // @todo review in case we can use the node ID.
+            // @todo review in case other aliases are indexed in the RW API.
+            'field' => 'url_alias',
+            'value' => $url_alias,
+          ],
+        ],
+        'operator' => 'AND',
+      ],
+      'limit' => 1,
+      'fields' => [
+        'include' => [
+          'title',
+          'body-html',
+          'date.original',
+          // @todo we propably need to provide our own image_style_downloader to
+          // get the image from RW and convert it to the appropriate style.
+          'image',
+          'file',
+          // @todo use it as alternate or canonical URL?
+          'url_alias',
+        ],
+      ],
+    ];
+
+    $data = $this->apiClient->request('reports', $payload);
+    if (!empty($data['data'])) {
+      $this->data = $this->parseApiData($data);
+    }
+    else {
+      $this->throwNotFound();
+    }
+  }
+
+  /**
+   * Parse the ReliefWeb API data.
+   *
+   * @param array $raw
+   *   Raw data from the ReliefWeb API.
+   *
+   * @return array
+   *   The parsed API data.
+   */
+  protected function parseApiData(array $raw) {
+    if (empty($raw['data'][0]['fields'])) {
+      return [];
+    }
+
+    $data = [];
+    $fields = $raw['data'][0]['fields'];
+    $unocha_url = $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . '/';
+
+    $data['title'] = $fields['title'];
+    $data['date'] = DateHelper::getDateTimeStamp($fields['date']['original']);
+    $data['body'] = HtmlSanitizer::sanitize($fields['body-html']);
+
+    if (!empty($fields['file'])) {
+      $data['attachments'] = $fields['file'];
+      // Change the URLs of the attachment to be an unocha.org URL.
+      $this->apiClient::updateApiUrls($data['attachments'], $unocha_url);
+    }
+
+    if (!empty($fields['image'])) {
+      $data['image'] = $fields['image'];
+      // Change the URLs of the attachment to be an unocha.org URL.
+      $this->apiClient::updateApiUrls($data['image'], $unocha_url);
+    }
+
+    // @todo handle image.
+    return $data;
+  }
+
+  /**
+   * Throw a page not found exception.
+   */
+  protected function throwNotFound() {
+    $max_age = $this->config->get('reliefweb_document_not_found_max_age') ?? 0;
+    $cache_metadata = new CacheableMetadata();
+    $cache_metadata->setCacheMaxAge($max_age);
+    throw new CacheableNotFoundHttpException($cache_metadata);
+  }
+
+  /**
+   * Extract the extension of the file.
+   *
+   * @param string $file_name
+   *   File name.
+   *
+   * @return string
+   *   File extension in lower case.
+   */
+  protected function extractFileExtension($file_name) {
+    if (empty($file_name)) {
+      return '';
+    }
+    return mb_strtolower(pathinfo($file_name, PATHINFO_EXTENSION));
+  }
+
+}

--- a/html/modules/custom/unocha_reliefweb/src/Routing/ReliefWebDocumentRoutes.php
+++ b/html/modules/custom/unocha_reliefweb/src/Routing/ReliefWebDocumentRoutes.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\unocha_reliefweb\Routing;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * Defines dynamic routes.
+ */
+class ReliefWebDocumentRoutes {
+
+  /**
+   * Provides dynamic routes.
+   */
+  public function routes() {
+    // @todo find a common prefix or something to be able to identify those
+    // routes. Maybe define them in the config so we can add more?
+    $routes = [];
+
+    // Example route for press releases.
+    $routes['unocha_reliefweb.press_releases.document'] = new Route(
+      // Path.
+      '/press-releases/{country}/{title}',
+      // Route defaults.
+      [
+        '_controller' => '\Drupal\unocha_reliefweb\Controller\ReliefWebDocumentController::getPageContent',
+        '_title_callback' => '\Drupal\unocha_reliefweb\Controller\ReliefWebDocumentController::getPageTitle',
+        // @todo get that from the configuration as well and maybe use term ID.
+        'ocha_product' => 'Press Release',
+      ],
+      // Route requirements.
+      [
+        '_permission'  => 'access content',
+      ]
+    );
+
+    return $routes;
+  }
+
+}

--- a/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebApiClient.php
+++ b/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebApiClient.php
@@ -1,0 +1,497 @@
+<?php
+
+namespace Drupal\unocha_reliefweb\Services;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\Utils;
+
+/**
+ * ReliefWeb API client service class.
+ */
+class ReliefWebApiClient {
+
+  /**
+   * The default cache backend.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
+
+  /**
+   * ReliefWeb API config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * The HTTP client service.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * The logger service.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Map API resources to cache tags.
+   *
+   * @var array
+   */
+  protected static $cacheTags = [];
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The HTTP client service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory service.
+   */
+  public function __construct(CacheBackendInterface $cache_backend, ConfigFactoryInterface $config_factory, TimeInterface $time, ClientInterface $http_client, LoggerChannelFactoryInterface $logger_factory) {
+    $this->cache = $cache_backend;
+    $this->config = $config_factory->get('unocha_reliefweb.settings');
+    $this->time = $time;
+    $this->httpClient = $http_client;
+    $this->logger = $logger_factory->get('unocha_reliefweb');
+  }
+
+  /**
+   * Perform a POST request against the ReliefWeb API.
+   *
+   * @param string $resource
+   *   API resource endpoint (ex: reports).
+   * @param array $payload
+   *   API request payload (with fields, filters, sort etc.)
+   * @param bool $decode
+   *   Whether to decode (json) the output or not.
+   * @param int $timeout
+   *   Request timeout.
+   * @param bool $cache_enabled
+   *   Whether to cache the queries or not.
+   *
+   * @return array|null
+   *   The data from the API response or NULL in case of error.
+   */
+  public function request($resource, array $payload, $decode = TRUE, $timeout = 5, $cache_enabled = TRUE) {
+    $queries = [
+      $resource => [
+        'resource' => $resource,
+        'payload' => $payload,
+      ],
+    ];
+
+    $results = $this->requestMultiple($queries, $decode, $timeout, $cache_enabled);
+    return $results[$resource];
+  }
+
+  /**
+   * Perform parallel queries to the API.
+   *
+   * This only deals with POST requests.
+   *
+   * @param array $queries
+   *   List of queries to perform in parallel. Each item is an associative
+   *   array with the resource and the query payload.
+   * @param bool $decode
+   *   Whether to decode (json) the output or not.
+   * @param int $timeout
+   *   Request timeout.
+   * @param bool $cache_enabled
+   *   Whether to cache the queries or not.
+   *
+   * @return array
+   *   Return array where each item contains the response to the corresponding
+   *   query to the API.
+   *
+   * @see https://docs.guzzlephp.org/en/stable/quickstart.html#concurrent-requests
+   */
+  public function requestMultiple(array $queries, $decode = TRUE, $timeout = 5, $cache_enabled = TRUE) {
+    $results = [];
+    $api_url = $this->config->get('reliefweb_api_url');
+    $appname = $this->config->get('reliefweb_api_appname') ?: 'reliefweb.int';
+    $cache_enabled = $cache_enabled && ($this->config->get('reliefweb_api_cache_enabled') ?? TRUE);
+    $cache_lifetime = $this->config->get('reliefweb_api_cache_lifetime') ?? 300;
+    $verify_ssl = $this->config->get('reliefweb_api_verify_ssl');
+
+    // Initialize the result array and retrieve the data for the cached queries.
+    $cache_ids = [];
+    foreach ($queries as $index => $query) {
+      $payload = $query['payload'] ?? '';
+
+      // Sanitize the query payload.
+      if (is_array($payload)) {
+        $payload = static::sanitizePayload($payload);
+      }
+
+      // Update the query payload.
+      $queries[$index]['payload'] = $payload;
+
+      // Attempt to get the data from the cache.
+      $results[$index] = NULL;
+      if ($cache_enabled) {
+        // Retrieve the cache id for the query.
+        $cache_id = static::getCacheId($query['resource'], $payload);
+        $cache_ids[$index] = $cache_id;
+        // Attempt to retrieve the cached data for the query.
+        $cache = $this->cache->get($cache_id);
+        if (isset($cache->data)) {
+          $results[$index] = $cache->data;
+        }
+      }
+    }
+
+    // Prepare the requests.
+    $promises = [];
+    foreach ($queries as $index => $query) {
+      // Skip queries with cached data.
+      if (isset($results[$index])) {
+        continue;
+      }
+
+      $url = $api_url . '/' . $query['resource'] . '?appname=' . $appname;
+
+      // Encode the payload if needed. It may already be an encoded JSON string.
+      $payload = $query['payload'] ?? '';
+      if (is_array($payload)) {
+        $payload = json_encode($payload);
+
+        // Skip the request if something is wrong with the payload.
+        if ($payload === FALSE) {
+          $results[$index] = NULL;
+          $this->logger->error('Could not encode payload when requesting @url: @payload', [
+            '@url' => $api_url . '/' . $query['resource'],
+            '@payload' => print_r($query['payload'], TRUE),
+          ]);
+          continue;
+        }
+      }
+
+      try {
+        $promises[$index] = $this->httpClient->postAsync($url, [
+          'headers' => ['Content-Type: application/json'],
+          'body' => $payload,
+          'timeout' => $timeout,
+          'connect_timeout' => $timeout,
+          'verify' => $verify_ssl,
+        ]);
+      }
+      catch (\Exception $exception) {
+        $this->logger->error('Exception while querying @url: @exception', [
+          '@url' => $api_url . '/' . $query['resource'],
+          '@exception' => $exception->getMessage(),
+        ]);
+      }
+    }
+
+    // Execute the requests in parallel and retrieve and cache the response's
+    // data.
+    $promise_results = Utils::settle($promises)->wait();
+    foreach ($promise_results as $index => $result) {
+      $data = NULL;
+
+      // Parse the response in case of success.
+      if ($result['state'] === 'fulfilled') {
+        $response = $result['value'];
+
+        // Retrieve the raw response's data.
+        if ($response->getStatusCode() === 200) {
+          $data = (string) $response->getBody();
+        }
+        else {
+          $this->logger->notice('Unable to retrieve API data (code: @code) when requesting @url with payload @payload', [
+            '@code' => $response->getStatusCode(),
+            '@url' => $api_url . '/' . $queries[$index]['resource'],
+            '@payload' => print_r($queries[$index]['payload'], TRUE),
+          ]);
+          $data = '';
+        }
+      }
+      // Otherwise log the error.
+      else {
+        $this->logger->notice('Unable to retrieve API data (code: @code) when requesting @url with payload @payload: @reason', [
+          '@code' => $result['reason']->getCode(),
+          '@url' => $api_url . '/' . $queries[$index]['resource'],
+          '@payload' => print_r($queries[$index]['payload'], TRUE),
+          '@reason' => $result['reason']->getMessage(),
+        ]);
+      }
+
+      // Cache the data unless cache is disabled or there was an issue with the
+      // request in which case $data is NULL.
+      if (isset($cache, $cache_ids[$index], $queries[$index]['resource'])) {
+        $tags = static::getCacheTags($queries[$index]['resource']);
+        $this->cache->set($cache_ids[$index], $data, $cache_lifetime, $tags);
+      }
+
+      $results[$index] = $data;
+    }
+
+    // We don't store the decoded data. This is to ensure that we can use the
+    // same cached data regardless of whether to return JSON data or not.
+    if ($decode) {
+      foreach ($results as $index => $data) {
+        if (!empty($data)) {
+          // Decode the data, skip if invalid.
+          try {
+            $data = json_decode($data, TRUE, 512, JSON_THROW_ON_ERROR);
+          }
+          catch (\Exception $exception) {
+            $data = NULL;
+            $this->logger->notice('Unable to decode ReliefWeb API data for request @url with payload @payload', [
+              '@url' => $api_url . '/' . $queries[$index]['resource'],
+              '@payload' => print_r($queries[$index]['payload'], TRUE),
+            ]);
+          }
+
+          // Ensure the URL aliases of the resources point to the current site.
+          if (!empty($data['data'])) {
+            static::updateApiUrls($data['data']);
+          }
+
+          // Add the resulting data with same index as the query.
+          $results[$index] = $data;
+        }
+      }
+    }
+    return $results;
+  }
+
+  /**
+   * Sanitize and simplify an API query payload.
+   *
+   * @param array $payload
+   *   API query payload.
+   * @param bool $combine
+   *   TRUE to optimize the filters by combining their values when possible.
+   *
+   * @return array
+   *   Sanitized payload.
+   */
+  public static function sanitizePayload(array $payload, $combine = FALSE) {
+    // Remove search value and fields if the value is empty.
+    if (empty($payload['query']['value'])) {
+      unset($payload['query']);
+    }
+    // Optimize the filter if any.
+    if (isset($payload['filter'])) {
+      $filter = static::optimizeFilter($payload['filter'], $combine);
+
+      if (!empty($filter)) {
+        $payload['filter'] = $filter;
+      }
+      else {
+        unset($payload['filter']);
+      }
+    }
+    // Optimize the facet filters if any.
+    if (isset($payload['facets'])) {
+      foreach ($payload['facets'] as $key => $facet) {
+        if (isset($facet['filter'])) {
+          $filter = static::optimizeFilter($facet['filter'], $combine);
+          if (!empty($filter)) {
+            $payload['facets'][$key]['filter'] = $filter;
+          }
+          else {
+            unset($payload['facets'][$key]['filter']);
+          }
+        }
+      }
+    }
+    return $payload;
+  }
+
+  /**
+   * Optimize a filter, removing uncessary nested conditions.
+   *
+   * @param array $filter
+   *   Filter following the API syntax.
+   * @param bool $combine
+   *   TRUE to optimize even more the filter by combining values when possible.
+   *
+   * @return array|null
+   *   Optimized filter.
+   */
+  public static function optimizeFilter(array $filter, $combine = FALSE) {
+    if (isset($filter['conditions'])) {
+      if (isset($filter['operator'])) {
+        $filter['operator'] = strtoupper($filter['operator']);
+      }
+
+      foreach ($filter['conditions'] as $key => $condition) {
+        $condition = static::optimizeFilter($condition, $combine);
+        if (isset($condition)) {
+          $filter['conditions'][$key] = $condition;
+        }
+        else {
+          unset($filter['conditions'][$key]);
+        }
+      }
+      // @todo eventually check if it's worthy to optimize by combining
+      // filters with same field and same negation inside a conditional filter.
+      if (!empty($filter['conditions'])) {
+        if ($combine) {
+          $filter['conditions'] = static::combineConditions($filter['conditions'], $filter['operator'] ?? NULL);
+        }
+        if (count($filter['conditions']) === 1) {
+          $condition = reset($filter['conditions']);
+          if (!empty($filter['negate'])) {
+            $condition['negate'] = TRUE;
+          }
+          $filter = $condition;
+        }
+      }
+      else {
+        $filter = NULL;
+      }
+    }
+    return !empty($filter) ? $filter : NULL;
+  }
+
+  /**
+   * Combine simple filter conditions to shorten the filters.
+   *
+   * @param array $conditions
+   *   Filter conditions.
+   * @param string $operator
+   *   Operator to join the conditions.
+   *
+   * @return array
+   *   Combined and simplied filter conditions.
+   */
+  public static function combineConditions(array $conditions, $operator = 'AND') {
+    $operator = $operator ?: 'AND';
+    $filters = [];
+    $result = [];
+
+    foreach ($conditions as $condition) {
+      $field = $condition['field'] ?? NULL;
+      $value = $condition['value'] ?? NULL;
+      $condition_operator = $condition['operator'] ?? NULL;
+
+      // Nested conditions - flatten the condition's conditions.
+      if (!empty($condition['conditions'])) {
+        $condition['conditions'] = static::combineConditions($condition['conditions'], $condition_operator);
+        $result[] = $condition;
+      }
+      // Existence filter - keep as is.
+      elseif (is_null($value)) {
+        $result[] = $condition;
+      }
+      // Range filter - keep as is.
+      elseif (is_array($value) && (isset($value['to']) || isset($value['to']))) {
+        $result[] = $condition;
+      }
+      // Different operator or negated condition -  keep as is.
+      elseif ((isset($condition_operator) && $condition_operator !== $operator) || !empty($condition['negate'])) {
+        $result[] = $condition;
+      }
+      elseif (is_array($value)) {
+        foreach ($value as $item) {
+          $filters[$field][] = $item;
+        }
+      }
+      else {
+        $filters[$field][] = $value;
+      }
+    }
+
+    foreach ($filters as $field => $values) {
+      $filter = [
+        'field' => $field,
+      ];
+
+      $value = array_unique($values);
+      if (count($value) === 1) {
+        $filter['value'] = reset($value);
+      }
+      else {
+        $filter['value'] = $value;
+        $filter['operator'] = $operator;
+      }
+      $result[] = $filter;
+    }
+    return $result;
+  }
+
+  /**
+   * Determine the cache id of an API query.
+   *
+   * @param string $resource
+   *   API resource.
+   * @param array|string|null $payload
+   *   API payload.
+   *
+   * @return string
+   *   Cache id.
+   */
+  public static function getCacheId($resource, $payload) {
+    $hash = hash('sha256', serialize($payload ?? ''));
+    return 'reliefweb_api:queries:' . $resource . ':' . $hash;
+  }
+
+  /**
+   * Determine the cache tags of an API query's resource.
+   *
+   * @param string $resource
+   *   API resource.
+   *
+   * @return array
+   *   Cache tags.
+   */
+  public static function getCacheTags($resource) {
+    // @todo review what tags would make sense.
+    $tags = static::$cacheTags[$resource] ?? [];
+    $tags[] = 'reliefweb_api:' . $resource;
+    return $tags;
+  }
+
+  /**
+   * Update the host of API URL fields recursively.
+   *
+   * Note: this mostly for development to convert the URLs from the API used
+   * for dev (ex: stage) to URLs starting with `reliefweb.int`.
+   *
+   * @param array $data
+   *   API data.
+   * @param string $replacement
+   *   Replacement host and scheme.
+   * @param string $pattern
+   *   Pattern to replace.
+   * @param string $recursive
+   *   TRUE to also check subfields.
+   */
+  public static function updateApiUrls(array &$data, $replacement = 'https://reliefweb.int/', $pattern = '#https?://[^/]+/#', $recursive = TRUE) {
+    foreach ($data as $key => $item) {
+      if (is_string($item) && strpos($key, 'url') === 0) {
+        $data[$key] = preg_replace($pattern, $replacement, $item);
+      }
+      elseif (is_array($item) && $recursive) {
+        static::updateApiUrls($data[$key], $replacement, $pattern, $recursive);
+      }
+    }
+  }
+
+}

--- a/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-attachment-list.html.twig
+++ b/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-attachment-list.html.twig
@@ -1,0 +1,46 @@
+{#
+
+/**
+ * @file
+ * Template for a list of files.
+ *
+ * Available variables:
+ * - attributes: section attributes
+ * - title: section title
+ * - title_attributes: attributes for the title
+ * - level: heading level for the title
+ * - list: list of attachments with a preview, label, description and url
+ * - list_attributes: attributes for the list
+ * - lazy_load_first_preview: also lazy load the first attachment preview
+ */
+
+#}
+{% if list is not empty %}
+<section{{ attributes.addClass('unocha-reliefweb-attachment-list') }}>
+  <h{{ level }}{{ title_attributes.addClass('visually-hidden') }}>{{ title }}</h{{ level }}>
+  <ul{{ list_attributes }}>
+    {% for item in list %}
+    <li>
+      <a href="{{ item.url }}">
+        {% if item.preview is not empty and loop.index == 1 and not lazy_load_first_preview %}
+          {%
+            set item = item|merge({
+              'preview': item.preview|merge({
+                '#attributes': (item.preview['#attributes'] ?? {})|merge({
+                  'loading': 'eager'
+                })
+              })
+            })
+          %}
+        {% endif %}
+
+        {{ item.preview }}
+        <strong class="unocha-reliefweb-attachment-list__label">{{ item.label }}</strong>
+        <span class="unocha-reliefweb-attachment-list__description">{{ item.description }}</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+

--- a/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-document.html.twig
+++ b/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-document.html.twig
@@ -1,0 +1,23 @@
+{#
+
+/**
+ * @file
+ * Template of the reliefweb document pages.
+ *
+ * Available variables:
+ * - level: heading level
+ * - attributes: attributes for the document wrapper element
+ * - title: document title
+ * - title_attributes: attributes for the document title element
+ * - date: document publication date
+ * - content: document's content
+ * - content_attributes: attributes for the document content wrapper
+#}
+<article{{ attributes.addClass('unocha-reliefweb-document')}}>
+<header class="unocha-reliefweb-document__header">
+  <h{{ level }}{{ title_attributes.addClass('unocha-reliefweb-document__title') }}>{{ title }}</h{{ level }}>
+  <time class="unocha-reliefweb-document__date" datetime="{{ date|date('c') }} ">{{ date|date('j M Y') }}</time>
+</header>
+<div{{ content_attributes.addClass('unocha-reliefweb-document__content') }}>
+  {{- content -}}
+</div>

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.info.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.info.yml
@@ -1,0 +1,7 @@
+type: module
+name: UNOCHA ReliefWeb
+description: 'Provides integration with ReliefWeb.'
+package: unocha
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:unocha_utility

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.module
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.module
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Module file for the ReliefWeb integration.
+ */
+
+/**
+ * Implements hook_theme().
+ */
+function unocha_reliefweb_theme() {
+  $themes = [
+    // Theme for a ReliefWeb document.
+    'unocha_reliefweb_document' => [
+      'variables' => [
+        // Heading level.
+        'level' => 1,
+        // Wrapper attributes.
+        'attributes' => NULL,
+        // Document title.
+        'title' => NULL,
+        // Attributes for the title.
+        'title_attributes' => NULL,
+        // Document publication date.
+        'date' => NULL,
+        // Document's main content.
+        'content' => NULL,
+        // Attributes for the content.
+        'content_attributes' => NULL,
+      ],
+    ],
+    // Theme for a list of attachments.
+    'unocha_reliefweb_attachment_list' => [
+      'variables' => [
+        // Section heading level.
+        'level' => 2,
+        // Section attributes.
+        'attributes' => NULL,
+        // Section title.
+        'title' => t('Attachments'),
+        // Section title attributes.
+        'title_attributes' => NULL,
+        // List of files. Each item has the following properties:
+        // - url: link to the file
+        // - name: file name
+        // - label: file name or 'Download' etc.
+        // - description: file description (extension, size, language etc.)
+        'list' => [],
+        // List attributes.
+        'list_attributes' => NULL,
+        // Section footer.
+        'footer' => NULL,
+        // Section footer attributes.
+        'footer_attributes' => NULL,
+        // Flag to indicate if the first attachment's preview should be lazy
+        // loaded or not.
+        'lazy_load_first_preview' => TRUE,
+      ],
+    ],
+  ];
+
+  return $themes;
+}

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.routing.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.routing.yml
@@ -1,0 +1,2 @@
+route_callbacks:
+  - '\Drupal\unocha_reliefweb\Routing\ReliefWebDocumentRoutes::routes'

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.services.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.services.yml
@@ -1,0 +1,10 @@
+services:
+  cache.reliefweb_api:
+    class: Drupal\Core\Cache\CacheBackendInterface
+    tags:
+      - { name: cache.bin }
+    factory: cache_factory:get
+    arguments: [reliefweb_api]
+  reliefweb_api.client:
+    class: Drupal\unocha_reliefweb\Services\ReliefWebApiClient
+    arguments: ['@cache.reliefweb_api', '@config.factory', '@datetime.time', '@http_client', '@logger.factory']

--- a/html/modules/custom/unocha_utility/README.md
+++ b/html/modules/custom/unocha_utility/README.md
@@ -1,0 +1,18 @@
+UNOCHA - Utility module
+=======================
+
+
+This module provides various utility helpers, traits and plugins.
+
+## Helpers
+
+This module provides a set of helpers used by other custom modules:
+
+- [DateHelper](src/Helpers/DateHelper.php): get timestamp from a date (string, object etc.) and format date.
+- [HtmlOutliner](src/Helpers/HtmlOutliner.php): helper to fix the heading hierarchy of HTML.
+- [HtmlSanitizer](src/Helpers/HtmlSanitizer.php): helper to sanitize HTML content.
+- [UrlHelper](src/Helpers/UrlHelper.php): helper extending the functionalities of the Drupal UrlHelper.
+
+## Twig extension
+
+This module provides a [twig extension](src/TwigExtension.php) that adds useful filters and functions to help getting or transforming data in the custom templates.

--- a/html/modules/custom/unocha_utility/src/Helpers/DateHelper.php
+++ b/html/modules/custom/unocha_utility/src/Helpers/DateHelper.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\unocha_utility\Helpers;
+
+/**
+ * Helper to manipulate date and date fields.
+ */
+class DateHelper {
+
+  /**
+   * Get the timestamp from a date value extracted from the form state.
+   *
+   * The type of data returned from a date field is not consistent so we
+   * we ensure we get a timestamp to be able to do some comparison.
+   *
+   * @param mixed $date
+   *   Date field value.
+   *
+   * @return int|null
+   *   A UNIX timestamp or NULL if the type of the date couldn't be inferred.
+   */
+  public static function getDateTimeStamp($date) {
+    if (!empty($date)) {
+      // Date object. It can be a PHP DateTime or DrupalDateTime...
+      if (is_object($date)) {
+        return $date->getTimeStamp();
+      }
+      // Date in the expected format YYYY-MM-DD.
+      elseif (is_string($date) && !is_numeric($date)) {
+        $date = date_create($date, timezone_open('UTC'));
+        if (!$date) {
+          return NULL;
+        }
+
+        return $date->getTimeStamp();
+      }
+      // Assume it's a timestamp.
+      elseif (is_numeric($date)) {
+        return intval($date);
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Format a date.
+   *
+   * Wrapper around DateFormatter::format() that accepts various types for the
+   * date parameter and convert it to a timestamp and also using UTC as default
+   * timezone.
+   *
+   * @param mixed $date
+   *   Date field value.
+   * @param string $type
+   *   The format to use, one of:
+   *   - A built-in format: 'short', 'medium', 'long', 'html_datetime',
+   *    'html_date', 'html_time', 'html_yearless_date', 'html_week',
+   *    'html_month' or 'html_year'.
+   *   - The name of a date type defined by a date format config entity.
+   *   - The machine name of an administrator-defined date format.
+   *   - 'custom', to use $format.
+   *   Defaults to 'medium'.
+   * @param string $format
+   *   If $type is 'custom', a PHP date format string suitable for input to
+   *   date(). Use a backslash to escape ordinary text, so it does not get
+   *   interpreted as date format characters.
+   * @param string|null $timezone
+   *   Time zone as described at https://php.net/manual/timezones.php
+   *   Defaults to the time zone used to display the page.
+   * @param string|null $langcode
+   *   Language code to translate to. NULL (default) means to use the user
+   *   interface language for the page.
+   *
+   * @return string
+   *   A translated date string in the requested format. Since the format may
+   *   contain user input, this value should be escaped when output.
+   *   An empty string is returned if the date couldn't be formatted.
+   */
+  public static function format($date, $type = 'medium', $format = '', $timezone = 'UTC', $langcode = NULL) {
+    $timestamp = static::getDateTimeStamp($date);
+    if (empty($timestamp)) {
+      return '';
+    }
+    return \Drupal::service('date.formatter')
+      ->format($timestamp, $type, $format, $timezone, $langcode);
+  }
+
+}

--- a/html/modules/custom/unocha_utility/src/Helpers/HtmlOutliner.php
+++ b/html/modules/custom/unocha_utility/src/Helpers/HtmlOutliner.php
@@ -1,0 +1,727 @@
+<?php
+
+namespace Drupal\unocha_utility\Helpers;
+
+/**
+ * Helper to fix the heading hierarchy of some HTML.
+ *
+ * Implements the HTML5 outline algorithms and enables fixing the hierarchy.
+ *
+ * Adaptation of https://github.com/h5o/h5o-js.
+ */
+class HtmlOutliner {
+
+  /**
+   * Check if a node is a heading.
+   *
+   * @param \DOMNode|null $node
+   *   DOM node.
+   *
+   * @return bool
+   *   TRUE if the node is a heading.
+   */
+  public static function isHeading(?\DOMNode $node) {
+    static $tags = [
+      'h1' => TRUE,
+      'h2' => TRUE,
+      'h3' => TRUE,
+      'h4' => TRUE,
+      'h5' => TRUE,
+      'h6' => TRUE,
+      'hgroup' => TRUE,
+    ];
+    return isset($node, $tags[$node->nodeName]);
+  }
+
+  /**
+   * Check if a node is a sectioning content.
+   *
+   * @param \DOMNode|null $node
+   *   DOM node.
+   *
+   * @return bool
+   *   TRUE if the node is a sectioning content.
+   */
+  public static function isSectioningContent(?\DOMNode $node) {
+    static $tags = [
+      'article' => TRUE,
+      'aside' => TRUE,
+      'nav' => TRUE,
+      'section' => TRUE,
+    ];
+    return isset($node, $tags[$node->nodeName]);
+  }
+
+  /**
+   * Check if a node is a sectioning root.
+   *
+   * @param \DOMNode|null $node
+   *   DOM node.
+   *
+   * @return bool
+   *   TRUE if the node is a sectioning root.
+   */
+  public static function isSectioningRoot(?\DOMNode $node) {
+    static $tags = [
+      'blockquote' => TRUE,
+      'body' => TRUE,
+      'details' => TRUE,
+      'dialogue' => TRUE,
+      'fieldset' => TRUE,
+      'figure' => TRUE,
+      'td' => TRUE,
+    ];
+    return isset($node, $tags[$node->nodeName]);
+  }
+
+  /**
+   * Check if a node is hidden.
+   *
+   * @param \DOMNode|null $node
+   *   DOM node.
+   *
+   * @return bool
+   *   TRUE if the node is hidden.
+   */
+  public static function isHidden(?\DOMNode $node) {
+    return isset($node) && $node->hasAttributes() && $node->hasAttribute('hidden');
+  }
+
+  /**
+   * Get a heading's rank (= negative level).
+   *
+   * @param \DOMNode $node
+   *   DOM node.
+   *
+   * @return int
+   *   Heading's rank.
+   */
+  public static function getHeadingRank(\DOMNode $node) {
+    $heading = static::getRankingHeading($node);
+    return !empty($heading) ? -intval(substr($heading->nodeName, 1)) : -1;
+  }
+
+  /**
+   * Get the ranking heading.
+   *
+   * Return the node if it's heading or the top level heading if it's a hgroup.
+   *
+   * @param \DOMNode $node
+   *   DOM node.
+   *
+   * @return \DOMNode|null
+   *   Ranking heading node.
+   */
+  public static function getRankingHeading(\DOMNode $node) {
+    // Get the top level heading in the hgroup.
+    if ($node->nodeName === 'hgroup') {
+      for ($i = 1; $i <= 6; $i++) {
+        $headings = static::getElementsByTagName($node, 'h' . $i);
+        if (count($headings) > 0) {
+          return $headings[0];
+        }
+      }
+      return NULL;
+    }
+    return $node;
+  }
+
+  /**
+   * Check if heading node associated section is a sub-section.
+   *
+   * A heading node associated section is a sub-section of the current outline
+   * last section if the last section heading is implied or has a higher
+   * (or equal) rank than the checked node.
+   *
+   * @param \Outliner\OutlineTarget|null $outline_target
+   *   Outline target.
+   * @param \DOMNode $node
+   *   DOM node.
+   *
+   * @return int
+   *   Heading's rank.
+   */
+  public static function isSubSection(?OutlineTarget $outline_target, \DOMNode $node) {
+    if (empty($outline_target) || empty($outline_target->outline) || empty($outline_target->outline->sections)) {
+      return FALSE;
+    }
+    $heading = $outline_target->outline->getLastSection()->heading;
+    return $heading === TRUE || static::getHeadingRank($node) >= static::getHeadingRank($heading);
+  }
+
+  /**
+   * Enter a node and analyze its type and content.
+   *
+   * @param \DOMNode $node
+   *   DOM node.
+   * @param \Outliner\OutlineTarget|null $outline_target
+   *   Current outline target.
+   * @param \Outliner\Section|null $current_section
+   *   Current section.
+   * @param array $stack
+   *   Stack to track processed elements.
+   */
+  public static function enterNode(\DOMNode $node, ?OutlineTarget &$outline_target, ?Section &$current_section, array &$stack) {
+    // Nothing to do if the top of the stack is hidden or a heading.
+    $stackTop = end($stack);
+    if (!empty($stackTop) && (static::isHeading($stackTop->node) || static::isHidden($stackTop->node))) {
+      return;
+    }
+    // Push the node to the stack to skip it and its descendants.
+    elseif (static::isHidden($node)) {
+      $stack[] = new Node($node);
+    }
+    // Sectioning content.
+    elseif (static::isSectioningContent($node)) {
+      // Push current outline target to the stack.
+      if (!empty($outline_target)) {
+        // Mark the current section heading as implied if not defined.
+        if (empty($current_section->heading)) {
+          $current_section->heading = TRUE;
+        }
+        $stack[] = $outline_target;
+      }
+
+      // New outline target.
+      $outline_target = new OutlineTarget($node);
+
+      // New section.
+      $current_section = new Section($node);
+
+      // Set the outline of the new outline target.
+      $outline_target->outline = new Outline($node, $current_section);
+    }
+    // Sectioning root.
+    elseif (static::isSectioningRoot($node)) {
+      // Push current outline target to the stack.
+      if (!empty($outline_target)) {
+        $stack[] = $outline_target;
+      }
+
+      // New outline target.
+      $outline_target = new OutlineTarget($node);
+
+      // Set the current section as the outline target parent section.
+      $outline_target->parentSection = $current_section;
+
+      // New section.
+      $current_section = new Section($node);
+
+      // Set the outline of the new outline target.
+      $outline_target->outline = new Outline($node, $current_section);
+    }
+    // Heading.
+    elseif (static::isHeading($node)) {
+      // Set the node as the heading of the current section if it has none.
+      if (!empty($current_section) && empty($current_section->heading)) {
+        $current_section->heading = $node;
+      }
+      // If the last outline section heading is implied or has a higher rank
+      // than the node's one, then create a new section, add it to the outline
+      // sections, set the node as its heading and set this section as the
+      // current one.
+      elseif (static::isSubSection($outline_target, $node)) {
+        $section = new Section($node);
+        $outline_target->outline->sections[] = $section;
+        $current_section = $section;
+        $current_section->heading = $node;
+      }
+      // Otherwise, if the last outline section has a heading and its rank
+      // is lower than the node's one then we try to find the parent of the
+      // section associated with the node.
+      else {
+        $candidate = $current_section;
+
+        while (!empty($candidate)) {
+          // Found a candidate section as parent of the node's one.
+          if (static::getHeadingRank($node) < static::getHeadingRank($candidate->heading)) {
+            $section = new Section($node);
+
+            $candidate->sections[] = $section;
+            $section->container = $candidate;
+
+            $current_section = $section;
+            $current_section->heading = $node;
+            break;
+          }
+
+          $candidate = $candidate->container;
+        }
+      }
+
+      // Push the node to the stack to skip it and its descendants.
+      $stack[] = new Node($node);
+    }
+  }
+
+  /**
+   * Exit a node.
+   *
+   * @param \DOMNode $node
+   *   DOM node.
+   * @param \Outliner\OutlineTarget|null $outline_target
+   *   Current outline target.
+   * @param \Outliner\Section|null $current_section
+   *   Current section.
+   * @param array $stack
+   *   Stack to track processed elements.
+   */
+  public static function exitNode(\DOMNode $node, ?OutlineTarget &$outline_target, ?Section &$current_section, array &$stack) {
+    $stackTop = end($stack);
+    if (!empty($stackTop)) {
+      // Remove the node from the stack if it's the last added element.
+      if ($stackTop->node === $node) {
+        array_pop($stack);
+      }
+      // Nothing to do if the element is a heading or hidden.
+      if (static::isHeading($stackTop->node) || static::isHidden($stackTop->node)) {
+        return;
+      }
+    }
+
+    // Go through the stack if it's not empty.
+    if (!empty($stack)) {
+      // Sectioning content.
+      if (static::isSectioningContent($node)) {
+        // Set the node as the heading of the current section if it has none.
+        if (!empty($current_section) && empty($current_section->heading)) {
+          $current_section->heading = TRUE;
+        }
+
+        // Keep track of the current outline target which correspond to the
+        // outline for the node.
+        $exiting_outline_target = $outline_target;
+
+        // Switch the outline target to the last element in the stack which
+        // is above in the tree than the exiting one.
+        $outline_target = array_pop($stack);
+
+        // Set the current section to the last section of the outline.
+        $current_section = $outline_target->outline->getLastSection();
+
+        // Add the sections of the exiting outline as sub-sections of the
+        // current section.
+        foreach ($exiting_outline_target->outline->sections as $section) {
+          $current_section->append($section);
+        }
+      }
+      // Sectioning root.
+      elseif (static::isSectioningRoot($node)) {
+        // Set the node as the heading of the current section if it has none.
+        if (!empty($current_section) && empty($current_section->heading)) {
+          $current_section->heading = TRUE;
+        }
+
+        // Set the current section as the parent section of the outline target.
+        $current_section = $outline_target->parentSection;
+
+        // Set the outline target to the next item in the stack.
+        $outline_target = array_pop($stack);
+      }
+    }
+    // The node is the root, we simply set the heading if not defined.
+    elseif (static::isSectioningContent($node) || static::isSectioningRoot($node)) {
+      // Set the node as the heading of the current section if it has none.
+      if (!empty($current_section) && empty($current_section->heading)) {
+        $current_section->heading = TRUE;
+      }
+    }
+  }
+
+  /**
+   * Parse a DOM node and return it's outline structure.
+   *
+   * @param \DOMNode|null $root
+   *   Root node.
+   *
+   * @return \Outliner\Outline|null
+   *   Outline object.
+   */
+  public static function parseNode(?\DOMNode $root) {
+    // Skip if the root node is not a sectioning content or root node.
+    if (!empty($root) && !static::isSectioningContent($root) && !static::isSectioningRoot($root)) {
+      return NULL;
+    }
+
+    // Keep track of the outline and sections being parsed.
+    $outline_target = NULL;
+    $current_section = NULL;
+    $stack = [];
+
+    $node = $root;
+
+    // Walk the DOM tree.
+    start: while (!empty($node)) {
+      static::enterNode($node, $outline_target, $current_section, $stack);
+
+      if (!empty($node->firstChild)) {
+        $node = $node->firstChild;
+        goto start;
+      }
+
+      while (!empty($node)) {
+        static::exitNode($node, $outline_target, $current_section, $stack);
+
+        if (!empty($node->nextSibling)) {
+          $node = $node->nextSibling;
+          goto start;
+        }
+
+        $node = $node !== $root ? $node->parentNode : NULL;
+      }
+    }
+
+    return !empty($outline_target) ? $outline_target->outline : NULL;
+  }
+
+  /**
+   * Parse an HTML string and return its outline.
+   *
+   * @param string $html
+   *   HTML string.
+   *
+   * @return \Outliner\Outline|null
+   *   Outline object.
+   */
+  public static function parseHtml($html) {
+    if (empty($html)) {
+      return NULL;
+    }
+
+    // Flags to load the HTML string.
+    $flags = LIBXML_NONET | LIBXML_NOBLANKS | LIBXML_NOERROR | LIBXML_NOWARNING;
+
+    // Adding this meta tag is necessary to tell \DOMDocument we are dealing
+    // with UTF-8 encoded html.
+    $meta = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
+    $prefix = '<!DOCTYPE html><html><head>' . $meta . '</head><body>';
+    $suffix = '</body></html>';
+    $dom = new \DOMDocument();
+    $dom->loadHTML($prefix . $html . $suffix, $flags);
+
+    return static::parseNode(static::getBody($dom));
+  }
+
+  /**
+   * Fix the heading hierarchy of the given DOM node.
+   *
+   * @param \DOMNode $node
+   *   DOM node.
+   * @param int $level
+   *   Current hierarchy level.
+   * @param bool $nogap
+   *   If TRUE, then the hierarchy will be fixed in a way that ensures there are
+   *   no gaps between heading levels. Otherwise the headings will be fixed
+   *   according to their level in the outline.
+   */
+  public static function fixNodeHeadingHierarchy(\DOMNode $node, $level = 0, $nogap = TRUE) {
+    if (is_a($node, '\DOMDocument')) {
+      $outline = static::parseNode(static::getBody($node));
+    }
+    else {
+      $outline = static::parseNode($node);
+    }
+    if (!empty($outline)) {
+      static::fixSectionHeadingHierarchy($outline->sections, $level, $nogap);
+    }
+  }
+
+  /**
+   * Fix the heading heriarchy of the given sections.
+   *
+   * @param array $sections
+   *   Sections.
+   * @param int $level
+   *   Current hierarchy level.
+   * @param bool $nogap
+   *   If TRUE, then the hierarchy will be fixed in a way that ensures there are
+   *   no gaps between heading levels. Otherwise the headings will be fixed
+   *   according to their level in the outline.
+   */
+  public static function fixSectionHeadingHierarchy(array $sections, $level = 0, $nogap = TRUE) {
+    if (empty($sections)) {
+      return;
+    }
+
+    // Fix the heading of each section.
+    foreach ($sections as $section) {
+      $heading = $section->heading;
+      $implied = empty($heading) || $heading === TRUE;
+
+      // The rank is one higher than the hierarchical level.
+      $rank = $level + 1;
+
+      // Skip if the the heading is not defined or is implied.
+      if (!$implied) {
+        // For hgroup, we fix all the sub-headings ranks.
+        if ($heading->nodeName === 'hgroup') {
+          // Extract the headings by rank.
+          $headings = [];
+          for ($i = 1; $i <= 6; $i++) {
+            $nodes = static::getElementsByTagName($heading, 'h' . $i);
+            if (count($nodes) > 0) {
+              $headings[$rank++] = $nodes;
+            }
+          }
+          // Fix the rank of the heading nodes and append them to parent node
+          // to ensure they are ordered by rank.
+          foreach ($headings as $rank => $nodes) {
+            foreach ($nodes as $node) {
+              if ($node->parentNode !== NULL) {
+                $node->parentNode->appendChild(static::fixHeadingRank($node, $rank));
+              }
+            }
+          }
+        }
+        // Simply fix the heading rank.
+        else {
+          static::fixHeadingRank($heading, $rank);
+        }
+      }
+
+      // Process the sub-sections. If the heading was implied and no gap was
+      // set to TRUE then we keep the same hierarchical level so that there is
+      // no gap between the heading ranks. This breaks the outline but is the
+      // only way to have a proper rank hierarchy without gaps as recommended
+      // for accessibility.
+      static::fixSectionHeadingHierarchy($section->sections, $implied && $nogap ? $level : $level + 1);
+    }
+  }
+
+  /**
+   * Fix the heading rank by replacing it with a new node with the proper rank.
+   *
+   * @param \DOMNode $heading
+   *   Heading to fix.
+   * @param int $rank
+   *   New heading rank.
+   *
+   * @return \DOMNode
+   *   New heading or same one if there was no need for a change.
+   */
+  public static function fixHeadingRank(\DOMNode $heading, $rank) {
+    // Replace the heading with a strong tag if it goes beyond the 6th rank.
+    $tag = $rank > 6 ? 'strong' : 'h' . $rank;
+    // Nothing to do if the tag name is unchanged.
+    if ($tag === $heading->nodeName) {
+      return $heading;
+    }
+    // Create the new heading node.
+    $node = $heading->ownerDocument->createElement($tag);
+    // Transfer the heading children to the new node.
+    while ($heading->firstChild !== NULL) {
+      $node->appendChild($heading->firstChild);
+    }
+    // Copy the attributes.
+    foreach ($heading->attributes as $attribute => $dummy) {
+      $node->setAttribute($attribute, $heading->getAttribute($attribute));
+    }
+    // Wrap the strong element into a `<p>` element so that it's not displayed
+    // inline.
+    if ($tag === 'strong') {
+      $wrapper = $heading->ownerDocument->createElement('p');
+      $wrapper->appendChild($node);
+      $node = $wrapper;
+    }
+    // Replace the heading node with the new one.
+    $heading->parentNode->replaceChild($node, $heading);
+    return $node;
+  }
+
+  /**
+   * Get the nodes matching the tag name.
+   *
+   * \DOMElement::GetElementsByTagName returns a live collection. We convert it
+   * to a flat array so that the nodes can be manipulated during the iteration
+   * without creating infinite loops for example.
+   *
+   * @param \DOMNode $node
+   *   Node (\DOMDocument or \DOMElement)
+   * @param string $tag
+   *   Tag name or `*` for all nodes.
+   *
+   * @return array
+   *   List of nodes with the given tag name.
+   */
+  public static function getElementsByTagName(\DOMNode $node, $tag) {
+    $elements = [];
+    if (method_exists($node, 'getElementsByTagName')) {
+      foreach ($node->getElementsByTagName($tag) as $element) {
+        $elements[] = $element;
+      }
+    }
+    return $elements;
+  }
+
+  /**
+   * Get body.
+   *
+   * @param \DOMNode $node
+   *   Node (\DOMDocument or \DOMElement)
+   *
+   * @return \DOMNode
+   *   Body node.
+   */
+  public static function getBody(\DOMNode $node) {
+    $elements = static::getElementsByTagName($node, 'body');
+    return count($elements) > 0 ? $elements[0] : NULL;
+  }
+
+}
+
+/**
+ * DOM node wrapper base class.
+ */
+class Node {
+
+  /**
+   * DOM node.
+   *
+   * @var \DOMNode
+   */
+  public $node;
+
+  /**
+   * Construct the node wrapper.
+   *
+   * @param \DOMNode $node
+   *   DOM node.
+   */
+  public function __construct(\DOMNode $node) {
+    $this->node = $node;
+  }
+
+}
+
+/**
+ * Section node implementation.
+ */
+class Section extends Node {
+  /**
+   * Section heading.
+   *
+   * Either a DOM node or TRUE if the heading is implied.
+   *
+   * @var \DOMNode|true
+   */
+  public $heading = NULL;
+
+  /**
+   * Sub-sections.
+   *
+   * @var array
+   */
+  public $sections = [];
+
+  /**
+   * Section container.
+   *
+   * @var \Outliner\Node
+   */
+  public $container = NULL;
+
+  /**
+   * Append a sub-section.
+   *
+   * @param \Outliner\Section $section
+   *   Sub-section.
+   */
+  public function append(Section $section) {
+    $section->container = $this;
+    $this->sections[] = $section;
+  }
+
+}
+
+/**
+ * Outline node implementation.
+ */
+class Outline extends Node {
+  /**
+   * Sections.
+   *
+   * @var array
+   */
+  public $sections = [];
+
+  /**
+   * Construct the node wrapper.
+   *
+   * @param \DOMNode $node
+   *   DOM node.
+   * @param \Outliner\Section $section
+   *   First section of the outline.
+   */
+  public function __construct(\DOMNode $node, Section $section) {
+    $this->node = $node;
+    $this->sections[] = $section;
+  }
+
+  /**
+   * Get the last section of the outline.
+   *
+   * @return \Outliner\Section
+   *   Last outline section.
+   */
+  public function getLastSection() {
+    return !empty($this->sections) ? end($this->sections) : NULL;
+  }
+
+  /**
+   * Convert the outline to string.
+   */
+  public function __toString() {
+    return static::getHeadings($this->sections) . PHP_EOL;
+  }
+
+  /**
+   * Get the stringify version.
+   *
+   * @param array $sections
+   *   List of sections.
+   * @param int $level
+   *   Current level in the hierarchy.
+   */
+  public static function getHeadings(array $sections, $level = 0) {
+    if (empty($sections)) {
+      return '';
+    }
+    $padding = str_pad('', $level * 4);
+    $output = [];
+    foreach ($sections as $section) {
+      if (empty($section->heading) || $section->heading === TRUE) {
+        $output[] = $padding . '?? untitled section';
+      }
+      else {
+        $heading = HtmlOutliner::getRankingHeading($section->heading) ?? $section->heading;
+        $output[] = $padding . $heading->nodeName . ' ' . trim($heading->textContent);
+      }
+      if (!empty($section->sections)) {
+        $output[] = static::getHeadings($section->sections, $level + 1);
+      }
+    }
+    return implode(PHP_EOL, $output);
+  }
+
+}
+
+/**
+ * Outline target node implementation.
+ */
+class OutlineTarget extends Node {
+
+  /**
+   * Outline.
+   *
+   * @var \Outliner\Outline
+   */
+  public $outline = NULL;
+
+  /**
+   * Parent section.
+   *
+   * @var \Outliner\Section
+   */
+  public $parentSection = NULL;
+
+}

--- a/html/modules/custom/unocha_utility/src/Helpers/HtmlSanitizer.php
+++ b/html/modules/custom/unocha_utility/src/Helpers/HtmlSanitizer.php
@@ -1,0 +1,612 @@
+<?php
+
+namespace Drupal\unocha_utility\Helpers;
+
+use Drupal\Component\Render\MarkupInterface;
+
+/**
+ * Helper to sanitize HTML.
+ */
+class HtmlSanitizer {
+
+  /**
+   * Flag indicating whether to allow iframes or not.
+   *
+   * @var bool
+   */
+  protected $iframe = FALSE;
+
+  /**
+   * Offset for the conversion of the headings to perserve the hierarchy.
+   *
+   * @var int
+   */
+  protected $headingOffset = 2;
+
+  /**
+   * List of attributes that should be preserved (ex: data-disaster-map).
+   *
+   * @var array
+   */
+  protected $allowedAttributes = [];
+
+  /**
+   * Constructor.
+   *
+   * @param bool $iframe
+   *   Whether to allow iframes or not.
+   * @param int $heading_offset
+   *   Offset for the conversion of the headings to perserve the hierarchy.
+   * @param array $allowed_attributes
+   *   List of attributes that should be preserved (ex: data-disaster-map).
+   */
+  public function __construct($iframe = FALSE, $heading_offset = 2, array $allowed_attributes = []) {
+    $this->iframe = $iframe;
+    $this->headingOffset = $heading_offset;
+    $this->allowedAttributes = $allowed_attributes;
+  }
+
+  /**
+   * Sanitize an HTML string, removing unallowed tags and attributes.
+   *
+   * This also attempts to fix the heading hierarchy, at least preventing
+   * the use of h1 and h2 in the sanitized content.
+   *
+   * @param string $html
+   *   HTML string to sanitize.
+   * @param bool $iframe
+   *   Whether to allow iframes or not.
+   * @param int $heading_offset
+   *   Offset for the conversion of the headings to perserve the hierarchy.
+   * @param array $allowed_attributes
+   *   List of attributes that should be preserved (ex: data-disaster-map).
+   *
+   * @return string
+   *   Sanitized HTML string.
+   */
+  public static function sanitize($html, $iframe = FALSE, $heading_offset = 2, array $allowed_attributes = []) {
+    $sanitizer = new static($iframe, $heading_offset, $allowed_attributes);
+    return $sanitizer->sanitizeHtml($html);
+  }
+
+  /**
+   * Sanitize an HTML string, removing unallowed tags and attributes.
+   *
+   * This also attempts to fix the heading hierarchy, at least preventing
+   * the use of h1 and h2 in the sanitized content.
+   *
+   * @param string|\Drupal\Component\Render\MarkupInterface $html
+   *   HTML string to sanitize.
+   *
+   * @return string
+   *   Sanitized HTML string.
+   */
+  public function sanitizeHtml($html) {
+    // Skip if html is not a string.
+    if (!is_string($html) && !($html instanceof MarkupInterface)) {
+      return '';
+    }
+
+    // Skip if the html string is empty.
+    $html = trim($html);
+    if (empty($html)) {
+      return '';
+    }
+
+    // Flags to load the HTML string.
+    $flags = LIBXML_NONET | LIBXML_NOBLANKS | LIBXML_NOERROR | LIBXML_NOWARNING;
+
+    // Supported tags an whether they can be empty (no children) or not.
+    $tags = [
+      'html' => FALSE,
+      'head' => FALSE,
+      'meta' => TRUE,
+      'body' => FALSE,
+      'div' => FALSE,
+      'article' => FALSE,
+      'section' => FALSE,
+      'header' => FALSE,
+      'footer' => FALSE,
+      'aside' => FALSE,
+      'span' => FALSE,
+      // No children.
+      'br' => TRUE,
+      'a' => FALSE,
+      'em' => FALSE,
+      'i' => FALSE,
+      'strong' => FALSE,
+      'b' => FALSE,
+      'big' => FALSE,
+      'cite' => FALSE,
+      'code' => FALSE,
+      'strike' => FALSE,
+      'ul' => FALSE,
+      'ol' => FALSE,
+      'li' => FALSE,
+      'dl' => FALSE,
+      'dt' => FALSE,
+      'dd' => FALSE,
+      'blockquote' => FALSE,
+      'p' => FALSE,
+      'pre' => FALSE,
+      'h1' => FALSE,
+      'h2' => FALSE,
+      'h3' => FALSE,
+      'h4' => FALSE,
+      'h5' => FALSE,
+      'h6' => FALSE,
+      'table' => FALSE,
+      'caption' => FALSE,
+      'thead' => FALSE,
+      'tbody' => FALSE,
+      'th' => FALSE,
+      'td' => FALSE,
+      'tr' => FALSE,
+      'sup' => FALSE,
+      'sub' => FALSE,
+      'small' => FALSE,
+      'font' => FALSE,
+      // No children.
+      'img' => TRUE,
+    ];
+
+    $convert = [
+      'i' => 'em',
+      'b' => 'strong',
+      'big' => 'strong',
+    ];
+
+    $headings = [
+      'h1' => TRUE,
+      'h2' => TRUE,
+      'h3' => TRUE,
+      'h4' => TRUE,
+      'h5' => TRUE,
+      'h6' => TRUE,
+    ];
+
+    // Allow iframes if instructed to.
+    if (!empty($this->iframe)) {
+      // No children.
+      $tags['iframe'] = TRUE;
+    }
+
+    // Convert all '&nbsp;' to normal spaces.
+    $html = str_replace('&nbsp;', ' ', $html);
+
+    // Adding this meta tag is necessary to tell \DOMDocument we are dealing
+    // with UTF-8 encoded html.
+    $meta = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
+    $prefix = '<!DOCTYPE html><html><head>' . $meta . '</head><body>';
+    $suffix = '</body></html>';
+    $dom = new \DOMDocument();
+    $dom->loadHTML($prefix . $html . $suffix, $flags);
+
+    // Fix the heading hierarchy.
+    HtmlOutliner::fixNodeHeadingHierarchy($dom, $this->headingOffset);
+
+    // Parse all the dom nodes.
+    foreach ($this->getElementsByTagName($dom, '*') as $node) {
+      // Skip orphan nodes (for example from manipulations below).
+      if (empty($node) || empty($node->parentNode)) {
+        continue;
+      }
+
+      // Remove style and event attributes.
+      $this->sanitizeAttributes($node);
+
+      // Get the node tag name to determine processing.
+      $tag = $node->tagName;
+
+      // Remove unrecognized/unallowed tags.
+      if (!isset($tags[$tag])) {
+        $this->removeChild($node);
+      }
+      // Remove tags that should not be empty.
+      elseif ($tags[$tag] === FALSE && $this->isEmpty($node)) {
+        $this->removeChild($node);
+      }
+      // Process headings, keeping only ids.
+      elseif (isset($headings[$tag])) {
+        $this->handleHeading($node);
+      }
+      // Process links, removing invalid ones.
+      elseif ($tag === 'a') {
+        $this->handleLink($node);
+      }
+      // Process images.
+      elseif ($tag === 'img') {
+        $this->handleImage($node);
+      }
+      // Process iframes.
+      elseif ($tag === 'iframe') {
+        $this->handleIframe($node);
+      }
+      // Process tables.
+      elseif ($tag === 'table') {
+        $this->handleTable($node);
+      }
+      // Process list items.
+      elseif ($tag === 'li') {
+        $this->handleListItem($node);
+      }
+      // Process tables.
+      elseif ($tag === 'font') {
+        $this->stripTag($node);
+      }
+      // Process the node, converting if necessary and removing attributes.
+      else {
+        if (isset($convert[$tag])) {
+          $this->changeTag($node, $convert[$tag]);
+        }
+        else {
+          $this->removeAttributes($node);
+        }
+      }
+    }
+    $html = $dom->saveHTML();
+
+    // Search for the body tag and return its content.
+    $start = mb_strpos($html, '<body>');
+    $end = mb_strrpos($html, '</body>');
+    if ($start !== FALSE && $end !== FALSE) {
+      $start += 6;
+      return trim(mb_substr($html, $start, $end - $start));
+    }
+
+    return '';
+  }
+
+  /**
+   * Check if a node is empty (empty or only whitespaces).
+   *
+   * @param \DOMNode $node
+   *   Node to check.
+   *
+   * @return bool
+   *   TRUE if the node is considered empty.
+   */
+  protected function isEmpty(\DOMNode $node) {
+    // Trim the content, including non-breaking spaces.
+    $content = preg_replace('/(?:^\s+)|(?:\s+$)/u', '', $node->textContent);
+    // If the element contains images or iframes keep it.
+    if (empty($content)) {
+      foreach (['meta', 'img', 'iframe'] as $tag) {
+        $children = $this->getElementsByTagName($node, $tag);
+        if (!empty($children)) {
+          return FALSE;
+        }
+      }
+    }
+    return empty($content);
+  }
+
+  /**
+   * Sanitize heading attributes.
+   *
+   * @param \DOMNode $node
+   *   Heading node.
+   */
+  protected function handleHeading(\DOMNode $node) {
+    // Remove all the attributes except the 'id' that we keep to allow
+    // internal links.
+    $this->removeAttributes($node, ['id']);
+  }
+
+  /**
+   * Validate link url and sanitize attributes.
+   *
+   * @todo check if the url is external and add the rel and target attributes.
+   *
+   * @param \DOMNode $node
+   *   Link node.
+   */
+  protected function handleLink(\DOMNode $node) {
+    $url = $node->getAttribute('href');
+
+    // Remove links with an invalid url.
+    // @todo check if anchors are preserved.
+    if (!$this->validateUrl($url)) {
+      // Replace the link with its content.
+      if ($node->hasChildNodes()) {
+        $fragment = $node->ownerDocument->createDocumentFragment();
+        while ($node->firstChild !== NULL) {
+          $fragment->appendChild($node->firstChild);
+        }
+        $node->parentNode->replaceChild($fragment, $node);
+      }
+      // Remove the link otherwise.
+      else {
+        $this->removeChild($node);
+      }
+    }
+    // Remove all the attributes except the 'href' and optional 'target'.
+    else {
+      $allowed_attributes = ['href'];
+
+      // We preserve the target attribute to open in a new tab/window.
+      $target = $node->getAttribute('target');
+      if ($target === '_blank') {
+        // Set the rel attribute to avoid exploitation of the window.opener Api.
+        // @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
+        $node->setAttribute('rel', 'noreferrer noopener');
+        $allowed_attributes[] = 'target';
+        $allowed_attributes[] = 'rel';
+      }
+
+      $this->removeAttributes($node, $allowed_attributes);
+    }
+  }
+
+  /**
+   * Validate image url and sanitize attributes.
+   *
+   * @param \DOMNode $node
+   *   Image node.
+   */
+  protected function handleImage(\DOMNode $node) {
+    $url = $node->getAttribute('src');
+
+    // Remove images with an invalid url.
+    if (!$this->validateUrl($url)) {
+      // Remove the node.
+      $this->removeChild($node);
+    }
+    // Remove all the attributes except the 'src', 'alt' and 'title' ones.
+    else {
+      // Ensure there is always an alt attribute.
+      if (!$node->hasAttribute('alt')) {
+        $node->setAttribute('alt', '');
+      }
+      $this->removeAttributes($node, ['src', 'alt', 'title']);
+    }
+  }
+
+  /**
+   * Validate iframe url and wrap it for responsivity.
+   *
+   * @todo handle `srcdoc` attribute?
+   *
+   * @param \DOMNode $node
+   *   Iframe node.
+   */
+  protected function handleIframe(\DOMNode $node) {
+    $url = $node->getAttribute('src');
+
+    // Remove iframes with an invalid url.
+    if (!$this->validateUrl($url)) {
+      $this->removeChild($node);
+    }
+    else {
+      // Create a wrapper for the iframe so it can be made responsive.
+      $wrapper = $node->ownerDocument->createElement('div');
+      $wrapper->setAttribute('class', 'iframe-wrapper');
+
+      // Extract the aspect ratio of the iframe.
+      $width = intval($node->getAttribute('width'), 10);
+      $height = intval($node->getAttribute('height'), 10);
+      // Default to a 2/1 ratio.
+      $ratio = '50';
+      if (!empty($width) && !empty($height)) {
+        $ratio = 100 * $height / $width;
+      }
+      // Set a padding top equal to the ratio to the parent so that the
+      // the aspect ratio of the iframe can be preserved.
+      $wrapper->setAttribute('style', 'padding-top:' . $ratio . '%');
+
+      // Remove most of the attributes.
+      $this->removeAttributes($node, ['src', 'title', 'allowfullscreen']);
+
+      // We allow scripts to run in the sandboxed iframe as mostly they
+      // contain dynamic content like maps or videos. We also allow opening
+      // links into new pages/tabs.
+      $node->setAttribute('sandbox', 'allow-same-origin allow-scripts allow-popups');
+      $node->setAttribute('target', '_blank');
+
+      // Replace the iframe by the wrapper and append the iframe to it.
+      $node->parentNode->replaceChild($wrapper, $node);
+      $wrapper->appendChild($node);
+    }
+  }
+
+  /**
+   * Wrap a table for responsivity.
+   *
+   * @param \DOMNode $node
+   *   Table node.
+   */
+  protected function handleTable(\DOMNode $node) {
+    $parent = $node->parentNode;
+    $parentClass = $parent->getAttribute('class');
+    // Add a wrapper around the table.
+    if (empty($parentClass) || strpos($parentClass, 'table-wrapper') === FALSE) {
+      // Create a wrapper for the table so it can be made responsive.
+      $wrapper = $node->ownerDocument->createElement('div');
+      $wrapper->setAttribute('class', 'table-wrapper');
+
+      // Replace the table by the wrapper and append the table to it.
+      $parent->replaceChild($wrapper, $node);
+      $wrapper->appendChild($node);
+    }
+  }
+
+  /**
+   * Ensure list items have a proper UL or OL parent.
+   *
+   * @param \DOMNode $node
+   *   List item node.
+   */
+  protected function handleListItem(\DOMNode $node) {
+    // Add a list parent to orphan list items.
+    if ($node->parentNode->tagName !== 'ul' && $node->parentNode->tagName !== 'ol') {
+      $listElement = $node->ownerDocument->createElement('ul');
+      $node->parentNode->insertBefore($listElement, $node);
+      $sibling = $node;
+      while ($sibling !== NULL && ($sibling->nodeType !== 1 || $sibling->tagName === 'li')) {
+        $next = $sibling->nextSibling;
+        $listElement->appendChild($sibling);
+        $sibling = $next;
+      }
+    }
+  }
+
+  /**
+   * Remove attributes from a node.
+   *
+   * @param \DOMNode $node
+   *   Node from which to remove attributes.
+   * @param array $allowed_attributes
+   *   List of allowed attributes.
+   */
+  protected function removeAttributes(\DOMNode $node, array $allowed_attributes = []) {
+    if ($node->hasAttributes()) {
+      // Merge the globally allowed attributes with the local ones.
+      $allowed_attributes = array_merge($allowed_attributes, $this->allowedAttributes);
+
+      // Flip the attributes for easier checking.
+      $allowed_attributes = array_flip($allowed_attributes);
+
+      // Remove unallowed attributes.
+      $attributes = $node->attributes;
+      for ($i = $attributes->length - 1; $i >= 0; $i--) {
+        $attribute = $attributes->item($i)->name;
+        if (!isset($allowed_attributes[$attribute])) {
+          $node->removeAttribute($attribute);
+        }
+      }
+    }
+  }
+
+  /**
+   * Remove style and event attributes from a node.
+   *
+   * @param \DOMNode $node
+   *   Node from which to remove attributes.
+   */
+  protected function sanitizeAttributes(\DOMNode $node) {
+    if ($node->hasAttributes()) {
+      // Remove unallowed attributes.
+      $attributes = $node->attributes;
+      for ($i = $attributes->length - 1; $i >= 0; $i--) {
+        $attribute = $attributes->item($i)->name;
+        if ($attribute === 'style' || strpos($attribute, 'on') === 0) {
+          $node->removeAttribute($attribute);
+        }
+      }
+    }
+  }
+
+  /**
+   * Replace a node by a node with the new tag, moving content and attributes.
+   *
+   * @param \DOMNode $node
+   *   Node to replace.
+   * @param string $tag
+   *   New tag name.
+   * @param array $allowed_attributes
+   *   Attributes to move to the new node.
+   */
+  protected function changeTag(\DOMNode $node, $tag, array $allowed_attributes = []) {
+    if (!empty($tag)) {
+      $newNode = $node->ownerDocument->createElement($tag);
+    }
+    else {
+      $newNode = $node->ownerDocument->createDocumentFragment();
+    }
+    // Move the content.
+    while ($node->firstChild !== NULL) {
+      $newNode->appendChild($node->firstChild);
+    }
+
+    // Merge the globally allowed attributes with the local ones.
+    $allowed_attributes = array_merge($allowed_attributes, $this->allowedAttributes);
+
+    // Copy the attributes.
+    $allowed_attributes = array_flip($allowed_attributes);
+    if (!empty($allowed_attributes) && $node->hasAttributes()) {
+      foreach ($node->attributes as $attribute) {
+        if (isset($allowed_attributes[$attribute->name])) {
+          $newNode->setAttribute($attribute->name, $attribute->value);
+        }
+      }
+    }
+    $node->parentNode->replaceChild($newNode, $node);
+    return $newNode;
+  }
+
+  /**
+   * Get the nodes matching the tag name.
+   *
+   * \DOMElement::GetElementsByTagName returns a live collection. We convert it
+   * to a flat array so that the nodes can be manipulated during the iteration
+   * without creating infinite loops for example when adding iframe wrappers.
+   *
+   * @param \DOMNode $node
+   *   Node (\DOMDocument or \DOMElement)
+   * @param string $tag
+   *   Tag name or `*` for all nodes.
+   *
+   * @return array
+   *   List of nodes with the given tag name.
+   */
+  protected function getElementsByTagName(\DOMNode $node, $tag) {
+    $elements = [];
+    if (method_exists($node, 'getElementsByTagName')) {
+      foreach ($node->getElementsByTagName($tag) as $element) {
+        $elements[] = $element;
+      }
+    }
+    return $elements;
+  }
+
+  /**
+   * Remove a child node and its parents if they become empty.
+   *
+   * @param \DOMNode $node
+   *   Node to remove.
+   */
+  protected function removeChild(\DOMNode $node) {
+    $parent = $node->parentNode;
+    if (!empty($node->parentNode)) {
+      // Remove the node then if the parent is empty remove it as well.
+      // Calling `$this->removeChild()` will remove parents until a non empty
+      // one is found.
+      $parent->removeChild($node);
+      if ($this->isEmpty($parent)) {
+        $this->removeChild($parent);
+      }
+    }
+  }
+
+  /**
+   * Strip a tag.
+   *
+   * @param \DOMNode $node
+   *   Heading node.
+   */
+  protected function stripTag(\DOMNode $node) {
+    $parent = $node->parentNode;
+    // Move the content to the parent.
+    while ($node->firstChild !== NULL) {
+      $parent->insertBefore($node->firstChild, $node);
+    }
+    // Remove the node.
+    $this->removeChild($node);
+  }
+
+  /**
+   * Validate a URL.
+   *
+   * @param string $url
+   *   URL to validate.
+   *
+   * @return bool
+   *   TRUE if valid.
+   *
+   * @todo use something more robust than valid_url.
+   */
+  protected function validateUrl($url) {
+    return UrlHelper::isValid($url, UrlHelper::isExternal($url));
+  }
+
+}

--- a/html/modules/custom/unocha_utility/src/Helpers/UrlHelper.php
+++ b/html/modules/custom/unocha_utility/src/Helpers/UrlHelper.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\unocha_utility\Helpers;
+
+use Drupal\Component\Utility\UrlHelper as DrupalUrlHelper;
+use Drupal\Core\File\Exception\InvalidStreamWrapperException;
+use Drupal\Core\Url;
+
+/**
+ * Helper extending the Drupal URL helper with additional functionalities.
+ */
+class UrlHelper extends DrupalUrlHelper {
+
+  /**
+   * Encode a URL.
+   *
+   * This ensures that urls like  '/updates?search=blabli' are properly
+   * encoded by decomposing the url and rebuilding it.
+   *
+   * @param string $url
+   *   Url to encode.
+   * @param bool $alias
+   *   Whether the passed url is already an alias or not. If it's an alias then
+   *   this will prevent another lookup.
+   *
+   * @return string
+   *   Encoded url.
+   *
+   * @todo handle language.
+   * @todo review if still need this function and where to add it.
+   */
+  public static function encodeUrl($url, $alias = TRUE) {
+    if (empty($url)) {
+      return '';
+    }
+
+    if (preg_match('#^(?:(?:[^?]*://)|/)#', $url) !== 1) {
+      $url = '/' . $url;
+    }
+    if (strpos($url, '/') === 0) {
+      $url = 'internal:' . $url;
+    }
+    elseif (strpos($url, '://') === 0) {
+      $url = 'http' . $url;
+    }
+
+    $parts = static::parse($url);
+    return Url::fromUri($parts['path'], [
+      'query' => $parts['query'],
+      'fragment' => $parts['fragment'],
+      'alias' => $alias,
+    ])->toString();
+  }
+
+  /**
+   * Get a path from its alias.
+   *
+   * @param string $alias
+   *   Path alias.
+   *
+   * @return string
+   *   Path.
+   */
+  public static function getPathFromAlias($alias) {
+    return \Drupal::service('path_alias.manager')->getPathByAlias($alias);
+  }
+
+  /**
+   * Get an alias from its path.
+   *
+   * @param string $path
+   *   Path.
+   *
+   * @return string
+   *   Path alias.
+   */
+  public static function getAliasFromPath($path) {
+    return \Drupal::service('path_alias.manager')->getAliasByPath($path);
+  }
+
+  /**
+   * Get an absolute file URI.
+   *
+   * @param string $uri
+   *   File URI.
+   *
+   * @return string
+   *   Absolute URI for the file or empty if an error occured.
+   */
+  public static function getAbsoluteFileUri($uri) {
+    if (empty($uri)) {
+      return '';
+    }
+    try {
+      return \Drupal::service('file_url_generator')->generateAbsoluteString($uri);
+    }
+    catch (InvalidStreamWrapperException $exception) {
+      return '';
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isValid($url, $absolute = FALSE) {
+    if (empty($url)) {
+      return FALSE;
+    }
+    return parent::isValid($url, $absolute);
+  }
+
+}

--- a/html/modules/custom/unocha_utility/src/TwigExtension.php
+++ b/html/modules/custom/unocha_utility/src/TwigExtension.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Drupal\unocha_utility;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\unocha_utility\Helpers\HtmlSanitizer;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+/**
+ * Custom twig functions.
+ */
+class TwigExtension extends AbstractExtension {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFilters() {
+    return [
+      new TwigFilter('sanitize_html', [$this, 'sanitizeHtml'], [
+        'is_safe' => ['html'],
+      ]),
+      new TwigFilter('dpm', 'dpm'),
+      new TwigFilter('values', 'array_values'),
+      new TwigFilter('hide_nested_label', [$this, 'hideNestedLabel']),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFunctions() {
+    return [
+      // May be in core one day...
+      // @see https://www.drupal.org/project/drupal/issues/3184316
+      new TwigFunction('entity_url', [$this, 'getEntityUrl']),
+      new TwigFunction('entity_link', [$this, 'getEntityLink'], [
+        'is_safe' => ['html'],
+      ]),
+    ];
+  }
+
+  /**
+   * Sanitize an HTML string, removing unallowed tags and attributes.
+   *
+   * This also attempts to fix the heading hierarchy, at least preventing
+   * the use of h1 and h2 in the sanitized content.
+   *
+   * @param string $html
+   *   HTML string to sanitize.
+   * @param bool $iframe
+   *   Whether to allow iframes or not.
+   * @param int $heading_offset
+   *   Offset for the conversion of the headings to perserve the hierarchy.
+   * @param array $allowed_attributes
+   *   List of attributes that should be preserved (ex: data-disaster-map).
+   *
+   * @return string
+   *   Sanitized HTML string.
+   */
+  public static function sanitizeHtml($html, $iframe = FALSE, $heading_offset = 2, array $allowed_attributes = []) {
+    $sanitizer = new HtmlSanitizer($iframe, $heading_offset, $allowed_attributes);
+    return $sanitizer->sanitizeHtml((string) $html);
+  }
+
+  /**
+   * Get an entity's URL.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   * @param string $rel
+   *   The link relationship type, for example: canonical or edit-form.
+   * @param array $options
+   *   See \Drupal\Core\Routing\UrlGeneratorInterface::generateFromRoute() for
+   *   the available options.
+   *
+   * @return string
+   *   The entity URL.
+   */
+  public static function getEntityUrl(EntityInterface $entity, $rel = 'canonical', array $options = []) {
+    return $entity->toUrl($rel, $options)->toString();
+  }
+
+  /**
+   * Get an entity's Link.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   * @param string|null $text
+   *   The link text for the anchor tag as a translated string. If NULL, it will
+   *   use the entity's label. Defaults to NULL.
+   * @param string $rel
+   *   The link relationship type, for example: canonical or edit-form.
+   * @param array $options
+   *   See \Drupal\Core\Routing\UrlGeneratorInterface::generateFromRoute() for
+   *   the available options.
+   *
+   * @return \Drupal\Core\GeneratedLink
+   *   The entity link HTML.
+   */
+  public static function getEntityLink(EntityInterface $entity, $text = NULL, $rel = 'canonical', array $options = []) {
+    return $entity->toLink($text, $rel, $options)->toString();
+  }
+
+  /**
+   * Hide a label in a nested render array.
+   *
+   * @param array $element
+   *   Form element.
+   * @param array $children
+   *   List of nested children of the form element.
+   */
+  public static function hideNestedLabel(array $element, array $children) {
+    $parent = &$element;
+    $last = count($children) - 1;
+    foreach ($children as $index => $child) {
+      if (isset($parent[$child])) {
+        if ($index === $last) {
+          $parent[$child]['#title_display'] = 'invisible';
+        }
+        else {
+          $parent = &$parent[$child];
+        }
+      }
+      else {
+        break;
+      }
+    }
+    return $element;
+  }
+
+}

--- a/html/modules/custom/unocha_utility/unocha_utility.info.yml
+++ b/html/modules/custom/unocha_utility/unocha_utility.info.yml
@@ -1,0 +1,5 @@
+type: module
+name: UNOCHA Utility
+description: 'Provides various utility helpers.'
+package: unocha
+core_version_requirement: ^9 || ^10

--- a/html/modules/custom/unocha_utility/unocha_utility.module
+++ b/html/modules/custom/unocha_utility/unocha_utility.module
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Helper functions that applies to a variety of things on UNOCHA.
+ */
+
+use Drupal\Core\Template\Attribute;
+
+/**
+ * Implements hook_preprocess().
+ *
+ * Ensure the attributes and *_attributes are set for the unocha templates.
+ */
+function unocha_utility_preprocess(array &$variables, $hook) {
+  if (strpos($hook, 'unocha_') === 0) {
+    foreach ($variables as $key => $value) {
+      if ($key === 'attributes' || strpos($key, '_attributes') !== FALSE) {
+        if (is_null($value)) {
+          $variables[$key] = new Attribute();
+        }
+      }
+    }
+  }
+}

--- a/html/modules/custom/unocha_utility/unocha_utility.services.yml
+++ b/html/modules/custom/unocha_utility/unocha_utility.services.yml
@@ -1,0 +1,5 @@
+services:
+  unocha_utility.twig.extension:
+    class: Drupal\unocha_utility\TwigExtension
+    tags:
+      - { name: twig.extension }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -64,6 +64,13 @@ rw-brand:
     theme:
       components/rw-brand/rw-brand.css: {}
 
+rw-document:
+  css:
+    theme:
+      components/rw-document/rw-document.css: {}
+  dependencies:
+    - common_design/cd-page-title
+
 rw-key-figures:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/components/rw-document/README.md
+++ b/html/themes/custom/common_design_subtheme/components/rw-document/README.md
@@ -1,0 +1,4 @@
+ReliefWeb Document
+==================
+
+This component handles the display of white label reliefweb documents.

--- a/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
@@ -1,0 +1,59 @@
+/**
+ * ReliefWeb document page.
+ */
+
+/* Date. */
+.unocha-reliefweb-document__date {
+  font-weight: bold;
+  font-style: italic;
+}
+
+/* Lists in content. */
+.unocha-reliefweb-document li {
+  margin: 8px 0 0;
+}
+
+/* Attachments. */
+.unocha-reliefweb-attachment-list {
+  max-width: 220px;
+  margin: 0 auto 24px auto;
+  padding-top: 0;
+}
+.unocha-reliefweb-attachment-list ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.unocha-reliefweb-attachment-list li {
+  margin: 0;
+  padding: 16px 0;
+  text-align: center;
+  border: 1px solid var(--brand-grey);
+}
+.unocha-reliefweb-attachment-list li + li {
+  margin-top: 24px;
+}
+.unocha-reliefweb-attachment-list img {
+  width: 100%;
+  margin: -16px 0 8px 0;
+  border-bottom: 1px solid var(--brand-grey);
+}
+.unocha-reliefweb-attachment-list strong {
+  display: block;
+  padding: 0 16px;
+}
+.unocha-reliefweb-attachment-list strong:first-letter {
+  text-transform: capitalize;
+}
+.unocha-reliefweb-attachment-list span {
+  display: block;
+  padding: 4px 16px 0 16px;
+  font-size: 14px;
+}
+
+@media screen and (min-width: 480px) {
+  .unocha-reliefweb-attachment-list {
+    float: right;
+    margin-left: 24px;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/package-lock.json
+++ b/html/themes/custom/common_design_subtheme/package-lock.json
@@ -2216,9 +2216,9 @@
       }
     },
     "node_modules/@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
       "dev": true
     },
     "node_modules/@sideway/pinpoint": {
@@ -10205,9 +10205,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
       "dev": true
     },
     "@sideway/pinpoint": {

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-document.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-document.html.twig
@@ -1,0 +1,5 @@
+{{ attach_library('common_design_subtheme/rw-document') }}
+
+{% set title_attributes = title_attributes.addClass('cd-page-title') %}
+
+{% include '@unocha_reliefweb/unocha-reliefweb-document.html.twig' %}

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -13,25 +13,24 @@ volumes:
 
 services:
   memcache:
-    restart: always
-    image: memcached:alpine
+    image: public.ecr.aws/unocha/memcache:1.6
     hostname: unocha-local-memcache
     container_name: unocha-local-memcache
-    entrypoint: ["memcached", "-m", "64"]
+    environment:
+      MEMCACHE_MAX_MEMORY: 64
     ports:
       - "11211"
     networks:
       - default
 
   mysql:
-    image: mariadb:latest
+    image: public.ecr.aws/unocha/mysql:10.6
     hostname: unocha-local-mysql
     container_name: unocha-local-mysql
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_DATABASE=unocha
+      - MYSQL_DB=unocha
       - MYSQL_USER=unocha
-      - MYSQL_PASSWORD=unocha
+      - MYSQL_PASS=unocha
     volumes:
       - "unocha-local-site-database:/var/lib/mysql:rw"
     networks:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,25 +10,24 @@ volumes:
 
 services:
   memcache:
-    restart: always
-    image: memcached:alpine
+    image: public.ecr.aws/unocha/memcache:1.6
     hostname: unocha-test-memcache
     container_name: unocha-test-memcache
-    entrypoint: ["memcached", "-m", "64"]
+    environment:
+      MEMCACHE_MAX_MEMORY: 64
     ports:
       - "11211"
     networks:
       - default
 
   mysql:
-    image: mariadb:latest
+    image: public.ecr.aws/unocha/mysql:10.6
     hostname: unocha-test-mysql
     container_name: unocha-test-mysql
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_DATABASE=unocha
+      - MYSQL_DB=unocha
       - MYSQL_USER=unocha
-      - MYSQL_PASSWORD=unocha
+      - MYSQL_PASS=unocha
     volumes:
       - "unocha-test-site-database:/var/lib/mysql:rw"
     networks:


### PR DESCRIPTION
Refs: UNO-514

**Note:** This PR is against the branch from https://github.com/UN-OCHA/unocha-site/pull/16 as I assumed it contains the most recent work.

This adds a custom module with some RW integration (API client notably) that also provides a controller that render documents from the RW API as pages on UNO.

There is also some nginx rules to handle attachments and attachment previews as well.

**Note:** Currently only `press releases` are displayed this way. We need to define the base path and there are other things to discuss about how to look up documents, what to do with images etc.

Ex: https://unocha-local.test/press-releases/honduras/humanitarians-seek-505-million-assist-49-million-people-el-salvador-guatemala-and-honduras-2023 (replace `unocha-local.test` with the local/stage domain).

<img width="1203" alt="Screen Shot 2023-02-16 at 16 39 15" src="https://user-images.githubusercontent.com/696348/219299077-cbe1b746-bb33-43c2-b144-c7767daf5558.png">
