### PR TITLE
[UNO-628] Breadcrumbs for RW docs, events and stories

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -75,6 +75,7 @@ module:
   text: 0
   token: 0
   toolbar: 0
+  unocha_breadcrumbs: 0
   unocha_canto: 0
   unocha_figures: 0
   unocha_migrate: 0

--- a/html/modules/custom/unocha_breadcrumbs/README.md
+++ b/html/modules/custom/unocha_breadcrumbs/README.md
@@ -1,0 +1,6 @@
+UNOCHA - Breadcrumbs module
+===========================
+
+This module handles breadcrumbs to the different node pages.
+
+Currently handles `event` and `story` content types.

--- a/html/modules/custom/unocha_breadcrumbs/src/Services/UnochaBreadcrumbBuilder.php
+++ b/html/modules/custom/unocha_breadcrumbs/src/Services/UnochaBreadcrumbBuilder.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\unocha_breadcrumbs\Services;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+
+/**
+ * Provides a breadcrumb builder for UNOCHA pages.
+ */
+class UnochaBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface|null
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs the BookBreadcrumbBuilder.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   */
+  public function __construct(
+    LanguageManagerInterface $language_manager
+  ) {
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    $node = $route_match->getParameter('node');
+    return $node instanceof NodeInterface && in_array($node->bundle(), [
+      'story',
+      'event',
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+
+    $node = $route_match->getParameter('node');
+    if (empty($node)) {
+      return $breadcrumb;
+    }
+
+    $current_language = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+
+    if ($node->hasTranslation($current_language->getId())) {
+      $node = $node->getTranslation($current_language->getId());
+    }
+
+    $url_options = ['language' => $current_language];
+
+    // Homepage.
+    $links = [Link::createFromRoute($this->t('Home'), '<front>', [], $url_options)];
+
+    switch ($node->bundle()) {
+      // Latest / Events.
+      case 'event':
+        $links[] = Link::createFromRoute($this->t('Latest'), '<nolink>', [], $url_options);
+        $links[] = Link::fromTextAndUrl($this->t('Events'), Url::fromUserInput('/latest/events'));
+        break;
+
+      // Latest / News and Stories.
+      case 'story':
+        $links[] = Link::createFromRoute($this->t('Latest'), '<nolink>', [], $url_options);
+        $links[] = Link::fromTextAndUrl($this->t('New and Stories'), Url::fromUserInput('/latest/news-and-stories'));
+        break;
+
+      // Skip.
+      default:
+        return $breadcrumb;
+    }
+
+    // Node's title.
+    $links[] = Link::createFromRoute($node->label(), '<nolink>', [], $url_options);
+
+    $breadcrumb->addCacheableDependency($node);
+    $breadcrumb->addCacheContexts(['languages:' . LanguageInterface::TYPE_CONTENT]);
+    $breadcrumb->setLinks(array_filter($links));
+    return $breadcrumb;
+  }
+
+}

--- a/html/modules/custom/unocha_breadcrumbs/unocha_breadcrumbs.info.yml
+++ b/html/modules/custom/unocha_breadcrumbs/unocha_breadcrumbs.info.yml
@@ -1,0 +1,5 @@
+type: module
+name: UNOCHA breadcrumbs
+description: 'Provides breadcrumbs for the different pages.'
+package: unocha
+core_version_requirement: ^9 || ^10

--- a/html/modules/custom/unocha_breadcrumbs/unocha_breadcrumbs.services.yml
+++ b/html/modules/custom/unocha_breadcrumbs/unocha_breadcrumbs.services.yml
@@ -1,0 +1,6 @@
+services:
+  unocha.breadcrumb:
+    class: Drupal\unocha_breadcrumbs\Services\UnochaBreadcrumbBuilder
+    arguments: ['@language_manager']
+    tags:
+      - { name: breadcrumb_builder, priority: 701 }

--- a/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebBreadcrumbBuilder.php
+++ b/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebBreadcrumbBuilder.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\unocha_reliefweb\Services;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Controller\ControllerResolverInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Provides a breadcrumb builder for ReliefWeb white labeled documents.
+ */
+class ReliefWebBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The controller resolver.
+   *
+   * @var \Drupal\Core\Controller\ControllerResolverInterface
+   */
+  protected $controllerResolver;
+
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface|null
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs the BookBreadcrumbBuilder.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   * @param \Drupal\Core\Controller\ControllerResolverInterface $controller_resolver
+   *   Ther controller resolver service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   */
+  public function __construct(
+    RequestStack $request_stack,
+    ControllerResolverInterface $controller_resolver,
+    LanguageManagerInterface $language_manager
+  ) {
+    $this->requestStack = $request_stack;
+    $this->controllerResolver = $controller_resolver;
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    return $route_match->getRouteName() === 'unocha_reliefweb.publications.document';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+
+    try {
+      // @see 'unocha_reliefweb.publications.document' route.
+      $controller = $this->controllerResolver->getController($this->requestStack->getCurrentRequest());
+      $class = reset($controller);
+      $ocha_product = call_user_func([$class, 'getOchaProduct']);
+      $title = call_user_func([$class, 'getPageTitle']);
+    }
+    catch (\Exception $exception) {
+      return $breadcrumb;
+    }
+
+    $current_language = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+
+    $url_options = ['language' => $current_language];
+
+    // Homepage.
+    $links = [Link::createFromRoute($this->t('Home'), '<front>', [], $url_options)];
+
+    switch ($ocha_product) {
+      // Press releases.
+      case 'Press Release':
+        $links[] = Link::fromTextAndUrl($this->t('Press Releases'), Url::fromUserInput('/press-releases', $url_options));
+        break;
+
+      // Latest / Speeches and Statements.
+      case 'Statement/Speech':
+        $links[] = Link::createFromRoute($this->t('Latest'), '<nolink>', [], $url_options);
+        $links[] = Link::fromTextAndUrl($this->t('Speeches and Statements'), Url::fromUserInput('/speeches-and-statements', $url_options));
+        break;
+
+      // Latest / Publications.
+      default:
+        $links[] = Link::createFromRoute($this->t('Latest'), '<nolink>', [], $url_options);
+        $links[] = Link::fromTextAndUrl($this->t('Publications'), Url::fromUserInput('/publications', $url_options));
+    }
+
+    // Document's title.
+    $links[] = Link::createFromRoute($title, '<nolink>', [], $url_options);
+
+    $breadcrumb->addCacheContexts(['languages:' . LanguageInterface::TYPE_CONTENT]);
+    $breadcrumb->setLinks(array_filter($links));
+    return $breadcrumb;
+  }
+
+}

--- a/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
+++ b/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
@@ -431,6 +431,7 @@ class ReliefWebDocuments {
         'country' => 'country',
         'source' => 'source',
         'language' => 'language',
+        'ocha_product' => 'ocha_product',
       ]);
 
       // Base article data.

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.services.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.services.yml
@@ -14,3 +14,8 @@ services:
   reliefweb.documents:
     class: Drupal\unocha_reliefweb\Services\ReliefWebDocuments
     arguments: ['@config.factory', '@reliefweb_api.client', '@reliefweb_api.converter', '@logger.factory', '@request_stack', '@string_translation']
+  reliefweb.breadcrumb:
+    class: Drupal\unocha_reliefweb\Services\ReliefWebBreadcrumbBuilder
+    arguments: ['@request_stack', '@controller_resolver', '@language_manager']
+    tags:
+      - { name: breadcrumb_builder, priority: 701 }


### PR DESCRIPTION
Refs: UNO-628

Note: this PR is against the `UNO-628-breadcrumbs` branch from https://github.com/UN-OCHA/unocha-site/pull/92

This PR adds `BreadcrumbBuilder` services to handle the breadcrumbs for the RW white labeled documents and the events and stories.

The parts of the breadcrumbs are hardcoded for simplicity and performance. The code is simple enough that it should be easy to adjust the breadcrumbs.

### Tests

1. Checkout this branch, clear the cache and import the config
2. Visit a RW press release, check the breadcrumb
3. Visit a RW speech, check the breadcrumb
4. Visit a story, check the breadcrumb
5. Visit an event, check the breadcrumb