### PR TITLE
[UNO-632] Add pagination to Canto library widget

### DIFF
--- a/html/modules/custom/unocha_canto/assets/canto/library.css
+++ b/html/modules/custom/unocha_canto/assets/canto/library.css
@@ -4,6 +4,10 @@
   box-sizing: border-box;
 }
 
+html {
+  font-family: sans-serif;
+}
+
 [hidden] {
   display: none !important;
 }
@@ -152,6 +156,21 @@
   padding: 20px;
   text-align: center;
   font-size: 1.25rem;
+}
+.canto-pager-wrapper {
+  text-align: center;
+  font-size: 1.1rem;
+}
+.canto-pager {
+  display: inline-flex;
+  gap: 12px;
+  margin: 0;
+  padding: 12px;
+  list-style: none;
+}
+.canto-page-current a {
+  color: black;
+  font-weight: bold;
 }
 
 /** IMAGES. **/

--- a/html/modules/custom/unocha_canto/assets/canto/library.html
+++ b/html/modules/custom/unocha_canto/assets/canto/library.html
@@ -31,6 +31,7 @@
     <div class="canto-gallery" id="canto-gallery">
       <div id="canto-asset-list" class="canto-asset-list"></div>
       <div id="canto-empty-list" class="canto-empty-list" hidden>No items were found.</div>
+      <div id="canto-pager-wrapper" class="canto-pager-wrapper"></div>
     </div>
   </div>
 


### PR DESCRIPTION
Refs: UNO-632

This adds pagination to the Canto library widget so it's possible to select older images.

### Tests.

1.  Checkout the branch, clear the cache
2. Edit a response for example, add a media, click select from Canto
3. Check that the pager appears at the below the images and click on some links to confirm the list is updated