### PR TITLE
UNO-613 Follow up PR to avoid deploy error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "drupal/imageapi_optimize_binaries": "^1.0@beta",
         "drupal/imageapi_optimize_webp": "^2.0",
         "drupal/imagemagick": "^3.4",
+        "drupal/json_field": "^1.2",
         "drupal/layout_paragraphs": "^2.0",
         "drupal/linkit": "^6.0@RC",
         "drupal/maintenance200": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d92abe455e4bce563701763fb791e235",
+    "content-hash": "768c46d4e157fc0962df73f5cad77338",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3917,6 +3917,71 @@
             "homepage": "https://www.drupal.org/project/imagemagick",
             "support": {
                 "source": "https://git.drupalcode.org/project/imagemagick"
+            }
+        },
+        {
+            "name": "drupal/json_field",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/json_field.git",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/json_field-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "9d1233be45736afcaa29336d7d09410a6b342c46"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10",
+                "ext-json": "*"
+            },
+            "require-dev": {
+                "swaggest/json-schema": "^0"
+            },
+            "suggest": {
+                "drupal/diff": "^0",
+                "swaggest/json-schema": "^0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1673020757",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "See contributors",
+                    "homepage": "https://www.drupal.org/node/2653746/committers",
+                    "role": "Developer"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "Jaesin",
+                    "homepage": "https://www.drupal.org/user/841054"
+                }
+            ],
+            "description": "Provides a JSON field, formatter and views integration",
+            "homepage": "https://www.drupal.org/project/json_field",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/json_field",
+                "issues": "https://www.drupal.org/project/issues/json_field"
             }
         },
         {


### PR DESCRIPTION
chore: composer require drupal json_field to prevent config error on deploy

https://jenkins.aws.ahconu.org/view/UN-OCHA%20D10/job/unocha-dev-deploy/51/console

I'm getting the same issue locally when I try to import config
`Unable to determine class for field type 'json_native' found in the 'field.storage.media.field_cantodam_asset_metadata' configuration`
Once I get past this, I get other issues but let's see what happens on the server.

Refs: UNO-613