### PR TITLE
[UNO-633] RW river pagination

### DIFF
--- a/config/core.entity_form_display.paragraph.reliefweb_river.default.yml
+++ b/config/core.entity_form_display.paragraph.reliefweb_river.default.yml
@@ -45,10 +45,12 @@ content:
     region: content
     settings:
       view_modes:
-        default: Default
-        cards: Cards
-        teasers: Teasers
-      default_view_mode: default
+        cards: cards
+        cards_paginated: cards_paginated
+        teasers: teasers
+        teasers_paginated: teasers_paginated
+        default: '0'
+      default_view_mode: teasers
       form_mode_bind: true
     third_party_settings: {  }
 hidden:

--- a/config/core.entity_view_display.paragraph.reliefweb_river.cards_paginated.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_river.cards_paginated.yml
@@ -1,0 +1,52 @@
+uuid: 53f5fd35-d49f-4f58-b008-272b073fa2fc
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.cards_paginated
+    - field.field.paragraph.reliefweb_river.field_reliefweb_river
+    - field.field.paragraph.reliefweb_river.field_text
+    - field.field.paragraph.reliefweb_river.field_title
+    - field.field.paragraph.reliefweb_river.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river
+  module:
+    - layout_builder
+    - text
+    - unocha_reliefweb
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.reliefweb_river.cards_paginated
+targetEntityType: paragraph
+bundle: reliefweb_river
+mode: cards_paginated
+content:
+  field_reliefweb_river:
+    type: reliefweb_river
+    label: hidden
+    settings:
+      white_label: true
+      view_all_link: false
+      ocha_only: '1'
+      paginated: '1'
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  paragraph_view_mode: true

--- a/config/core.entity_view_display.paragraph.reliefweb_river.teasers_paginated.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_river.teasers_paginated.yml
@@ -1,0 +1,52 @@
+uuid: 3c89ca13-4a8e-47ab-bd16-a3ded1aab180
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.teasers_paginated
+    - field.field.paragraph.reliefweb_river.field_reliefweb_river
+    - field.field.paragraph.reliefweb_river.field_text
+    - field.field.paragraph.reliefweb_river.field_title
+    - field.field.paragraph.reliefweb_river.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river
+  module:
+    - layout_builder
+    - text
+    - unocha_reliefweb
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.reliefweb_river.teasers_paginated
+targetEntityType: paragraph
+bundle: reliefweb_river
+mode: teasers_paginated
+content:
+  field_reliefweb_river:
+    type: reliefweb_river
+    label: hidden
+    settings:
+      white_label: true
+      view_all_link: false
+      ocha_only: '1'
+      paginated: '1'
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  paragraph_view_mode: true

--- a/config/core.entity_view_mode.paragraph.cards_paginated.yml
+++ b/config/core.entity_view_mode.paragraph.cards_paginated.yml
@@ -1,0 +1,10 @@
+uuid: 50fa7903-8593-4924-9a80-5a8c97f27b88
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.cards_paginated
+label: 'Cards (paginated)'
+targetEntityType: paragraph
+cache: true

--- a/config/core.entity_view_mode.paragraph.teasers_paginated.yml
+++ b/config/core.entity_view_mode.paragraph.teasers_paginated.yml
@@ -1,0 +1,10 @@
+uuid: 5aee96d7-6e84-4f8f-af3f-bf9635fef1e6
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.teasers_paginated
+label: 'Teasers (paginated)'
+targetEntityType: paragraph
+cache: true

--- a/html/modules/custom/unocha_reliefweb/config/schema/unocha_reliefweb.schema.yml
+++ b/html/modules/custom/unocha_reliefweb/config/schema/unocha_reliefweb.schema.yml
@@ -53,3 +53,6 @@ field.formatter.settings.reliefweb_river:
     view_all_link:
       type: boolean
       label: 'Display a link to the full list of articles'
+    paginated:
+      type: boolean
+      label: 'User a pager to navigate the list'

--- a/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
+++ b/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
@@ -200,6 +200,8 @@ class ReliefWebDocuments {
    *   The URL of the river.
    * @param int $limit
    *   Number of items to retrieve from the API. Defaults to 5.
+   * @param int $offset
+   *   Number of items from which to start retrieving results. Defaults to 0.
    * @param array $filter
    *   Optional filter to further limit the document to return.
    * @param bool $white_label
@@ -209,7 +211,7 @@ class ReliefWebDocuments {
    *   An associative array with the river information and the document entities
    *   data usable in templates.
    */
-  public function getRiverDataFromUrl($url, $limit = 5, array $filter = NULL, $white_label = TRUE) {
+  public function getRiverDataFromUrl($url, $limit = 5, $offset = 0, array $filter = NULL, $white_label = TRUE) {
     $river = $this->getRiverFromUrl($url);
     if (empty($river)) {
       return [];
@@ -218,6 +220,10 @@ class ReliefWebDocuments {
     $payload = $this->getPayloadFromUrl($url);
     if (empty($payload)) {
       return [];
+    }
+
+    if (!empty($offset)) {
+      $payload['offset'] = $offset;
     }
 
     return $this->getDocumentsFromPayload($river, $payload, $limit, $filter, $white_label);
@@ -238,8 +244,9 @@ class ReliefWebDocuments {
    *   Whether to white label the ReliefWeb article URL or not.
    *
    * @return array
-   *   An associative array with the river information and the entities data
-   *   usable in templates.
+   *   An associative array with the river information, the entities data
+   *   usable in templates and the total number of resources matching the
+   *   payload.
    */
   protected function getDocumentsFromPayload(array $river, array $payload, $limit, array $filter = NULL, $white_label = TRUE) {
     // Set the maximum number of items to return.
@@ -278,6 +285,7 @@ class ReliefWebDocuments {
     return [
       'river' => $river,
       'entities' => $entities,
+      'total' => $data['totalCount'] ?? count($entities),
     ];
   }
 

--- a/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-river-results.html.twig
+++ b/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-river-results.html.twig
@@ -12,7 +12,7 @@
  */
 
 #}
-{% spaceless %}
+{% apply spaceless %}
 <div{{ attributes
   .addClass([
     'rw-river-results',
@@ -34,4 +34,4 @@
 {% endif %}
 
 </div>
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
Refs: UNO-633

This adds an option of the RW river formatters to display a pager (and the results) for a river.

This also adds 2 new view modes, used for RW river paragraphs: Teasers (paginated) and Cards (paginated). When selecting such a view mode, the pager will be displayed for the river.

### Tests.

1. Edit the press releases page, edit the paragraph type, select "Teasers (paginated)" as view mode, save
2. Open the press releases page and check that the pager is displays at the bottom of the river and works and that the "Showing X-Y of Z" is shown a the top of the river.