### PR TITLE
[UNO-627] Maps - related responses

### DIFF
--- a/html/modules/custom/unocha_maps/unocha_maps.module
+++ b/html/modules/custom/unocha_maps/unocha_maps.module
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\unocha_utility\Helpers\LocalizationHelper;
 
 /**
  * Implements hook_preprocess_paragraph__type().
@@ -74,6 +75,32 @@ function unocha_maps_preprocess_paragraph__response_map(array &$variables) {
 
     // Add the responses to render.
     if (!empty($responses)) {
+      // Sort responses by priority and name.
+      $collator = LocalizationHelper::getCollator();
+      uasort($responses, function ($a, $b) use ($collator) {
+        $a_active = (int) ($a->field_active_response?->value ?? 0);
+        $b_active = (int) ($b->field_active_response?->value ?? 0);
+
+        if ($a_active === $b_active) {
+          return $collator->compare($a->label(), $b->label());
+        }
+        return $b_active <=> $a_active;
+      });
+
+      // Group responses by countries.
+      $grouped = [];
+      foreach ($responses as $response) {
+        foreach ($response->field_country as $item) {
+          $country = $item->target_id;
+          if (isset($grouped[$country])) {
+            $grouped[$country]['related'][$response->id()] = $response;
+          }
+          else {
+            $grouped[$country]['response'] = $response;
+          }
+        }
+      }
+
       $id = Html::getUniqueId('response-map');
 
       $build = $entity_type_manager
@@ -84,14 +111,56 @@ function unocha_maps_preprocess_paragraph__response_map(array &$variables) {
       foreach ($responses as $response) {
         if (isset($build[$response->id()])) {
           $coordinates = [];
+          $related = [];
+
+          // Add the coordinates for each country the response is tagged with
+          // and store the related responses.
           foreach ($response->field_country as $item) {
             $country = $item->entity;
-            if (isset($country)) {
+            if (isset($country->field_location->lon, $country->field_location->lat)) {
               $coordinates[] = $country->field_location->lon . 'x' . $country->field_location->lat;
+
+              // Add the related responses.
+              $country_responses = $grouped[$country->id()] ?? [];
+              // First add the main response for the country.
+              if (isset($country_responses['response'])) {
+                $related[$country_responses['response']->id()] = $country_responses['response'];
+              }
+              // Then add the related responses.
+              if (isset($country_responses['related'])) {
+                $related += $country_responses['related'];
+              }
+              // Remove the current response from the list of related responses.
+              unset($related[$response->id()]);
             }
           }
+
+          $build[$response->id()]['#attributes']['data-response'] = $response->id();
           $build[$response->id()]['#attributes']['data-coordinates'] = implode('|', $coordinates);
           $build[$response->id()]['#attributes']['class'][] = 'unocha-response-map__article';
+
+          // Add the related responses as a list of links to their pages.
+          if (!empty($related)) {
+            // Sort the related responses alphabetically.
+            uasort($related, function ($a, $b) use ($collator) {
+              return $collator->compare($a->label(), $b->label());
+            });
+
+            $build[$response->id()]['related'] = [
+              '#theme' => 'links',
+              '#links' => array_map(function ($response) {
+                return [
+                  'title' => $response->label(),
+                  'url' => $response->toUrl(),
+                ];
+              }, $related),
+              '#heading' => [
+                'level' => 'h4',
+                'text' => t('Related responses'),
+              ],
+              '#weight' => 100,
+            ];
+          }
         }
       }
 

--- a/html/themes/custom/common_design_subtheme/components/uno-response-map/uno-response-map.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-response-map/uno-response-map.css
@@ -85,6 +85,22 @@
   margin: 0;
   font-size: 15px;
 }
+.js .unocha-response-map[data-map-enabled] .unocha-response-map__article__content * {
+  font-size: 1rem;
+}
+.js .unocha-response-map[data-map-enabled] .unocha-response-map__article__footer * {
+  font-size: 1rem;
+}
+.js .unocha-response-map[data-map-enabled] .unocha-response-map__article__footer ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+/* Hide responses that don't have associated markers when the map is displayed
+ * because they cannot be displayed by clicking on a marker obviously. */
+.js .unocha-response-map[data-map-enabled] .unocha-response-map__article[data-response]:not([data-marker-id]) {
+  display: none;
+}
 
 /**
  * Map markers.

--- a/html/themes/custom/common_design_subtheme/templates/content/node--response--map.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--response--map.html.twig
@@ -77,8 +77,14 @@
   {% endif %}
   {{ title_suffix }}
 
-  <div{{ content_attributes }}>
-    {{ content }}
+  <div{{ content_attributes.addClass('unocha-response-map__article__content') }}>
+    {{ content|without('related') }}
   </div>
+
+  {% if content.related is not empty %}
+  <footer class="unocha-response-map__article__footer">
+    {{ content.related }}
+  </footer>
+  {% endif %}
 
 </article>


### PR DESCRIPTION
Refs: UNO-627

Follow-up of https://github.com/UN-OCHA/unocha-site/pull/112 to sort responses by priority then name and better handle responses with overlapping countries (shown as "related responses" below the response currently displayed next to the map).

### Tests

1. Create a response, tag it with a country already used by another response, select the same parent region, save
2. Check that when clicking the marker for the country from (1), the displayed response has a "related responses" list with the other response(s) tagged with the same country
3. Also check that the first "selected" response changes when checking "priority response" for one of them.