### PR TITLE
[UNO-638] Leadership

### DIFF
--- a/config/core.base_field_override.node.leader.title.yml
+++ b/config/core.base_field_override.node.leader.title.yml
@@ -1,0 +1,18 @@
+uuid: cb900903-c44d-46d4-9ad8-d1e4a310c0e0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.leader
+id: node.leader.title
+field_name: title
+entity_type: node
+bundle: leader
+label: Name
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.entity_form_display.node.leader.default.yml
+++ b/config/core.entity_form_display.node.leader.default.yml
@@ -1,0 +1,73 @@
+uuid: 5d90a509-815c-4759-928d-c4a880d025e1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.leader.body
+    - field.field.node.leader.field_leader_portrait
+    - field.field.node.leader.field_leader_title
+    - image.style.thumbnail
+    - node.type.leader
+  module:
+    - image
+    - path
+    - text
+id: node.leader.default
+targetEntityType: node
+bundle: leader
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 3
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_leader_portrait:
+    type: image_image
+    weight: 2
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_leader_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 1024
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 5
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 255
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  promote: true
+  status: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_display.paragraph.leader.default.yml
+++ b/config/core.entity_form_display.paragraph.leader.default.yml
@@ -1,0 +1,36 @@
+uuid: 0b49baec-0b2d-4409-914f-67ffd8eaadcb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.leader.field_single_node
+    - field.field.paragraph.leader.paragraph_view_mode
+    - paragraphs.paragraphs_type.leader
+  module:
+    - paragraph_view_mode
+id: paragraph.leader.default
+targetEntityType: paragraph
+bundle: leader
+mode: default
+content:
+  field_single_node:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  paragraph_view_mode:
+    type: paragraph_view_mode
+    weight: 1
+    region: content
+    settings:
+      view_modes:
+        large: large
+        small: small
+        default: '0'
+      default_view_mode: large
+      form_mode_bind: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.node.leader.default.yml
+++ b/config/core.entity_view_display.node.leader.default.yml
@@ -1,0 +1,46 @@
+uuid: c2c7594a-85fd-4e9d-8a09-d2176bb3239e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.leader.body
+    - field.field.node.leader.field_leader_portrait
+    - field.field.node.leader.field_leader_title
+    - node.type.leader
+    - responsive_image.styles.portrait
+  module:
+    - responsive_image
+    - text
+    - user
+id: node.leader.default
+targetEntityType: node
+bundle: leader
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_leader_portrait:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: portrait
+      image_link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_leader_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.node.leader.teaser.yml
+++ b/config/core.entity_view_display.node.leader.teaser.yml
@@ -1,0 +1,40 @@
+uuid: 217b5f1b-107f-497a-8148-f93e0b093a4d
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.leader.body
+    - field.field.node.leader.field_leader_portrait
+    - field.field.node.leader.field_leader_title
+    - node.type.leader
+    - responsive_image.styles.portrait
+  module:
+    - responsive_image
+    - user
+id: node.leader.teaser
+targetEntityType: node
+bundle: leader
+mode: teaser
+content:
+  field_leader_portrait:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: portrait
+      image_link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_leader_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  body: true
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.node.leader.title.yml
+++ b/config/core.entity_view_display.node.leader.title.yml
@@ -1,0 +1,45 @@
+uuid: ad9d86b4-4141-4e47-b5e8-4bc5bc43158f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.title
+    - field.field.node.leader.body
+    - field.field.node.leader.field_leader_portrait
+    - field.field.node.leader.field_leader_title
+    - node.type.leader
+    - responsive_image.styles.portrait
+  module:
+    - layout_builder
+    - responsive_image
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.leader.title
+targetEntityType: node
+bundle: leader
+mode: title
+content:
+  field_leader_portrait:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: portrait
+      image_link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_leader_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  body: true
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.paragraph.leader.default.yml
+++ b/config/core.entity_view_display.paragraph.leader.default.yml
@@ -1,0 +1,23 @@
+uuid: 538ca92a-cf51-4aaa-bc05-c86bb7327df3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.leader.field_single_node
+    - field.field.paragraph.leader.paragraph_view_mode
+    - paragraphs.paragraphs_type.leader
+id: paragraph.leader.default
+targetEntityType: paragraph
+bundle: leader
+mode: default
+content:
+  field_single_node:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  paragraph_view_mode: true

--- a/config/core.entity_view_display.paragraph.leader.large.yml
+++ b/config/core.entity_view_display.paragraph.leader.large.yml
@@ -1,0 +1,31 @@
+uuid: 193a5222-47bb-4603-83ca-330f875a07bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.large
+    - field.field.paragraph.leader.field_single_node
+    - field.field.paragraph.leader.paragraph_view_mode
+    - paragraphs.paragraphs_type.leader
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.leader.large
+targetEntityType: paragraph
+bundle: leader
+mode: large
+content:
+  field_single_node:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  paragraph_view_mode: true

--- a/config/core.entity_view_display.paragraph.leader.small.yml
+++ b/config/core.entity_view_display.paragraph.leader.small.yml
@@ -1,0 +1,31 @@
+uuid: 59c68a91-c8de-481e-8470-3409a871aee0
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.small
+    - field.field.paragraph.leader.field_single_node
+    - field.field.paragraph.leader.paragraph_view_mode
+    - paragraphs.paragraphs_type.leader
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.leader.small
+targetEntityType: paragraph
+bundle: leader
+mode: small
+content:
+  field_single_node:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: title
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  paragraph_view_mode: true

--- a/config/core.entity_view_mode.paragraph.large.yml
+++ b/config/core.entity_view_mode.paragraph.large.yml
@@ -1,0 +1,10 @@
+uuid: cef31a73-79c2-43b3-b135-58e8567317ca
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.large
+label: Large
+targetEntityType: paragraph
+cache: true

--- a/config/core.entity_view_mode.paragraph.small.yml
+++ b/config/core.entity_view_mode.paragraph.small.yml
@@ -1,0 +1,10 @@
+uuid: 7ab2a4c2-79c5-48ec-9db4-fb6b4584f149
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.small
+label: Small
+targetEntityType: paragraph
+cache: true

--- a/config/field.field.node.leader.body.yml
+++ b/config/field.field.node.leader.body.yml
@@ -1,0 +1,28 @@
+uuid: cae3dfb6-8f7b-4c60-a63b-4a9ae34a3264
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.leader
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - text_editor_simple
+id: node.leader.body
+field_name: body
+entity_type: node
+bundle: leader
+label: Biography
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.leader.field_leader_portrait.yml
+++ b/config/field.field.node.leader.field_leader_portrait.yml
@@ -1,0 +1,38 @@
+uuid: 8e08d994-04f3-43bd-b193-3a06da8f2a3e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_leader_portrait
+    - node.type.leader
+  module:
+    - image
+id: node.leader.field_leader_portrait
+field_name: field_leader_portrait
+entity_type: node
+bundle: leader
+label: Portrait
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: images/portraits
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/field.field.node.leader.field_leader_title.yml
+++ b/config/field.field.node.leader.field_leader_title.yml
@@ -1,0 +1,19 @@
+uuid: f0b1c82b-065a-4fc7-bfb5-fccfd6c215ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_leader_title
+    - node.type.leader
+id: node.leader.field_leader_title
+field_name: field_leader_title
+entity_type: node
+bundle: leader
+label: 'Leader Title'
+description: 'Title(s) like USG, ASG etc.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.leader.field_single_node.yml
+++ b/config/field.field.paragraph.leader.field_single_node.yml
@@ -1,0 +1,29 @@
+uuid: 562153de-98b9-4816-a1d2-c1aeaac35c2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_single_node
+    - node.type.leader
+    - paragraphs.paragraphs_type.leader
+id: paragraph.leader.field_single_node
+field_name: field_single_node
+entity_type: paragraph
+bundle: leader
+label: Leader
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      leader: leader
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.paragraph.leader.paragraph_view_mode.yml
+++ b/config/field.field.paragraph.leader.paragraph_view_mode.yml
@@ -1,0 +1,21 @@
+uuid: 4bc69174-5f83-4dcd-9029-b13528850347
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.paragraph_view_mode
+    - paragraphs.paragraphs_type.leader
+  module:
+    - paragraph_view_mode
+id: paragraph.leader.paragraph_view_mode
+field_name: paragraph_view_mode
+entity_type: paragraph
+bundle: leader
+label: 'Paragraph view mode'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: paragraph_view_mode

--- a/config/field.storage.node.field_leader_portrait.yml
+++ b/config/field.storage.node.field_leader_portrait.yml
@@ -1,0 +1,30 @@
+uuid: 2881fd71-5dcb-4ced-b49d-21b8cbdcc55d
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_leader_portrait
+field_name: field_leader_portrait
+entity_type: node
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_leader_title.yml
+++ b/config/field.storage.node.field_leader_title.yml
@@ -1,0 +1,21 @@
+uuid: 539818b3-665f-4d71-8896-3f3793c890a8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_leader_title
+field_name: field_leader_title
+entity_type: node
+type: string
+settings:
+  max_length: 1024
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_single_node.yml
+++ b/config/field.storage.paragraph.field_single_node.yml
@@ -1,0 +1,20 @@
+uuid: da6f30fb-11c5-4e28-b191-20a72afa3c5a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_single_node
+field_name: field_single_node
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/image.style.full_width_1_1_100.yml
+++ b/config/image.style.full_width_1_1_100.yml
@@ -1,0 +1,16 @@
+uuid: 19a95df6-1f45-4896-8e36-b16774afaa6e
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_1_1_100
+label: 'Full width - 1:1 - 100%'
+effects:
+  c2d1a371-4ae5-4754-a559-94fc0d5e3790:
+    uuid: c2d1a371-4ae5-4754-a559-94fc0d5e3790
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1140
+      height: 1140
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_1_1_25.yml
+++ b/config/image.style.full_width_1_1_25.yml
@@ -1,0 +1,16 @@
+uuid: 695d3ea2-83a3-4c4f-a476-d207a4fa4f71
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_1_1_25
+label: 'Full width - 1:1 - 25%'
+effects:
+  bfe0b034-4319-4e84-acb1-d253b7635d70:
+    uuid: bfe0b034-4319-4e84-acb1-d253b7635d70
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 285
+      height: 285
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_1_1_50.yml
+++ b/config/image.style.full_width_1_1_50.yml
@@ -1,0 +1,16 @@
+uuid: 6d72937a-735b-4235-9eee-c721354083a5
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_1_1_50
+label: 'Full width - 1:1 - 50%'
+effects:
+  d7f770cc-d7c5-4df1-9ec6-62735343d42d:
+    uuid: d7f770cc-d7c5-4df1-9ec6-62735343d42d
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 570
+      height: 570
+      anchor: center-center
+pipeline: __default__

--- a/config/language.content_settings.node.leader.yml
+++ b/config/language.content_settings.node.leader.yml
@@ -1,0 +1,11 @@
+uuid: ceed67fb-d1d3-4ecf-9ba3-50ef3a23f6ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.leader
+id: node.leader
+target_entity_type_id: node
+target_bundle: leader
+default_langcode: site_default
+language_alterable: false

--- a/config/node.type.leader.yml
+++ b/config/node.type.leader.yml
@@ -1,0 +1,18 @@
+uuid: 84a69fdf-d914-49f7-b6dd-ad3fd7cd4e90
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Leader
+type: leader
+description: ''
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/paragraphs.paragraphs_type.leader.yml
+++ b/config/paragraphs.paragraphs_type.leader.yml
@@ -1,0 +1,10 @@
+uuid: 89d54ba1-343b-48ea-98a0-ec9c76fb3919
+langcode: en
+status: true
+dependencies: {  }
+id: leader
+label: Leader
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/config/pathauto.pattern.leaders.yml
+++ b/config/pathauto.pattern.leaders.yml
@@ -1,0 +1,22 @@
+uuid: 78677030-1bb3-4619-b5da-b18bb4200cee
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: leaders
+label: Leaders
+type: 'canonical_entities:node'
+pattern: '[node:menu-link:parent]/[node:title]'
+selection_criteria:
+  2b2dab71-ae6b-466b-a109-c5514ebdbd31:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 2b2dab71-ae6b-466b-a109-c5514ebdbd31
+    context_mapping:
+      node: node
+    bundles:
+      leader: leader
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/responsive_image.styles.portrait.yml
+++ b/config/responsive_image.styles.portrait.yml
@@ -1,0 +1,35 @@
+uuid: 433dd8f5-97ba-46ae-a5be-a8cc0fc6216a
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.full_width_1_1_100
+    - image.style.full_width_1_1_25
+    - image.style.full_width_1_1_50
+  theme:
+    - common_design
+id: portrait
+label: Portrait
+image_style_mappings:
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_1_1_50
+    breakpoint_id: common_design.sm
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_1_1_100
+    breakpoint_id: common_design.sm
+    multiplier: 2x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_1_1_25
+    breakpoint_id: common_design.xs
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_1_1_50
+    breakpoint_id: common_design.xs
+    multiplier: 2x
+breakpoint_group: common_design
+fallback_image_style: full_width_1_1_50

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -165,6 +165,11 @@ uno-layout:
     theme:
       components/uno-layout/uno-layout.css: {}
 
+uno-leader:
+  css:
+    theme:
+      components/uno-leader/uno-leader.css: {}
+
 uno-mega-menu:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/README.md
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/README.md
@@ -1,0 +1,4 @@
+UNOCHA Leader
+=============
+
+This component provides styling for the leader content type and paragraph type.

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
@@ -1,0 +1,55 @@
+.uno-leader--full .field--name-field-leader-title {
+  margin-bottom: 2rem;
+  font-size: var(--cd-font-size--large);
+}
+.uno-leader--full .field--name-field-leader-portrait {
+  float: left;
+  max-width: 30%;
+  margin: 0 2rem 2rem 0;
+}
+
+.uno-leader--teaser {
+  display: grid;
+  grid-template-areas: "image name" "image title" "image link";
+  grid-template-rows: 1fr auto 1fr;
+  grid-template-columns: 25% 75%;
+  gap: 1rem 2rem;
+}
+.uno-leader--teaser .uno-leader__name {
+  grid-area: name;
+  align-self: end;
+  margin: 0;
+}
+.uno-leader--teaser .field--name-field-leader-title {
+  grid-area: title;
+  font-size: var(--cd-font-size--medium);
+}
+.uno-leader--teaser .cd-read-more {
+  grid-area: link;
+}
+.uno-leader--teaser .field--name-field-leader-portrait {
+  grid-area: image;
+}
+
+.uno-leader--title {
+  display: grid;
+  grid-template-areas: "image name" "image title" "image link";
+  grid-template-rows: 1fr auto 1fr;
+  grid-template-columns: 20% 80%;
+  gap: 1rem 1rem;
+}
+.uno-leader--title .uno-leader__name {
+  grid-area: name;
+  align-self: end;
+  margin: 0;
+}
+.uno-leader--title .field--name-field-leader-title {
+  grid-area: title;
+  font-size: var(--cd-font-size--base);
+}
+.uno-leader--title .cd-read-more {
+  grid-area: link;
+}
+.uno-leader--title .field--name-field-leader-portrait {
+  grid-area: image;
+}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--leader--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--leader--full.html.twig
@@ -1,0 +1,113 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+    'cd-article',
+    'uno-leader--full',
+  ]
+%}
+
+{{ attach_library('common_design/cd-article') }}
+{{ attach_library('common_design/cd-bleed') }}
+{{ attach_library('common_design/cd-typography') }}
+{{ attach_library('common_design_subtheme/uno-leader') }}
+
+<article{{ attributes.addClass(classes) }}>
+
+  {{ title_prefix }}
+  {% if page %}
+    {% if title %}
+      {# This is not wrapped as this renders the page title block which
+         already wraps the node title in a <h1>. #}
+      {{ title }}
+    {% endif %}
+  {% else %}
+    <h2{{ title_attributes }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+  {% endif %}
+  {{ title_suffix }}
+
+  {{ local_tasks }}
+
+  <div{{ content_attributes.addClass('cd-layout-main-content') }}>
+    {{ content }}
+  </div>
+
+</article>

--- a/html/themes/custom/common_design_subtheme/templates/content/node--leader--teaser.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--leader--teaser.html.twig
@@ -1,0 +1,108 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+    'cd-article',
+    'uno-leader--teaser',
+  ]
+%}
+
+{{ attach_library('common_design/cd-article') }}
+{{ attach_library('common_design/cd-bleed') }}
+{{ attach_library('common_design/cd-typography') }}
+{{ attach_library('common_design_subtheme/uno-leader') }}
+
+<article{{ attributes.addClass(classes) }}>
+
+  {{ title_prefix }}
+  <h2{{ title_attributes.addClass('uno-leader__name') }}>{{ label }}</h2>
+  {{ title_suffix }}
+
+  {{ content }}
+
+  {% block read_more %}
+  <a href="{{ url }}" class="cd-card__link cd-read-more">
+    {% trans %}See biography{% endtrans %}
+    <svg class="cd-icon cd-icon--arrow-right" aria-hidden="true" focusable="false" width="16" height="16">
+      <use xlink:href="#cd-icon--arrow-right"></use>
+    </svg>
+  </a>
+  {% endblock %}
+
+</article>

--- a/html/themes/custom/common_design_subtheme/templates/content/node--leader--title.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--leader--title.html.twig
@@ -1,0 +1,108 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+    'cd-article',
+    'uno-leader--title',
+  ]
+%}
+
+{{ attach_library('common_design/cd-article') }}
+{{ attach_library('common_design/cd-bleed') }}
+{{ attach_library('common_design/cd-typography') }}
+{{ attach_library('common_design_subtheme/uno-leader') }}
+
+<article{{ attributes.addClass(classes) }}>
+
+  {{ title_prefix }}
+  <h3{{ title_attributes.addClass('uno-leader__name') }}>{{ label }}</a></h3>
+  {{ title_suffix }}
+
+  {{ content }}
+
+  {% block read_more %}
+  <a href="{{ url }}" class="cd-card__link cd-read-more">
+    {% trans %}See biography{% endtrans %}
+    <svg class="cd-icon cd-icon--arrow-right" aria-hidden="true" focusable="false" width="16" height="16">
+      <use xlink:href="#cd-icon--arrow-right"></use>
+    </svg>
+  </a>
+  {% endblock %}
+
+</article>


### PR DESCRIPTION
Refs: UNO-638

This PR adds a `Leader` node type and a `Leader` paragraph type. There is also a path alias pattern for the content type (menu/title) and basic template overrides and minimal styling.

The node type has 3 view modes (default (full page), teaser (for USG/ASG) and title (for the others). The paragraph type has 2 view modes to render a "leader" node as either "large" (teaser) or "small" (title view mode).

There is also a few new image styles (Full width - 1:1  - XX%) and  a `Portrait` responsive image style (probably needs another one like `Portrait small` for the paragraph types).

### Workflow

New leader page.

1. Create a new `Leader` node
2. Add name, title, portrait image and bibliography.
3. Select "Main navigation >  Who we are > Our leadership" as parent link under "Menu Settings"
4. Save

Update of "our leadership" page

1. Add a `Leader` paragraph, 
2. Select the leader and the display "Large" (USG, ASG) or "Small".
3. Save

### Tests

1. Checkout this branch, clear the cache and import the config
2. Follow the workflow above