### PR TITLE
[UNO-634] Order paragraph types in widget

### DIFF
--- a/config/paragraphs.paragraphs_type.reliefweb_river.yml
+++ b/config/paragraphs.paragraphs_type.reliefweb_river.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: reliefweb_river
-label: 'Reliefweb - River'
+label: 'ReliefWeb - River'
 icon_uuid: null
 icon_default: null
 description: 'List of documents from ReliefWeb.'

--- a/html/themes/custom/common_design_claro/templates/form/layout-paragraphs-builder-component-menu.html.twig
+++ b/html/themes/custom/common_design_claro/templates/form/layout-paragraphs-builder-component-menu.html.twig
@@ -1,0 +1,40 @@
+{% set all_types = types.layout|merge(types.content) %}
+{{ status_messages }}
+<div{{ attributes }}>
+  <h4 class="visually-hidden">{{ 'Add Item'|t }}</h4>
+  {% if all_types|length > 1 %}
+  <div class="lpb-component-list__search">
+    <input class="lpb-component-list-search-input" type="text" placeholder="Filter items..." />
+  </div>
+  <div class="lpb-component-list__group">
+    {% if types.layout %}
+    <div class="lpb-component-list__group--layout">
+      <h5 class="lpb-component-list__group__title">{{ 'Layout paragraphs'|t }}</h5>
+    {% endif %}
+    {% for type in types.layout|sort((a, b) => a.label <=> b.label) %}
+      <div class="lpb-component-list__item type-{{type.id}} is-layout">
+        <a{{ type.link_attributes.setAttribute('href', type.url) }}>{% if type.image %}<img src="{{ type.image }}" alt ="" />{% endif %}{{ type.label }}</a>
+      </div>
+    {% endfor %}
+    {% if types.layout %}
+    </div>
+    {% endif %}
+    {% if types.content %}
+    <div class="lpb-component-list__group--content">
+      <h5 class="lpb-component-list__group__title">{{ 'Content paragaphs'|t }}</h5>
+    {% endif %}
+    {% for type in types.content|sort((a, b) => a.label <=> b.label) %}
+      <div class="lpb-component-list__item type-{{type.id}}">
+        <a{{ type.link_attributes.setAttribute('href', type.url) }}>{% if type.image %}<img src="{{ type.image }}" alt ="" />{% endif %}{{ type.label }}</a>
+      </div>
+    {% endfor %}
+    {% if types.content %}
+    </div>
+    {% endif %}
+  </div>
+  {% else %}
+  <div class="lpb-component-list__empty-message">
+  {{ empty_message }}
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
Refs: UNO-634

This sorts the paragraph types in the selector widget and also adds labels to distinguish layout paragraphs and content ones:

<img width="323" alt="Screenshot 2023-05-25 at 11 47 58" src="https://github.com/UN-OCHA/unocha-site/assets/696348/c98ff424-8299-450d-8fbd-09fede5b62fc">

### Tests

1. Checkout the branch, clear the cache and import the config
2. Edit a story for example, click the button to add a paragraph and verify that the list of paragraph types is ordered