### PR TITLE
[UNO-613] POC canto integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
     ],
     "repositories": [
         {
+           "type": "vcs",
+           "url": "https://github.com/orakili/canto_connector.git",
+           "no-api": true
+        },
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         },
@@ -26,6 +31,7 @@
         "drupal-composer/preserve-paths": "^0.1.6",
         "drupal/admin_denied": "^2.0",
         "drupal/allowed_formats": "^2.0",
+        "drupal/canto_connector": "dev-develop",
         "drupal/components": "^3.0@beta",
         "drupal/config_split": "@rc",
         "drupal/core-composer-scaffold": "^10",
@@ -34,6 +40,7 @@
         "drupal/csp": "^1.17",
         "drupal/devel": "^5.0",
         "drupal/devel_php": "^1.3",
+        "drupal/entity_browser": "^2.9",
         "drupal/entity_reference_display": "^2.0",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/google_tag": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "397fb54f4f054014c030b8be0f8a2ab7",
+    "content-hash": "08cc810451d3aad04af9c13c5d131426",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2485,6 +2485,41 @@
             }
         },
         {
+            "name": "drupal/canto_connector",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orakili/canto_connector.git",
+                "reference": "006ff721466dda110eb8123847482ca9277a3c16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orakili/canto_connector/zipball/006ff721466dda110eb8123847482ca9277a3c16",
+                "reference": "006ff721466dda110eb8123847482ca9277a3c16",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/json_field": "^1.0@RC"
+            },
+            "default-branch": true,
+            "type": "drupal-module",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "awm",
+                    "homepage": "https://www.drupal.org/u/awm"
+                },
+                {
+                    "name": "flightdev",
+                    "homepage": "https://www.drupal.org/u/flightdev"
+                }
+            ],
+            "description": "DAM integration with Canto.",
+            "time": "2023-03-03T06:04:58+00:00"
+        },
+        {
             "name": "drupal/coder",
             "version": "8.3.17",
             "source": {
@@ -3255,6 +3290,96 @@
             }
         },
         {
+            "name": "drupal/entity_browser",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_browser.git",
+                "reference": "8.x-2.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.9.zip",
+                "reference": "8.x-2.9",
+                "shasum": "251afad80cde9fa547501a8d9de5d94b9f5bacff"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/embed": "~1.0",
+                "drupal/entity_embed": "1.x-dev",
+                "drupal/entity_reference_revisions": "1.x-dev",
+                "drupal/entityqueue": "1.x-dev",
+                "drupal/inline_entity_form": "1.x-dev",
+                "drupal/paragraphs": "1.x-dev",
+                "drupal/token": "1.x-dev"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.9",
+                    "datestamp": "1674070933",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Janez Urevc",
+                    "homepage": "https://github.com/slashrsm",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Primoz Hmeljak",
+                    "homepage": "https://github.com/primsi",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "See other contributors",
+                    "homepage": "https://www.drupal.org/node/1943336/committers",
+                    "role": "contributor"
+                },
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "marcingy",
+                    "homepage": "https://www.drupal.org/user/77320"
+                },
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                },
+                {
+                    "name": "Primsi",
+                    "homepage": "https://www.drupal.org/user/282629"
+                },
+                {
+                    "name": "samuel.mortenson",
+                    "homepage": "https://www.drupal.org/user/2582268"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Entity browsing and selecting component.",
+            "homepage": "http://drupal.org/project/entity_browser",
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_browser",
+                "issues": "https://www.drupal.org/project/issues/entity_browser",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
             "name": "drupal/entity_reference_display",
             "version": "2.0.0",
             "source": {
@@ -3718,6 +3843,71 @@
             "homepage": "https://www.drupal.org/project/imagemagick",
             "support": {
                 "source": "https://git.drupalcode.org/project/imagemagick"
+            }
+        },
+        {
+            "name": "drupal/json_field",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/json_field.git",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/json_field-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "9d1233be45736afcaa29336d7d09410a6b342c46"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10",
+                "ext-json": "*"
+            },
+            "require-dev": {
+                "swaggest/json-schema": "^0"
+            },
+            "suggest": {
+                "drupal/diff": "^0",
+                "swaggest/json-schema": "^0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1673020757",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "See contributors",
+                    "homepage": "https://www.drupal.org/node/2653746/committers",
+                    "role": "Developer"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "Jaesin",
+                    "homepage": "https://www.drupal.org/user/841054"
+                }
+            ],
+            "description": "Provides a JSON field, formatter and views integration",
+            "homepage": "https://www.drupal.org/project/json_field",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/json_field",
+                "issues": "https://www.drupal.org/project/issues/json_field"
             }
         },
         {
@@ -14225,6 +14415,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/canto_connector": 20,
         "drupal/components": 10,
         "drupal/config_split": 5,
         "drupal/entity_usage": 10,

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -3,6 +3,9 @@
     "drupal/csp": {
       "Simplify log format": "patches/csp-log-format.patch"
     },
+    "drupal/entity_browser": {
+      "PHP 8.2 compatibility": "patches/entity_browser-php-82-compatiblity.patch"
+    },
     "drupal/maintenance200": {
       "Drupal 10 compatibility": "patches/maintenance200-drupal-10-compatibility.patch"
     },

--- a/config/core.entity_form_display.media.canto_image.default.yml
+++ b/config/core.entity_form_display.media.canto_image.default.yml
@@ -1,0 +1,122 @@
+uuid: 68fe3d22-8c98-44e9-a4dc-b2dea91788fe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.canto_image.field_canto_asset_image
+    - field.field.media.canto_image.field_cantodam_asset_id
+    - field.field.media.canto_image.field_cantodam_asset_metadata
+    - field.field.media.canto_image.field_image_copyright
+    - field.field.media.canto_image.field_image_description
+    - field.field.media.canto_image.field_image_height
+    - field.field.media.canto_image.field_image_width
+    - image.style.thumbnail
+    - media.type.canto_image
+  module:
+    - image
+    - json_field
+    - path
+id: media.canto_image.default
+targetEntityType: media
+bundle: canto_image
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_canto_asset_image:
+    type: image_image
+    weight: 108
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_cantodam_asset_id:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_cantodam_asset_metadata:
+    type: json_textarea
+    weight: 101
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_image_copyright:
+    type: string_textfield
+    weight: 106
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_image_description:
+    type: string_textarea
+    weight: 107
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_image_height:
+    type: number
+    weight: 105
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_image_width:
+    type: number
+    weight: 104
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/core.entity_form_display.media.canto_image.media_library.yml
+++ b/config/core.entity_form_display.media.canto_image.media_library.yml
@@ -1,0 +1,40 @@
+uuid: 60155538-8d00-4058-b2cd-db6c043fbb7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.canto_image.field_canto_asset_image
+    - field.field.media.canto_image.field_cantodam_asset_id
+    - field.field.media.canto_image.field_cantodam_asset_metadata
+    - field.field.media.canto_image.field_image_copyright
+    - field.field.media.canto_image.field_image_description
+    - field.field.media.canto_image.field_image_height
+    - field.field.media.canto_image.field_image_width
+    - media.type.canto_image
+id: media.canto_image.media_library
+targetEntityType: media
+bundle: canto_image
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_canto_asset_image: true
+  field_cantodam_asset_id: true
+  field_cantodam_asset_metadata: true
+  field_image_copyright: true
+  field_image_description: true
+  field_image_height: true
+  field_image_width: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/config/core.entity_form_display.paragraph.canto_image.default.yml
+++ b/config/core.entity_form_display.paragraph.canto_image.default.yml
@@ -1,0 +1,33 @@
+uuid: 4b61ba62-2ee5-4fb2-abc2-3aab20033699
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.canto_images
+    - field.field.paragraph.canto_image.field_image
+    - paragraphs.paragraphs_type.canto_image
+  module:
+    - entity_browser
+id: paragraph.canto_image.default
+targetEntityType: paragraph
+bundle: canto_image
+mode: default
+content:
+  field_image:
+    type: entity_browser_entity_reference
+    weight: 0
+    region: content
+    settings:
+      entity_browser: canto_images
+      field_widget_display: rendered_entity
+      field_widget_edit: false
+      field_widget_remove: true
+      field_widget_replace: true
+      open: true
+      field_widget_display_settings:
+        view_mode: default
+      selection_mode: selection_append
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.media.canto_image.default.yml
+++ b/config/core.entity_view_display.media.canto_image.default.yml
@@ -1,0 +1,56 @@
+uuid: 4e9e9519-0885-487d-abff-6f10727e2cc2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.canto_image.field_canto_asset_image
+    - field.field.media.canto_image.field_cantodam_asset_id
+    - field.field.media.canto_image.field_cantodam_asset_metadata
+    - field.field.media.canto_image.field_image_copyright
+    - field.field.media.canto_image.field_image_description
+    - field.field.media.canto_image.field_image_height
+    - field.field.media.canto_image.field_image_width
+    - media.type.canto_image
+  module:
+    - image
+id: media.canto_image.default
+targetEntityType: media
+bundle: canto_image
+mode: default
+content:
+  field_canto_asset_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_image_copyright:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_image_description:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  field_cantodam_asset_id: true
+  field_cantodam_asset_metadata: true
+  field_image_height: true
+  field_image_width: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.media.canto_image.media_library.yml
+++ b/config/core.entity_view_display.media.canto_image.media_library.yml
@@ -1,0 +1,45 @@
+uuid: 28084aaf-7573-4e88-869d-6ff28f7cef4e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.canto_image.field_canto_asset_image
+    - field.field.media.canto_image.field_cantodam_asset_id
+    - field.field.media.canto_image.field_cantodam_asset_metadata
+    - field.field.media.canto_image.field_image_copyright
+    - field.field.media.canto_image.field_image_description
+    - field.field.media.canto_image.field_image_height
+    - field.field.media.canto_image.field_image_width
+    - image.style.medium
+    - media.type.canto_image
+  module:
+    - image
+id: media.canto_image.media_library
+targetEntityType: media
+bundle: canto_image
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_canto_asset_image: true
+  field_cantodam_asset_id: true
+  field_cantodam_asset_metadata: true
+  field_image_copyright: true
+  field_image_description: true
+  field_image_height: true
+  field_image_width: true
+  langcode: true
+  name: true
+  uid: true

--- a/config/core.entity_view_display.paragraph.canto_image.default.yml
+++ b/config/core.entity_view_display.paragraph.canto_image.default.yml
@@ -1,0 +1,22 @@
+uuid: 3dba6974-9f88-4ca8-b93f-127fb596fd57
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.canto_image.field_image
+    - paragraphs.paragraphs_type.canto_image
+id: paragraph.canto_image.default
+targetEntityType: paragraph
+bundle: canto_image
+mode: default
+content:
+  field_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -5,6 +5,7 @@ module:
   allowed_formats: 0
   block: 0
   breakpoint: 0
+  canto_connector: 0
   ckeditor5: 0
   components: 0
   config: 0
@@ -19,6 +20,7 @@ module:
   devel_generate: 0
   dynamic_page_cache: 0
   editor: 0
+  entity_browser: 0
   entity_reference_display: 0
   entity_reference_revisions: 0
   entity_usage: 0
@@ -33,6 +35,7 @@ module:
   imageapi_optimize_binaries: 0
   imagemagick: 0
   inline_form_errors: 0
+  json_field: 0
   language: 0
   layout_builder: 0
   layout_builder_restrictions: 0
@@ -57,6 +60,7 @@ module:
   path_alias: 0
   redirect: 0
   responsive_image: 0
+  serialization: 0
   social_api: 0
   social_auth: 0
   social_auth_hid: 0

--- a/config/entity_browser.browser.canto_images.yml
+++ b/config/entity_browser.browser.canto_images.yml
@@ -1,0 +1,27 @@
+uuid: 5cae9a5d-e0ab-4409-bcd9-3b17f481f6bd
+langcode: en
+status: true
+dependencies:
+  module:
+    - canto_connector
+name: canto_images
+label: 'Canto Images'
+display: iframe
+display_configuration:
+  width: '650'
+  height: '500'
+  link_text: 'Select entities'
+  auto_open: false
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: single
+widget_selector_configuration: {  }
+widgets:
+  31609aa9-96d8-4c65-8b2d-2a071d6dbca0:
+    id: canto_browser
+    uuid: 31609aa9-96d8-4c65-8b2d-2a071d6dbca0
+    label: canto_browser
+    weight: 1
+    settings:
+      media_type: canto_image
+      submit_text: 'Select image'

--- a/config/field.field.media.canto_image.field_canto_asset_image.yml
+++ b/config/field.field.media.canto_image.field_canto_asset_image.yml
@@ -1,0 +1,38 @@
+uuid: 80cc8b08-bb27-40f7-bbc4-736f4a82af9e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_canto_asset_image
+    - media.type.canto_image
+  module:
+    - image
+id: media.canto_image.field_canto_asset_image
+field_name: field_canto_asset_image
+entity_type: media
+bundle: canto_image
+label: 'Canto Asset Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: images/canto
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/field.field.media.canto_image.field_cantodam_asset_id.yml
+++ b/config/field.field.media.canto_image.field_cantodam_asset_id.yml
@@ -1,0 +1,19 @@
+uuid: e2bfeb3d-9727-405a-8c68-c401c432e395
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_cantodam_asset_id
+    - media.type.canto_image
+id: media.canto_image.field_cantodam_asset_id
+field_name: field_cantodam_asset_id
+entity_type: media
+bundle: canto_image
+label: 'Canto Asset ID'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.media.canto_image.field_cantodam_asset_metadata.yml
+++ b/config/field.field.media.canto_image.field_cantodam_asset_metadata.yml
@@ -1,0 +1,21 @@
+uuid: d94ea233-e81e-4b93-acea-bffb48a6e6ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_cantodam_asset_metadata
+    - media.type.canto_image
+  module:
+    - json_field
+id: media.canto_image.field_cantodam_asset_metadata
+field_name: field_cantodam_asset_metadata
+entity_type: media
+bundle: canto_image
+label: 'Canto Asset Raw Metadata'
+description: 'Raw metadata retrieved from the Canto website in JSON format.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: json_native

--- a/config/field.field.media.canto_image.field_image_copyright.yml
+++ b/config/field.field.media.canto_image.field_image_copyright.yml
@@ -1,0 +1,19 @@
+uuid: 689dd764-9c3b-4909-9f23-dc9b64ceca40
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_image_copyright
+    - media.type.canto_image
+id: media.canto_image.field_image_copyright
+field_name: field_image_copyright
+entity_type: media
+bundle: canto_image
+label: Copyright
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.media.canto_image.field_image_description.yml
+++ b/config/field.field.media.canto_image.field_image_description.yml
@@ -1,0 +1,19 @@
+uuid: 7df0ce7c-4e7d-49d3-a41d-3d58b9b4b272
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_image_description
+    - media.type.canto_image
+id: media.canto_image.field_image_description
+field_name: field_image_description
+entity_type: media
+bundle: canto_image
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.media.canto_image.field_image_height.yml
+++ b/config/field.field.media.canto_image.field_image_height.yml
@@ -1,0 +1,23 @@
+uuid: 22a2953f-9c07-4aff-855f-099e684dc719
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_image_height
+    - media.type.canto_image
+id: media.canto_image.field_image_height
+field_name: field_image_height
+entity_type: media
+bundle: canto_image
+label: Height
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.field.media.canto_image.field_image_width.yml
+++ b/config/field.field.media.canto_image.field_image_width.yml
@@ -1,0 +1,23 @@
+uuid: 09e801c9-b991-45af-be82-47f31a3767d1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_image_width
+    - media.type.canto_image
+id: media.canto_image.field_image_width
+field_name: field_image_width
+entity_type: media
+bundle: canto_image
+label: Width
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.field.paragraph.canto_image.field_image.yml
+++ b/config/field.field.paragraph.canto_image.field_image.yml
@@ -1,0 +1,29 @@
+uuid: 1c36ebac-195a-4ef3-973f-2712a67f4daf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image
+    - media.type.canto_image
+    - paragraphs.paragraphs_type.canto_image
+id: paragraph.canto_image.field_image
+field_name: field_image
+entity_type: paragraph
+bundle: canto_image
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      canto_image: canto_image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.storage.media.field_canto_asset_image.yml
+++ b/config/field.storage.media.field_canto_asset_image.yml
@@ -1,0 +1,30 @@
+uuid: 32053e8d-ddb3-4516-bbf2-316c2bf54316
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - media
+id: media.field_canto_asset_image
+field_name: field_canto_asset_image
+entity_type: media
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_cantodam_asset_id.yml
+++ b/config/field.storage.media.field_cantodam_asset_id.yml
@@ -1,0 +1,21 @@
+uuid: c47dba7c-e207-408a-824a-8454a36aab5f
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_cantodam_asset_id
+field_name: field_cantodam_asset_id
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_cantodam_asset_metadata.yml
+++ b/config/field.storage.media.field_cantodam_asset_metadata.yml
@@ -1,0 +1,19 @@
+uuid: ea2d5b3a-b868-4048-97c8-5542d98ac9d6
+langcode: en
+status: true
+dependencies:
+  module:
+    - json_field
+    - media
+id: media.field_cantodam_asset_metadata
+field_name: field_cantodam_asset_metadata
+entity_type: media
+type: json_native
+settings: {  }
+module: json_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_image_copyright.yml
+++ b/config/field.storage.media.field_image_copyright.yml
@@ -1,0 +1,21 @@
+uuid: c0d2be1f-e46b-4200-ace9-69d22ed38b25
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_image_copyright
+field_name: field_image_copyright
+entity_type: media
+type: string
+settings:
+  max_length: 2048
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_image_description.yml
+++ b/config/field.storage.media.field_image_description.yml
@@ -1,0 +1,19 @@
+uuid: 86547436-12e6-470c-b99c-2a5e73c88bd0
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_image_description
+field_name: field_image_description
+entity_type: media
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_image_height.yml
+++ b/config/field.storage.media.field_image_height.yml
@@ -1,0 +1,20 @@
+uuid: b4ad01d4-1b36-4702-b643-2943d24b44bc
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_image_height
+field_name: field_image_height
+entity_type: media
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_image_width.yml
+++ b/config/field.storage.media.field_image_width.yml
@@ -1,0 +1,20 @@
+uuid: 61085910-7cdd-4c23-9a5b-2db286d43532
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_image_width
+field_name: field_image_width
+entity_type: media
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/language.content_settings.media.canto_image.yml
+++ b/config/language.content_settings.media.canto_image.yml
@@ -1,0 +1,11 @@
+uuid: 87f46677-7452-45ac-9629-fdeb313c4590
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.canto_image
+id: media.canto_image
+target_entity_type_id: media
+target_bundle: canto_image
+default_langcode: site_default
+language_alterable: false

--- a/config/media.type.canto_image.yml
+++ b/config/media.type.canto_image.yml
@@ -1,0 +1,24 @@
+uuid: e97315e3-4c0c-441e-85ff-4c8aad6dab07
+langcode: en
+status: true
+dependencies:
+  module:
+    - canto_connector
+id: canto_image
+label: 'Canto Image'
+description: ''
+source: cantodam_asset
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_cantodam_asset_id
+  metadata_field: field_cantodam_asset_metadata
+field_map:
+  description: field_image_description
+  file: field_canto_asset_image
+  metadata: field_cantodam_asset_metadata
+  uuid: field_cantodam_asset_id
+  name: name
+  copyright: field_image_copyright
+  width: field_image_width
+  height: field_image_height

--- a/config/paragraphs.paragraphs_type.canto_image.yml
+++ b/config/paragraphs.paragraphs_type.canto_image.yml
@@ -1,0 +1,10 @@
+uuid: 0a50b4df-c1a2-4b11-957c-e4b952babe60
+langcode: en
+status: true
+dependencies: {  }
+id: canto_image
+label: 'Canto Image'
+icon_uuid: null
+icon_default: null
+description: 'Image from Canto DAM.'
+behavior_plugins: {  }

--- a/docker/etc/nginx/custom/01_canto_assets.conf
+++ b/docker/etc/nginx/custom/01_canto_assets.conf
@@ -1,0 +1,5 @@
+## Use the Canto static assets from the canto_connector module directory.
+location /canto-assets/ {
+  rewrite ^/canto-assets/static/universal/ /modules/contrib/canto_connector/canto_assets/ last;
+  try_files $uri =404;
+}

--- a/patches/entity_browser-php-82-compatiblity.patch
+++ b/patches/entity_browser-php-82-compatiblity.patch
@@ -1,0 +1,13 @@
+diff --git a/src/WidgetSelectorBase.php b/src/WidgetSelectorBase.php
+index b71687d..b5d44ad 100644
+--- a/src/WidgetSelectorBase.php
++++ b/src/WidgetSelectorBase.php
+@@ -25,7 +25,7 @@ abstract class WidgetSelectorBase extends PluginBase implements WidgetSelectorIn
+    *
+    * @var array
+    */
+-  protected $widgets_ids;
++  protected $widget_ids;
+ 
+   /**
+    * ID of the default widget.


### PR DESCRIPTION
Refs: UNO-613

This adds the canto_connector and entity_browser modules to allow selecting images from Canto DAM. The selected images are saved as media entities.

This also adds the "Canto Image" media type and the "Canto Image" paragraph type (with a field to add such a media) and uses an entity browser widget to display the Canto interface to select an image.

**Note:** this is a proof of concept at this stage because it's a bit brittle and the UX is not great but it works so we can expand on it, notably writing a simpler form widget with a better UX.