### PR TITLE
[UNO-643] RW OCHA documents

### DIFF
--- a/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
+++ b/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
@@ -116,7 +116,30 @@ class ReliefWebDocumentController extends ControllerBase {
    */
   public function getOchaProduct() {
     $data = $this->getDocumentData();
-    return $data['tags']['ocha_product'][0]['name'] ?? '';
+    if (empty($data['bundle']) || $data['bundle'] !== 'report') {
+      return '';
+    }
+
+    // We use a temporary mapping because some OCHA documents prior to the
+    // introduction of the OCHA product field don't have one.
+    // @todo remove if tagged with a OCHA product (ref: RW-765).
+    $ocha_product = $data['tags']['ocha_product'][0]['name'] ?? '';
+    if (empty($ocha_product) && !empty($data['format'])) {
+      $mapping = [
+        'Analysis' => 'Humanitarian Needs Overview',
+        'Appeal' => 'Other',
+        'Assessment' => 'Other',
+        'Evaluation and Lessons Learned' => 'Other',
+        'Infographic' => 'Infographic',
+        'Manual and Guideline' => 'Other',
+        'Map' => 'Thematic Map',
+        'News and Press Release' => 'Press Release',
+        'Other' => 'Other',
+        'Situation Report' => 'Situation Report',
+      ];
+      $ocha_product = $mapping[$data['format']] ?? 'Other';
+    }
+    return $ocha_product;
   }
 
   /**

--- a/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
+++ b/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
@@ -128,8 +128,12 @@ class ReliefWebDocuments {
           'date',
           'body-html',
         ],
+        // @todo if all the OCHA documents get tagged with an OCHA product then
+        // replace this filter with a `'field' => 'ocha_product'` (ref: RW-765).
+        // That may be a bit faster.
         'filter' => [
-          'field' => 'ocha_product',
+          'field' => 'source.shortname.exact',
+          'value' => 'OCHA',
         ],
         'parse' => [$this, 'parseReportsApiData'],
       ],

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--404.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--404.html.twig
@@ -4,7 +4,11 @@
     {# Link to skip to the main content is in html.html.twig #}
     <main role="main" id="main-content" class="cd-container">
 
+      {% if page.page_title is not empty %}
       {{ page.page_title }}
+      {% else %}
+      {% include '@common_design_subtheme/layout/page-title.html.twig' with {'title': 'Page not found'|t} %}
+      {% endif %}
 
       <div class="cd-layout">
 


### PR DESCRIPTION
Refs: UNO-643

This replaces the filter on the OCHA product field with a filter on the source field because some documents prior to 2016 do not have a OCHA product.