### PR TITLE
[UNO-642] Subscribe paragraph type

### DIFF
--- a/config/core.entity_form_display.paragraph.subscribe.default.yml
+++ b/config/core.entity_form_display.paragraph.subscribe.default.yml
@@ -1,0 +1,34 @@
+uuid: 40ac9393-da8f-4ab0-860d-46f10f0586a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.subscribe.field_title
+    - field.field.paragraph.subscribe.field_url
+    - paragraphs.paragraphs_type.subscribe
+  module:
+    - link
+id: paragraph.subscribe.default
+targetEntityType: paragraph
+bundle: subscribe
+mode: default
+content:
+  field_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_url:
+    type: link_default
+    weight: 1
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.subscribe.default.yml
+++ b/config/core.entity_view_display.paragraph.subscribe.default.yml
@@ -1,0 +1,36 @@
+uuid: 4c366368-1198-4f2d-a18d-c14f94202156
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.subscribe.field_title
+    - field.field.paragraph.subscribe.field_url
+    - paragraphs.paragraphs_type.subscribe
+  module:
+    - link
+id: paragraph.subscribe.default
+targetEntityType: paragraph
+bundle: subscribe
+mode: default
+content:
+  field_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_url:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/field.field.paragraph.subscribe.field_title.yml
+++ b/config/field.field.paragraph.subscribe.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 22e8c304-d325-492b-a318-88799e39c8b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.subscribe
+id: paragraph.subscribe.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: subscribe
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.subscribe.field_url.yml
+++ b/config/field.field.paragraph.subscribe.field_url.yml
@@ -1,0 +1,23 @@
+uuid: 5481a5f8-0623-438b-ac72-0a7b0360523a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_url
+    - paragraphs.paragraphs_type.subscribe
+  module:
+    - link
+id: paragraph.subscribe.field_url
+field_name: field_url
+entity_type: paragraph
+bundle: subscribe
+label: URL
+description: 'Mailing list subscription URL.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/field.storage.paragraph.field_url.yml
+++ b/config/field.storage.paragraph.field_url.yml
@@ -1,0 +1,19 @@
+uuid: 7a468446-027b-450c-9e88-143269388717
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_url
+field_name: field_url
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.subscribe.yml
+++ b/config/paragraphs.paragraphs_type.subscribe.yml
@@ -1,0 +1,10 @@
+uuid: 06270238-f454-4f22-8938-897336e847b9
+langcode: en
+status: true
+dependencies: {  }
+id: subscribe
+label: Subscribe
+icon_uuid: null
+icon_default: null
+description: 'Mailing list subscription.'
+behavior_plugins: {  }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -192,6 +192,11 @@ uno-rss-feed:
     theme:
       components/uno-rss-feed/uno-rss-feed.css: {}
 
+uno-subscribe:
+  css:
+    theme:
+      components/uno-subscribe/uno-subscribe.css: {}
+
 uno-tabs:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/components/uno-subscribe/README.md
+++ b/html/themes/custom/common_design_subtheme/components/uno-subscribe/README.md
@@ -1,0 +1,4 @@
+UNOCHA Subscribe
+================
+
+This component provides styling for the mailing list subscription form.

--- a/html/themes/custom/common_design_subtheme/components/uno-subscribe/uno-subscribe.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-subscribe/uno-subscribe.css
@@ -1,0 +1,4 @@
+.paragraph--type--subscribe {
+  display: flex;
+  justify-content: center;
+}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--subscribe.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--subscribe.html.twig
@@ -11,9 +11,6 @@
  */
 #}
 {{ attach_library('common_design/cd-button') }}
-{{ attach_library('common_design_subtheme/uno-cta') }}
-{{ attach_library('common_design/cd-bleed') }}
-
 
 {%
   set classes = [
@@ -22,11 +19,9 @@
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
     'cd-align--center',
-    'cd-bleed'
   ]
 %}
-{% set destination = paragraph.field_destination.0.url %}
-{% set link_text = paragraph.field_destination.0.title %}
+
 {% block paragraph %}
   <div{{ attributes
     .addClass(classes)
@@ -34,9 +29,15 @@
     .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
   }}>
     {% block content %}
-    {{ content|without('field_destination')}}
 
-    {% include '@common_design_subtheme/uno/subscribe.html.twig' %}
+    {%
+      include '@common_design_subtheme/uno/subscribe.html.twig' with {
+        'title': paragraph.field_title.0.value,
+        'url': paragraph.field_url.0.url,
+        'submit': paragraph.field_title.0.value,
+        'logo': '',
+      }
+    %}
 
     {% endblock %}
   </div>

--- a/html/themes/custom/common_design_subtheme/templates/uno/subscribe.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/uno/subscribe.html.twig
@@ -1,16 +1,26 @@
+{{ attach_library('common_design_subtheme/uno-subscribe') }}
+
+{# Default to the global OCHA mailing list if values are not provided. #}
+{% set url = url ?? 'https://unocha.us2.list-manage.com/profile?u=83487eb1105d72ff2427e4bd7&id=fdc5b4f7e9' %}
+{% set title = title ?? 'Subscribe to UNOCHA mailing list'|t %}
+{% set submit = submit ?? 'Subscribe to our newsletter'|t %}
+{% set logo = logo ?? 'yes' %}
+
 <!-- Begin Mailchimp Signup Form -->
 <div id="mc_embed_signup" class="uno-subscribe">
-  <form action="https://unocha.us2.list-manage.com/profile?u=83487eb1105d72ff2427e4bd7&id=fdc5b4f7e9" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate="">
+  <form action="{{ url }}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate="">
+    {% if logo is not empty %}
     <span class="uno-subscribe__logo">
       <span class="visually-hidden">{{ 'United Nations Office for the Coordination of Humanitarian Affairs'|t }}</span>
       {{ source('@common_design_subtheme/img/logos/ocha-lockup.svg') }}
     </span>
+    {% endif %}
     <div id="mc_embed_signup_scroll">
       <h2 class="visually-hidden">{% trans %}Subscribe{% endtrans %}</h2>
       <div class="mc-field-group">
-        <label for="mce-EMAIL" class="visually-hidden">{% trans %}Subscribe to UNOCHA mailing list{% endtrans %}</label>
-        <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Enter your email address">
-        <input type="submit" value="Subscribe to our newsletter" name="subscribe" id="mc-embedded-subscribe" class="button cd-button cd-button--wide cd-button--bold cd-button--uppercase">
+        <label for="mce-EMAIL" class="visually-hidden">{{ title }}</label>
+        <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="{{ 'Enter your email address'|t }}">
+        <input type="submit" value="{{ submit }}" name="subscribe" id="mc-embedded-subscribe" class="button cd-button cd-button--wide cd-button--bold cd-button--uppercase">
       </div>
       <div id="mce-responses" class="clear">
         <div class="response" id="mce-error-response" style="display:none"></div>
@@ -18,7 +28,8 @@
       </div>
       <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
       <div style="position: absolute; left: -5000px;" aria-hidden="true">
-        <label for="mce-HONEYPOT">Do not fill in this field</label>
+        <label for="mce-HONEYPOT">{% trans %}Do not fill in this field{% endtrans %}</label>
+        {# @todo does name needs to be different for each form? #}
         <input id="mce-HONEYPOT" type="text" name="83487eb1105d72ff2427e4bd7" tabindex="-1" value="">
       </div>
     </div>


### PR DESCRIPTION
Refs: UNO-642

This PR adds a `subscribe` paragraph type that accepts a URL (ex: mailchimp subscription URL) and a title (used as label for the input field and submit button label).

It uses the `uno/subscribe.html.twig` template and there is a new `uno-subscribe` component for the styling (currently not doing much there).

### Tests

1. Checkout the branch, clear the cache, import the config
2. Edit a response for example and add a `subscribe` paragraph type
3. Save
4. Check that the `title` field is used for the button label and that the form redirects to URL of the mailing list entered in the URL field.