### PR TITLE
[UNO-610] Resources

### DIFF
--- a/config/core.entity_form_display.node.resource.default.yml
+++ b/config/core.entity_form_display.node.resource.default.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.node.resource.field_custom_content
     - node.type.resource
   module:
-    - entity_reference_revisions
+    - layout_paragraphs
     - path
     - text
 id: node.resource.default
@@ -32,14 +32,14 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_custom_content:
-    type: entity_reference_revisions_autocomplete
+    type: layout_paragraphs
     weight: 122
     region: content
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      preview_view_mode: preview
+      nesting_depth: 2
+      require_layouts: 0
+      empty_message: ''
     third_party_settings: {  }
   langcode:
     type: language_select

--- a/config/core.entity_form_display.node.resource.default.yml
+++ b/config/core.entity_form_display.node.resource.default.yml
@@ -1,0 +1,101 @@
+uuid: 3c06cfaf-414b-45b5-96a0-4955ebe0e01d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.resource.body
+    - field.field.node.resource.field_custom_content
+    - node.type.resource
+  module:
+    - entity_reference_revisions
+    - path
+    - text
+id: node.resource.default
+targetEntityType: node
+bundle: resource
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_custom_content:
+    type: entity_reference_revisions_autocomplete
+    weight: 122
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/core.entity_form_display.paragraph.resources.default.yml
+++ b/config/core.entity_form_display.paragraph.resources.default.yml
@@ -1,0 +1,23 @@
+uuid: d8c5f194-cf68-4ce8-aa7e-ed71e700cc6f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.resources.field_title
+    - paragraphs.paragraphs_type.resources
+id: paragraph.resources.default
+targetEntityType: paragraph
+bundle: resources
+mode: default
+content:
+  field_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.node.resource.default.yml
+++ b/config/core.entity_view_display.node.resource.default.yml
@@ -1,0 +1,40 @@
+uuid: e0841dc6-beba-4a56-adc9-58677ec9b251
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.resource.body
+    - field.field.node.resource.field_custom_content
+    - node.type.resource
+  module:
+    - entity_reference_revisions
+    - text
+    - user
+id: node.resource.default
+targetEntityType: node
+bundle: resource
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  field_custom_content:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 102
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.resource.full.yml
+++ b/config/core.entity_view_display.node.resource.full.yml
@@ -1,0 +1,42 @@
+uuid: b6ef89e9-a7d7-4278-8b47-a360b3092c27
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.full
+    - field.field.node.resource.body
+    - field.field.node.resource.field_custom_content
+    - node.type.resource
+  module:
+    - layout_builder
+    - layout_paragraphs
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.resource.full
+targetEntityType: node
+bundle: resource
+mode: full
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_custom_content:
+    type: layout_paragraphs
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.node.resource.teaser.yml
+++ b/config/core.entity_view_display.node.resource.teaser.yml
@@ -1,0 +1,33 @@
+uuid: f5d6066d-d3f8-414e-9ec2-01c5f52454f5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.resource.body
+    - field.field.node.resource.field_custom_content
+    - node.type.resource
+  module:
+    - text
+    - user
+id: node.resource.teaser
+targetEntityType: node
+bundle: resource
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_custom_content: true
+  langcode: true

--- a/config/core.entity_view_display.node.resource.teaser.yml
+++ b/config/core.entity_view_display.node.resource.teaser.yml
@@ -21,12 +21,12 @@ content:
     settings:
       trim_length: 600
     third_party_settings: {  }
-    weight: 101
+    weight: 1
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 0
     region: content
 hidden:
   field_custom_content: true

--- a/config/core.entity_view_display.paragraph.resources.default.yml
+++ b/config/core.entity_view_display.paragraph.resources.default.yml
@@ -1,0 +1,21 @@
+uuid: 20b4969c-b94c-402e-a5cf-6219f5fe59c6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.resources.field_title
+    - paragraphs.paragraphs_type.resources
+id: paragraph.resources.default
+targetEntityType: paragraph
+bundle: resources
+mode: default
+content:
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/field.field.node.resource.body.yml
+++ b/config/field.field.node.resource.body.yml
@@ -1,0 +1,23 @@
+uuid: e44c88a1-7bf3-42e7-9857-877a5460fc3c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.resource
+  module:
+    - text
+id: node.resource.body
+field_name: body
+entity_type: node
+bundle: resource
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.resource.field_custom_content.yml
+++ b/config/field.field.node.resource.field_custom_content.yml
@@ -1,0 +1,80 @@
+uuid: f5f60162-f0e1-415f-851a-95f173ce6ee2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_custom_content
+    - node.type.resource
+  module:
+    - entity_reference_revisions
+id: node.resource.field_custom_content
+field_name: field_custom_content
+entity_type: node
+bundle: resource
+label: 'Custom content'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles: null
+    negate: 0
+    target_bundles_drag_drop:
+      call_to_action:
+        weight: 19
+        enabled: false
+      campaign:
+        weight: 20
+        enabled: false
+      canto_image:
+        weight: 21
+        enabled: false
+      content_list:
+        weight: 22
+        enabled: false
+      datawrapper:
+        weight: 23
+        enabled: false
+      embed:
+        weight: 24
+        enabled: false
+      figures:
+        weight: 25
+        enabled: false
+      image:
+        weight: 26
+        enabled: false
+      layout:
+        weight: 27
+        enabled: false
+      node:
+        weight: 28
+        enabled: false
+      reliefweb_document:
+        weight: 29
+        enabled: false
+      reliefweb_river:
+        weight: 30
+        enabled: false
+      rss_feed:
+        weight: 31
+        enabled: false
+      rw_key_figures:
+        weight: 32
+        enabled: false
+      section:
+        weight: 33
+        enabled: false
+      text:
+        weight: 34
+        enabled: false
+      text_and_image:
+        weight: 35
+        enabled: false
+      video:
+        weight: 36
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/field.field.paragraph.resources.field_title.yml
+++ b/config/field.field.paragraph.resources.field_title.yml
@@ -1,0 +1,21 @@
+uuid: 0d6560c2-fde0-4e94-b2eb-3f4398bcbe6e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.resources
+id: paragraph.resources.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: resources
+label: Title
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: Resources
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/language.content_settings.node.resource.yml
+++ b/config/language.content_settings.node.resource.yml
@@ -1,0 +1,11 @@
+uuid: 8272d7d4-872e-4d82-a56c-99b95ac4c9d3
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.resource
+id: node.resource
+target_entity_type_id: node
+target_bundle: resource
+default_langcode: site_default
+language_alterable: false

--- a/config/node.type.resource.yml
+++ b/config/node.type.resource.yml
@@ -1,0 +1,18 @@
+uuid: 144bb058-d888-4fa2-afe6-bd63880d3bbb
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Resource
+type: resource
+description: 'A response resource page.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/config/paragraphs.paragraphs_type.resources.yml
+++ b/config/paragraphs.paragraphs_type.resources.yml
@@ -1,0 +1,10 @@
+uuid: 488eac45-6c03-4d6e-b3c6-3efb0c641c8f
+langcode: en
+status: true
+dependencies: {  }
+id: resources
+label: Resources
+icon_uuid: null
+icon_default: null
+description: 'List of resources for a response.'
+behavior_plugins: {  }

--- a/config/pathauto.pattern.resources.yml
+++ b/config/pathauto.pattern.resources.yml
@@ -1,0 +1,22 @@
+uuid: b7ba2bf6-94b4-44e3-a2bc-727cbb8700eb
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: resources
+label: Resources
+type: 'canonical_entities:node'
+pattern: '[node:menu-link:parent]/[node:title]'
+selection_criteria:
+  74b7a80c-01d5-4019-859e-14f85145627a:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 74b7a80c-01d5-4019-859e-14f85145627a
+    context_mapping:
+      node: node
+    bundles:
+      resource: resource
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/views.view.content.yml
+++ b/config/views.view.content.yml
@@ -39,26 +39,124 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: view
+          output_url_as_text: true
+          absolute: false
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
           plugin_id: field
           label: Title
           exclude: false
           alter:
-            alter_text: false
+            alter_text: true
+            text: "{{ title }}\r\n<div><small><em>{{ view_node }}<em></small></div>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
           element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          click_sort_column: value
           type: string
           settings:
             link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         type:
           id: type
           table: node_field_data

--- a/html/modules/custom/unocha_paragraphs/README.md
+++ b/html/modules/custom/unocha_paragraphs/README.md
@@ -4,3 +4,4 @@ UNOCHA - Paragraphs module
 This module provides manipulation of paragraph types.
 
 - Preprocessing of the `Stories` paragraph type to generate the list of stories to display based on the paragraph parent.
+- Preprocessing of the `Resources` paragraph type to generate the list of resources to display based on the paragraph parent.

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -5,9 +5,13 @@
  * Module file for the unocha_paragraphs module.
  */
 
+use Drupal\Core\Menu\MenuLinkInterface;
+use Drupal\Core\Menu\MenuLinkTreeElement;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
+use Drupal\Core\Menu\MenuTreeParameters;
 
 /**
  * Implements hook_preprocess_paragraph__type().
@@ -17,17 +21,8 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
   $paragraph = $variables['paragraph'];
   $limit = $paragraph->field_limit->value ?? 3;
 
-  // Retrieve the closest node parent. We need to do loop because the paragraph
-  // maybe nested in another paragraph or other entity for example.
-  $parent = $paragraph->getParentEntity();
-  while (isset($parent) && !($parent instanceof NodeInterface)) {
-    if ($parent instanceof ParagraphInterface) {
-      $parent = $parent->getParentEntity();
-    }
-    else {
-      $parent = NULL;
-    }
-  }
+  // Retrieve the closest node parent.
+  $parent = unocha_paragraphs_get_paragraph_parent_node($paragraph);
 
   // Parameters for the "view all" link.
   $view_all_query = [];
@@ -47,8 +42,8 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       // If we don't have enough stories for the response, complete with
       // stories from the region.
       if (count($stories) < $limit) {
-        $region = unocha_paragraphs_get_region_from_response($parent);
-        if (isset($region)) {
+        $region = unocha_paragraphs_get_node_parent_node($parent);
+        if (isset($region) && $region->bundle() === 'region') {
           $stories += unocha_paragraphs_get_stories([
             ['field_region', $region->id(), '='],
           ], $limit - count($stories));
@@ -122,6 +117,69 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
 }
 
 /**
+ * Implements hook_preprocess_paragraph__type().
+ */
+function unocha_paragraphs_preprocess_paragraph__resources(array &$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+
+  // Retrieve the closest node parent.
+  $parent = unocha_paragraphs_get_paragraph_parent_node($paragraph);
+
+  if (!empty($parent)) {
+    $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+
+    // Get the menu links referencing this node.
+    $menu_links = $menu_link_manager->loadLinksByRoute('entity.node.canonical', [
+      'node' => $parent->id(),
+    ]);
+
+    // Get the ID of the menu link for the node in the main navigation menu.
+    $menu_link_id = NULL;
+    if (!empty($menu_links)) {
+      foreach ($menu_links as $menu_link) {
+        if ($menu_link->getMenuName() === 'main') {
+          $menu_link_id = $menu_link->getPluginId();
+        }
+      }
+    }
+
+    if (isset($menu_link_id)) {
+      $tree_parameters = new MenuTreeParameters();
+      $tree_parameters->setRoot($menu_link_id);
+      $tree_parameters->setMaxDepth(1);
+      $tree_parameters->excludeRoot();
+
+      // Get the child links.
+      $menu_links = \Drupal::service('menu.link_tree')
+        ->load('main', $tree_parameters);
+
+      // Get the associated nodes.
+      $nodes = unocha_paragraphs_get_nodes_from_menu_links($menu_links);
+
+      // Extract the title and url of the nodes that are resources to build
+      // the resource list.
+      $links = [];
+      foreach ($nodes as $node) {
+        if ($node->bundle() === 'resource') {
+          $links[] = [
+            'title' => $node->label(),
+            'url' => $node->toUrl(),
+          ];
+        }
+      }
+
+      if (!empty($links)) {
+        $variables['content']['resources'] = [
+          '#theme' => 'links__resources',
+          '#links' => $links,
+        ];
+      }
+    }
+  }
+}
+
+/**
  * Get story node entities from the given conditions and limit.
  *
  * @param array $conditions
@@ -165,25 +223,22 @@ function unocha_paragraphs_get_stories(array $conditions = [], $limit = 3, $excl
 }
 
 /**
- * Get the region parent entity from a response entity.
+ * Get the parent node from the menu link associated with the given node.
  *
- * Note: this function currently retrieves the region entity from the
- * parent in the main navigation hierarchy but if all the responses are tagged
- * with a region (field_region) then maybe we can use that instead which
- * would reduce a bit the lookups.
- *
- * @param \Drupal\node\NodeInterface $response
- *   Response.
+ * @param \Drupal\node\NodeInterface $node
+ *   Child node in the menu hierarchy.
+ * @param string $menu_name
+ *   Menu in which to look for the parent.
  *
  * @return \Drupal\node\NodeInteface|null
- *   Region.
+ *   Parent node.
  */
-function unocha_paragraphs_get_region_from_response(NodeInterface $response) {
+function unocha_paragraphs_get_node_parent_node(NodeInterface $node, $menu_name = 'main') {
   $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
 
   // Get the menu links referencing this node.
   $menu_links = $menu_link_manager->loadLinksByRoute('entity.node.canonical', [
-    'node' => $response->id(),
+    'node' => $node->id(),
   ]);
 
   // Get the parent link in the main navigation menu, which should be a link
@@ -191,7 +246,7 @@ function unocha_paragraphs_get_region_from_response(NodeInterface $response) {
   $parent_link_id = NULL;
   if (!empty($menu_links)) {
     foreach ($menu_links as $menu_link) {
-      if ($menu_link->getMenuName() === 'main') {
+      if ($menu_link->getMenuName() === $menu_name) {
         $parent_link_id = $menu_link->getParent();
       }
     }
@@ -199,11 +254,70 @@ function unocha_paragraphs_get_region_from_response(NodeInterface $response) {
 
   // Try to retrieve the region node from the parent menu link.
   if (!empty($parent_link_id)) {
-    $parent_link = $menu_link_manager->createInstance($parent_link_id);
-    if (!empty($parent_link) && $parent_link->getRouteName() === 'entity.node.canonical' && !empty($parent_link->getRouteParameters()['node'])) {
-      return \Drupal::entityTypeManager()->getStorage('node')->load($parent_link->getRouteParameters()['node']);
-    }
+    $nodes = unocha_paragraphs_get_nodes_from_menu_links([$parent_link_id]);
+    return !empty($nodes) ? reset($nodes) : NULL;
   }
 
   return NULL;
+}
+
+/**
+ * Get the parent node of a paragaph.
+ *
+ * @param \Drupal\paragaph\ParagraphInterface $paragraph
+ *   Paragrah entity.
+ *
+ * @return \Drupal\node\NodeInterface|null
+ *   Parent node.
+ */
+function unocha_paragraphs_get_paragraph_parent_node(ParagraphInterface $paragraph) {
+  // Retrieve the closest node parent. We need to do loop because the paragraph
+  // maybe nested in another paragraph or other entity for example.
+  $parent = $paragraph->getParentEntity();
+  while (isset($parent) && !($parent instanceof NodeInterface)) {
+    if ($parent instanceof ParagraphInterface) {
+      $parent = $parent->getParentEntity();
+    }
+    else {
+      $parent = NULL;
+    }
+  }
+  return $parent;
+}
+
+/**
+ * Get a nodes from a menu link items pointing at them.
+ *
+ * @param array $menu_links
+ *   List of menu link objects or IDs.
+ *
+ * @return \Drupal\node\NodeInterface[]
+ *   Nodes corresponding to the menu links.
+ */
+function unocha_paragraphs_get_nodes_from_menu_links(array $menu_links) {
+  $node_ids = [];
+  foreach ($menu_links as $menu_link) {
+    if (is_string($menu_link)) {
+      $menu_link = \Drupal::service('plugin.manager.menu.link')
+        ->createInstance($menu_link);
+    }
+    elseif ($menu_link instanceof MenuLinkTreeElement) {
+      $menu_link = $menu_link->link;
+    }
+
+    if (isset($menu_link) &&
+      $menu_link instanceof MenuLinkInterface &&
+      $menu_link->getRouteName() === 'entity.node.canonical' &&
+      !empty($menu_link->getRouteParameters()['node'])
+    ) {
+      $node_id = $menu_link->getRouteParameters()['node'];
+      $node_ids[$node_id] = $node_id;
+    }
+  }
+  if (!empty($node_ids)) {
+    return \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadMultiple($node_ids);
+  }
+  return [];
 }

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--resources.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--resources.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {% if content.field_title is not empty %}
+        {{
+          content|merge({
+            field_title: content.field_title|merge({
+              '#attributes': (content.field_title['#attributes'] ?? create_attribute()).addClass('visually-hidden')
+            })
+          })
+        }}
+      {% else %}
+        {{ content }}
+      {% endif %}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Refs: UNO-610

Note: this based of the "UNO-631-stories" from https://github.com/UN-OCHA/unocha-site/pull/98 because it extends the `unocha_paragraphs` module.

This PR adds a Resource content type to use for the response resource pages and a Resources paragraph type that displays the resources of a response.

This is handled by looking at the children of the reponse menu item. That means to add a resource to a response, editors have to select it as the parent menu when selecting the menu link item on the resource node form.

Note: another approach could be have a "response" entity reference field on the resource content type but the advantage of the menu approach is that we don't need to do anything for the breadcrumbs of the resource page as it's derived from the menu hierarchy.

### Deployment

See notes of https://github.com/UN-OCHA/unocha-site/pull/98 and also, the current paragraphs used to show "resources" on responses should be replaced by this new "Resources" paragraph type.

Note: This "Resources" paragraph type doesn't need to be wrapped in a `section` paragraph type. So `Section (tabs) > Resources` should be enough if we keep "Resources" as title.

### Styling

There is currently no styling (just a list of links) but there is a `paragraph--stories.html.twig` template in the sub theme and the list of links could be customized via the `list--resources.html.twig` template.

### Administration

To help differentiate between resources pages, the path alias is displayed below the title in the "Manage >  Content" page:

<img width="1513" alt="Screenshot 2023-05-15 at 8 27 01" src="https://github.com/UN-OCHA/unocha-site/assets/696348/0aab4fc9-9c81-40e2-b4c6-25c9089a1e6c">

### Tests

1. Checkout the branch, clear the cache and import the config
2. Create some Resource nodes and add them as children of a Response
3. Go to the Response page and add a Resources paragraph type, save and check that this displays the list of resource for the response as per (2)