### PR TITLE
[UNO-631] Stories paragraph type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "drupal/stable": "^2.0",
         "drupal/user_display_name": "^1.1",
         "drupal/user_expire": "^1.1",
+        "drupal/verf": "^2.0",
         "drupal/viewsreference": "^2.0@beta",
         "drupal/xmlsitemap": "^1.4",
         "drush/drush": "^11.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2332ced4e95134bfc15b1fe1bf57cdeb",
+    "content-hash": "04f9fb890b986ea272499b671a651e1a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5204,6 +5204,54 @@
             "support": {
                 "source": "https://git.drupal.org/project/user_expire.git",
                 "issues": "https://www.drupal.org/project/issues/user_expire"
+            }
+        },
+        {
+            "name": "drupal/verf",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/verf.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/verf-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "642fcf3bbd65855a23a53cab9f1c7d23d83b9bcc"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1683799678",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "legolasbo",
+                    "homepage": "https://www.drupal.org/user/2480548"
+                },
+                {
+                    "name": "podarok",
+                    "homepage": "https://www.drupal.org/user/116002"
+                }
+            ],
+            "description": "Provides Views filters for entity reference fields.",
+            "homepage": "https://www.drupal.org/project/verf",
+            "support": {
+                "source": "https://git.drupalcode.org/project/verf"
             }
         },
         {

--- a/config/core.entity_form_display.paragraph.stories.default.yml
+++ b/config/core.entity_form_display.paragraph.stories.default.yml
@@ -1,0 +1,31 @@
+uuid: d12fe0bb-17b9-41be-8d5a-d9cc676b38bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stories.field_limit
+    - field.field.paragraph.stories.field_title
+    - paragraphs.paragraphs_type.stories
+id: paragraph.stories.default
+targetEntityType: paragraph
+bundle: stories
+mode: default
+content:
+  field_limit:
+    type: number
+    weight: 1
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.stories.default.yml
+++ b/config/core.entity_view_display.paragraph.stories.default.yml
@@ -1,0 +1,23 @@
+uuid: ebd7cae0-adf9-473c-a812-e046252da661
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stories.field_limit
+    - field.field.paragraph.stories.field_title
+    - paragraphs.paragraphs_type.stories
+id: paragraph.stories.default
+targetEntityType: paragraph
+bundle: stories
+mode: default
+content:
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_limit: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -83,6 +83,7 @@ module:
   user_display_name: 0
   user_expire: 0
   views_ui: 0
+  verf: 0
   viewsreference: 0
   xmlsitemap_engines: 0
   pathauto: 1

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -76,6 +76,7 @@ module:
   toolbar: 0
   unocha_figures: 0
   unocha_migrate: 0
+  unocha_paragraphs: 0
   unocha_reliefweb: 0
   unocha_utility: 0
   update: 0

--- a/config/field.field.paragraph.stories.field_limit.yml
+++ b/config/field.field.paragraph.stories.field_limit.yml
@@ -1,0 +1,25 @@
+uuid: 4b53c46e-054a-42a3-8290-5f42ed95f7dd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_limit
+    - paragraphs.paragraphs_type.stories
+id: paragraph.stories.field_limit
+field_name: field_limit
+entity_type: paragraph
+bundle: stories
+label: Limit
+description: 'Maximum number of stories to display.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 3
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.field.paragraph.stories.field_title.yml
+++ b/config/field.field.paragraph.stories.field_title.yml
@@ -1,0 +1,21 @@
+uuid: 02843a7e-7dfd-440b-ae4d-47985efe3ff6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.stories
+id: paragraph.stories.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: stories
+label: Title
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: 'Latest News and Stories'
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.paragraph.field_limit.yml
+++ b/config/field.storage.paragraph.field_limit.yml
@@ -1,0 +1,20 @@
+uuid: 4ee7a1bc-b80b-4245-99ee-61431333f1ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_limit
+field_name: field_limit
+entity_type: paragraph
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.stories.yml
+++ b/config/paragraphs.paragraphs_type.stories.yml
@@ -1,0 +1,10 @@
+uuid: 75d4a760-55d0-4847-88ae-27eacb3edc54
+langcode: en
+status: true
+dependencies: {  }
+id: stories
+label: Stories
+icon_uuid: null
+icon_default: null
+description: 'List of latest news and stories.'
+behavior_plugins: {  }

--- a/config/views.view.stories.yml
+++ b/config/views.view.stories.yml
@@ -5,11 +5,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.card
     - node.type.story
-    - taxonomy.vocabulary.country
-    - taxonomy.vocabulary.story_type
   module:
     - node
-    - taxonomy
     - user
     - verf
 id: stories
@@ -227,7 +224,7 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: true
-          content: '<p class="empty-results">No stories found for the selected filters.</p>'
+          content: '<p class="empty-results">No news and stories found for the selected filters.</p>'
           tokenize: false
       filters:
         status:
@@ -251,106 +248,10 @@ display:
           value:
             story: story
           group: 1
-        field_story_type_target_id:
-          id: field_story_type_target_id
+        field_story_type_target_id_verf:
+          id: field_story_type_target_id_verf
           table: node__field_story_type
-          field: field_story_type_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_story_type_target_id_op
-            label: 'Story type'
-            description: ''
-            use_operator: false
-            operator: field_story_type_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          vid: story_type
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: false
-        field_country_target_id:
-          id: field_country_target_id
-          table: node__field_country
-          field: field_country_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_country_target_id_op
-            label: Country
-            description: ''
-            use_operator: false
-            operator: field_country_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: country
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          vid: country
-          type: select
-          hierarchy: false
-          limit: true
-          error_message: false
-        field_region_target_id_verf:
-          id: field_region_target_id_verf
-          table: node__field_region
-          field: field_region_target_id_verf
+          field: field_story_type_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
@@ -360,14 +261,14 @@ display:
           group: 1
           exposed: true
           expose:
-            operator_id: field_region_target_id_verf_op
-            label: Region
+            operator_id: field_story_type_target_id_verf_op
+            label: 'Story type'
             description: ''
             use_operator: false
-            operator: field_region_target_id_verf_op
+            operator: field_story_type_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: region
+            identifier: type
             required: false
             remember: false
             multiple: false
@@ -390,12 +291,62 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           verf_target_bundles:
-            region: region
-            basic: '0'
-            event: '0'
-            resource: '0'
-            response: '0'
-            story: '0'
+            story_type: story_type
+            country: '0'
+            event_type: '0'
+            regional_offices: '0'
+            response_type: '0'
+            theme: '0'
+          show_unpublished: 0
+        field_country_target_id_verf:
+          id: field_country_target_id_verf
+          table: node__field_country
+          field: field_country_target_id_verf
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: verf
+          operator: in
+          value: {  }
+          group: 2
+          exposed: true
+          expose:
+            operator_id: field_country_target_id_verf_op
+            label: Country
+            description: ''
+            use_operator: false
+            operator: field_country_target_id_verf_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: country
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            reduce: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          verf_target_bundles:
+            country: country
+            event_type: '0'
+            regional_offices: '0'
+            response_type: '0'
+            story_type: '0'
+            theme: '0'
           show_unpublished: 0
         field_response_target_id_verf:
           id: field_response_target_id_verf
@@ -407,7 +358,7 @@ display:
           plugin_id: verf
           operator: in
           value: {  }
-          group: 1
+          group: 2
           exposed: true
           expose:
             operator_id: field_response_target_id_verf_op
@@ -447,17 +398,89 @@ display:
             resource: '0'
             story: '0'
           show_unpublished: 0
+        field_region_target_id_verf:
+          id: field_region_target_id_verf
+          table: node__field_region
+          field: field_region_target_id_verf
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: verf
+          operator: in
+          value: {  }
+          group: 2
+          exposed: true
+          expose:
+            operator_id: field_region_target_id_verf_op
+            label: Region
+            description: ''
+            use_operator: false
+            operator: field_region_target_id_verf_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: region
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            reduce: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          verf_target_bundles:
+            region: region
+            basic: '0'
+            event: '0'
+            resource: '0'
+            response: '0'
+            story: '0'
+          show_unpublished: 0
       filter_groups:
         operator: AND
         groups:
           1: AND
+          2: OR
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
       defaults:
         empty: false
+        query: false
         relationships: false
         filters: false
         filter_groups: false
+        header: false
       relationships: {  }
       display_description: ''
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total news and stories.'
       display_extenders: {  }
       path: latest/news-and-stories
     cache_metadata:
@@ -467,12 +490,12 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:views.view.stories'
         - node_list
+        - taxonomy_term_list
   response_stories:
     id: response_stories
     display_title: 'Response stories block'

--- a/config/views.view.stories.yml
+++ b/config/views.view.stories.yml
@@ -11,6 +11,7 @@ dependencies:
     - node
     - taxonomy
     - user
+    - verf
 id: stories
 label: Stories
 module: views
@@ -216,6 +217,18 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<p class="empty-results">No stories found for the selected filters.</p>'
+          tokenize: false
       filters:
         status:
           id: status
@@ -237,6 +250,7 @@ display:
           plugin_id: bundle
           value:
             story: story
+          group: 1
         field_story_type_target_id:
           id: field_story_type_target_id
           table: node__field_story_type
@@ -257,7 +271,7 @@ display:
             operator: field_story_type_target_id_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_story_type_target_id
+            identifier: type
             required: false
             remember: false
             multiple: false
@@ -284,7 +298,7 @@ display:
           type: select
           hierarchy: false
           limit: true
-          error_message: true
+          error_message: false
         field_country_target_id:
           id: field_country_target_id
           table: node__field_country
@@ -305,7 +319,7 @@ display:
             operator: field_country_target_id_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_country_target_id
+            identifier: country
             required: false
             remember: false
             multiple: false
@@ -332,31 +346,28 @@ display:
           type: select
           hierarchy: false
           limit: true
-          error_message: true
-        field_region_target_id:
-          id: field_region_target_id
+          error_message: false
+        field_region_target_id_verf:
+          id: field_region_target_id_verf
           table: node__field_region
-          field: field_region_target_id
+          field: field_region_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: numeric
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
+          plugin_id: verf
+          operator: in
+          value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: field_region_target_id_op
+            operator_id: field_region_target_id_verf_op
             label: Region
             description: ''
             use_operator: false
-            operator: field_region_target_id_op
+            operator: field_region_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_region_target_id
+            identifier: region
             required: false
             remember: false
             multiple: false
@@ -365,59 +376,7 @@ display:
               anonymous: '0'
               administrator: '0'
               editor: '0'
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: 'Region (field_region)'
-            description: null
-            identifier: field_region_target_id
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1: {  }
-              2: {  }
-              3: {  }
-        field_response_target_id:
-          id: field_response_target_id
-          table: node__field_response
-          field: field_response_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: numeric
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_response_target_id_op
-            label: Response
-            description: ''
-            use_operator: false
-            operator: field_response_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: field_response_target_id
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
+            reduce: 0
           is_grouped: false
           group_info:
             label: ''
@@ -430,16 +389,77 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          verf_target_bundles:
+            region: region
+            basic: '0'
+            event: '0'
+            resource: '0'
+            response: '0'
+            story: '0'
+          show_unpublished: 0
+        field_response_target_id_verf:
+          id: field_response_target_id_verf
+          table: node__field_response
+          field: field_response_target_id_verf
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: verf
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_response_target_id_verf_op
+            label: Response
+            description: ''
+            use_operator: false
+            operator: field_response_target_id_verf_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: response
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            reduce: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          verf_target_bundles:
+            response: response
+            basic: '0'
+            event: '0'
+            region: '0'
+            resource: '0'
+            story: '0'
+          show_unpublished: 0
       filter_groups:
         operator: AND
         groups:
           1: AND
       defaults:
+        empty: false
+        relationships: false
         filters: false
         filter_groups: false
+      relationships: {  }
       display_description: ''
       display_extenders: {  }
-      path: stories
+      path: latest/news-and-stories
     cache_metadata:
       max-age: -1
       contexts:
@@ -450,7 +470,9 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:views.view.stories'
+        - node_list
   response_stories:
     id: response_stories
     display_title: 'Response stories block'

--- a/html/modules/custom/unocha_paragraphs/README.md
+++ b/html/modules/custom/unocha_paragraphs/README.md
@@ -1,0 +1,6 @@
+UNOCHA - Paragraphs module
+==========================
+
+This module provides manipulation of paragraph types.
+
+- Preprocessing of the `Stories` paragraph type to generate the list of stories to display based on the paragraph parent.

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.info.yml
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.info.yml
@@ -1,0 +1,6 @@
+type: module
+name: UNOCHA Paragraphs
+description: 'Provides alterations to paragraphs.'
+package: unocha
+core_version_requirement: ^9 || ^10
+

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -15,25 +15,10 @@ use Drupal\node\NodeInterface;
 function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-
   $limit = $paragraph->field_limit->value ?? 3;
 
-  $entity_type_manager = \Drupal::entityTypeManager();
-  $storage = $entity_type_manager->getStorage('node');
-  $builder = $entity_type_manager->getViewBuilder('node');
-
-  $query = $storage
-    ->getQuery()
-    ->accessCheck(TRUE)
-    ->condition('type', 'story')
-    ->sort('sticky', 'desc')
-    ->sort('promote', 'desc')
-    ->sort('created', 'desc')
-    // @todo get that from a field on the paragraph.
-    ->range(0, $limit);
-
-  // Retrieve the closest node parent. We do this because the paragraph may
-  // be nested in another paragraph for example.
+  // Retrieve the closest node parent. We need to do loop because the paragraph
+  // maybe nested in another paragraph or other entity for example.
   $parent = $paragraph->getParentEntity();
   while (isset($parent) && !($parent instanceof NodeInterface)) {
     if ($parent instanceof ParagraphInterface) {
@@ -48,41 +33,177 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
   $view_all_query = [];
 
   // Filter the stories based on the parent entity.
+  $stories = [];
   if (isset($parent) && $parent instanceof NodeInterface && !empty($parent->id())) {
     if ($parent->bundle() === 'response') {
-      $view_all_query['response'] = $parent->id();
-      $query->condition('field_response', $parent->id(), '=');
-    }
-    elseif ($parent->bundle() === 'region') {
-      $view_all_query['region'] = $parent->id();
-      $query->condition('field_region', $parent->id(), '=');
-    }
-    elseif ($parent->hasField('field_country')) {
-      $country_ids = [];
-      foreach ($parent->field_country->filterEmptyItems() as $item) {
-        $country_ids[] = $item->target_id;
-      }
-      if (!empty($country_ids)) {
-        // @todo review if we allow multiple selections for the country filter.
-        $view_all_query['country'] = reset($country_ids);
-        $query->condition('field_country', $country_ids, 'IN');
+      // Get the stories tagged with the response.
+      $stories = unocha_paragraphs_get_stories([
+        ['field_response', $parent->id(), '='],
+      ], $limit);
 
-        // Exclude the current story so we can show related ones only.
-        if ($parent->bundle() === 'story') {
-          $query->condition('nid', $parent->id(), '<>');
+      // Filter the News and Stories page by the response.
+      $view_all_query['response'] = $parent->id();
+
+      // If we don't have enough stories for the response, complete with
+      // stories from the region.
+      if (count($stories) < $limit) {
+        $region = unocha_paragraphs_get_region_from_response($parent);
+        if (isset($region)) {
+          $stories += unocha_paragraphs_get_stories([
+            ['field_region', $region->id(), '='],
+          ], $limit - count($stories));
+
+          // Also add the region as filter to have consistent results in the
+          // News and Stories landing page.
+          $view_all_query['region'] = $region->id();
         }
       }
     }
+    elseif ($parent->bundle() === 'region') {
+      // Get the stories tagged with the region.
+      $stories = unocha_paragraphs_get_stories([
+        ['field_region', $parent->id(), '='],
+      ], $limit);
+
+      // Filter the News and Stories page by the region.
+      $view_all_query['region'] = $parent->id();
+    }
+    else {
+      // Exclude the current story so we can show related ones only.
+      $exclude = $parent->bundle() === 'story' ? $parent->id() : NULL;
+
+      // Add conditions on the referenced entities.
+      $conditions = [];
+      $fields = [
+        'field_response' => 'response',
+        'field_region' => 'region',
+        'field_country' => 'country',
+      ];
+      foreach ($fields as $field => $filter) {
+        if ($parent->hasField($field)) {
+          $ids = [];
+          foreach ($parent->get($field)->filterEmptyItems() as $item) {
+            if (isset($item->target_id)) {
+              $ids[] = $item->target_id;
+            }
+          }
+          if (!empty($ids)) {
+            $conditions[] = [$field, $ids, 'IN'];
+
+            // @todo review if we allow multiple selections for the filters.
+            // Filter the News and Stories page.
+            $view_all_query[$filter] = reset($ids);
+          }
+        }
+      }
+
+      $stories = unocha_paragraphs_get_stories($conditions, $limit, $exclude);
+    }
+  }
+  // If there are no valid parent, we just show the latest stories,
+  // for example when adding a stories paragraph type to a response as the
+  // paragraph doesn't yet have a parent as it's not yet saved.
+  // @todo add disclaimer in the preview in the form?
+  else {
+    $stories = unocha_paragraphs_get_stories([], $limit);
   }
 
   // Add the renderable stories.
-  $stories = $storage->loadMultiple($query->execute() ?? []);
   if (!empty($stories)) {
     $view_all_url = Url::fromUserInput('/latest/news-and-stories', [
       'query' => $view_all_query,
     ]);
     $variables['content']['view_all'] = Link::fromTextAndUrl(t('View all'), $view_all_url)->toRenderable();
     // @todo get the view mode from the paragraph view mode?
-    $variables['content']['stories'] = $builder->viewMultiple($stories, 'card');
+    $variables['content']['stories'] = \Drupal::entityTypeManager()
+      ->getViewBuilder('node')
+      ->viewMultiple($stories, 'card');
   }
+}
+
+/**
+ * Get story node entities from the given conditions and limit.
+ *
+ * @param array $conditions
+ *   List of conditions. Each condition has field, value and operator.
+ * @param int $limit
+ *   Number of stories to return.
+ * @param int|null $exclude
+ *   ID of story to exclude. This is mostly for when showing other stories on a
+ *   story page.
+ *
+ * @return \Drupal\node\NodeInterface[]
+ *   List of story nodes.
+ */
+function unocha_paragraphs_get_stories(array $conditions = [], $limit = 3, $exclude = NULL) {
+  $storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  $query = $storage
+    ->getQuery()
+    ->accessCheck(TRUE)
+    ->condition('type', 'story')
+    ->sort('sticky', 'desc')
+    ->sort('promote', 'desc')
+    ->sort('created', 'desc')
+    ->range(0, $limit);
+
+  // Exclude a story.
+  if (!empty($exclude)) {
+    $query->condition('nid', $exclude, '<>');
+  }
+
+  // Additional conditions.
+  if (!empty($conditions)) {
+    $or_condition_group = $query->orConditionGroup();
+    foreach ($conditions as $condition) {
+      $or_condition_group->condition(...$condition);
+    }
+    $query->condition($or_condition_group);
+  }
+
+  return $storage->loadMultiple($query->execute() ?? []);
+}
+
+/**
+ * Get the region parent entity from a response entity.
+ *
+ * Note: this function currently retrieves the region entity from the
+ * parent in the main navigation hierarchy but if all the responses are tagged
+ * with a region (field_region) then maybe we can use that instead which
+ * would reduce a bit the lookups.
+ *
+ * @param \Drupal\node\NodeInterface $response
+ *   Response.
+ *
+ * @return \Drupal\node\NodeInteface|null
+ *   Region.
+ */
+function unocha_paragraphs_get_region_from_response(NodeInterface $response) {
+  $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+
+  // Get the menu links referencing this node.
+  $menu_links = $menu_link_manager->loadLinksByRoute('entity.node.canonical', [
+    'node' => $response->id(),
+  ]);
+
+  // Get the parent link in the main navigation menu, which should be a link
+  // to the region node.
+  $parent_link_id = NULL;
+  if (!empty($menu_links)) {
+    foreach ($menu_links as $menu_link) {
+      if ($menu_link->getMenuName() === 'main') {
+        $parent_link_id = $menu_link->getParent();
+      }
+    }
+  }
+
+  // Try to retrieve the region node from the parent menu link.
+  if (!empty($parent_link_id)) {
+    $parent_link = $menu_link_manager->createInstance($parent_link_id);
+    if (!empty($parent_link) && $parent_link->getRouteName() === 'entity.node.canonical' && !empty($parent_link->getRouteParameters()['node'])) {
+      return \Drupal::entityTypeManager()->getStorage('node')->load($parent_link->getRouteParameters()['node']);
+    }
+  }
+
+  return NULL;
 }

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file
+ * Module file for the unocha_paragraphs module.
+ */
+
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_preprocess_paragraph__type().
+ */
+function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+
+  $limit = $paragraph->field_limit->value ?? 3;
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $storage = $entity_type_manager->getStorage('node');
+  $builder = $entity_type_manager->getViewBuilder('node');
+
+  $query = $storage
+    ->getQuery()
+    ->accessCheck(TRUE)
+    ->condition('type', 'story')
+    ->sort('sticky', 'desc')
+    ->sort('promote', 'desc')
+    ->sort('created', 'desc')
+    // @todo get that from a field on the paragraph.
+    ->range(0, $limit);
+
+  // Retrieve the closest node parent. We do this because the paragraph may
+  // be nested in another paragraph for example.
+  $parent = $paragraph->getParentEntity();
+  while (isset($parent) && !($parent instanceof NodeInterface)) {
+    if ($parent instanceof ParagraphInterface) {
+      $parent = $parent->getParentEntity();
+    }
+    else {
+      $parent = NULL;
+    }
+  }
+
+  // Parameters for the "view all" link.
+  $view_all_query = [];
+
+  // Filter the stories based on the parent entity.
+  if (isset($parent) && $parent instanceof NodeInterface && !empty($parent->id())) {
+    if ($parent->bundle() === 'response') {
+      $view_all_query['response'] = $parent->id();
+      $query->condition('field_response', $parent->id(), '=');
+    }
+    elseif ($parent->bundle() === 'region') {
+      $view_all_query['region'] = $parent->id();
+      $query->condition('field_region', $parent->id(), '=');
+    }
+    elseif ($parent->hasField('field_country')) {
+      $country_ids = [];
+      foreach ($parent->field_country->filterEmptyItems() as $item) {
+        $country_ids[] = $item->target_id;
+      }
+      if (!empty($country_ids)) {
+        // @todo review if we allow multiple selections for the country filter.
+        $view_all_query['country'] = reset($country_ids);
+        $query->condition('field_country', $country_ids, 'IN');
+
+        // Exclude the current story so we can show related ones only.
+        if ($parent->bundle() === 'story') {
+          $query->condition('nid', $parent->id(), '<>');
+        }
+      }
+    }
+  }
+
+  // Add the renderable stories.
+  $stories = $storage->loadMultiple($query->execute() ?? []);
+  if (!empty($stories)) {
+    $view_all_url = Url::fromUserInput('/latest/news-and-stories', [
+      'query' => $view_all_query,
+    ]);
+    $variables['content']['view_all'] = Link::fromTextAndUrl(t('View all'), $view_all_url)->toRenderable();
+    // @todo get the view mode from the paragraph view mode?
+    $variables['content']['stories'] = $builder->viewMultiple($stories, 'card');
+  }
+}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--stories.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--stories.html.twig
@@ -1,0 +1,71 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ *
+ * @todo remove the 'view-stories', 'view-display-id-stories',
+ * 'paragraph--type--content-list', 'view-header' and 'view-content' which are
+ * just there for compatibility with the existing styling from the
+ * 'uno-card-list' component.
+ */
+#}
+{{ attach_library('common_design_subtheme/uno-card-list') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'uno-stories',
+    'view-stories',
+    'view-display-id-stories',
+    'paragraph--type--content-list'
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      <header class="uno-stories__header view-header">
+        {{- content.field_title -}}
+        <span class="uno-stories__view_all">{{- content.view_all -}}</span>
+      </header>
+      <div class="uno-stories__content view-content">
+        {{ content|without('field_title', 'view_all') }}
+      </div>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Refs: UNO-598, UNO-630, UNO-631

This PR does the following:

**News and Stories view**

1. Adds the drupal/verf module to be able to use a dropdown for the region and response filters
2. Updates the filters with a OR condition for the country, response and region to better it the view all links (see below, point 4 of stories paragraph type)

Notes:
- The "Stories" paragraph type replaces the blocks of the "News and Stories" view and should be removed when we clean up things.

**Stories paragraph type**

1. Adds a "Stories" paragraph type with a "title" (defaults to "Latest News and Stories") and a limit field (defaults to 3)
2. Adds the `unocha_paragraphs` module with notably a preprocess hook for the "stories" paragraph type with the logic to get the stories to display based on the parent of the paragraph (ex: response, etc.). Stories are ordered by "sticky" then "promote" then "created" date.
3. Adds a template override for the "stories" paragraph type to wrap the story articles and use the `uno-card-list` library.
4. Generates "view all" links to the filtered "News and Stories" page. @left23 Not sure if that's what we want but I though it's a better UX.

Notes:
- On a "response" page: show stories tagged with the response and complete with stories from the region if less than the limit
- On a "region" page: show stories tagged with the region
- On other node pages: use any "country", "response" or "region" field to filter the list or return the unfiltered list of stories (ex: homepage).
- The above point means, it's possible to add a "stories" paragraph type to a `story` page to show related stories if that's something we want to do at some point.
- **view modes**: currently the `card` view mode is hardcoded in the stories paragraph type preprocess. If we want to offer other view modes, we could add a mapping between the view mode of the stories paragraph type and the view mode of the story node.

### Deployment

After deployment, the existing content list paragraph types using the stories view should be replaced by a `stories` paragraph type.

### Tests

1. Checkout the branch and recreate the image or run `composer install` to install the `drupal/verf` module
2. Clear the cache and import the config
3. Add a "stories" paragraph  to a response, region and home page and check that the proper stories are displayed.