### PR TITLE
UNO-638 UNO-575 Leader and other styles

### DIFF
--- a/config/core.entity_view_display.node.leader.teaser.yml
+++ b/config/core.entity_view_display.node.leader.teaser.yml
@@ -24,7 +24,7 @@ content:
       responsive_image_style: portrait
       image_link: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
   field_leader_title:
     type: string
@@ -32,7 +32,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   body: true

--- a/config/core.entity_view_display.node.leader.title.yml
+++ b/config/core.entity_view_display.node.leader.title.yml
@@ -29,7 +29,7 @@ content:
       responsive_image_style: portrait
       image_link: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
   field_leader_title:
     type: string
@@ -37,7 +37,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   body: true

--- a/config/core.entity_view_display.node.response.full.yml
+++ b/config/core.entity_view_display.node.response.full.yml
@@ -35,6 +35,14 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
+  field_region:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_response_image:
     type: entity_reference_entity_view
     label: hidden
@@ -60,6 +68,5 @@ hidden:
   body: true
   field_active_response: true
   field_country: true
-  field_region: true
   langcode: true
   links: true

--- a/config/editor.editor.ckeditor.yml
+++ b/config/editor.editor.ckeditor.yml
@@ -18,6 +18,7 @@ settings:
       - '|'
       - bulletedList
       - numberedList
+      - alignment
       - '|'
       - blockQuote
       - '|'
@@ -25,6 +26,10 @@ settings:
       - '|'
       - sourceEditing
   plugins:
+    ckeditor5_alignment:
+      enabled_alignments:
+        - center
+        - left
     ckeditor5_heading:
       enabled_headings:
         - heading2

--- a/config/filter.format.ckeditor.yml
+++ b/config/filter.format.ckeditor.yml
@@ -25,7 +25,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href data-entity-type data-entity-uuid data-entity-substitution> <blockquote cite> <ul type> <ol type start> <img data-entity-type data-entity-uuid> <strong> <em> <li>'
+      allowed_html: '<br> <p class="text-align-left text-align-center"> <h2 id class="text-align-left text-align-center"> <h3 id class="text-align-left text-align-center"> <h4 id class="text-align-left text-align-center"> <h5 id class="text-align-left text-align-center"> <h6 id class="text-align-left text-align-center"> <cite> <dl> <dt> <dd> <a hreflang href data-entity-type data-entity-uuid data-entity-substitution> <blockquote cite> <ul type> <ol type start> <img data-entity-type data-entity-uuid> <strong> <em> <li>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -209,6 +209,10 @@ uno-tabs:
   js:
     components/uno-tabs/uno-tabs.js: {}
 
+uno-text-image:
+  css:
+    theme:
+      components/uno-text-image/uno-text-image.css: {}
 ###
 # Define Drupal libraries for additional webfonts.
 #

--- a/html/themes/custom/common_design_subtheme/components/cd-social-links/cd-social-links.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-social-links/cd-social-links.css
@@ -8,6 +8,9 @@
   margin-top: -1rem;
   margin-bottom: 3rem;
 }
+
+.page-node-type-response .cd-social-links,
+.page-node-type-region .cd-social-links,
 .path-frontpage .cd-social-links {
   margin-bottom: 2rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/cd/cd.css
+++ b/html/themes/custom/common_design_subtheme/components/cd/cd.css
@@ -82,10 +82,36 @@ body {
   align-items: flex-start;
 }
 
-.cd-soft-footer .cd-soft-footer__inner .cd-soft-footer__nav-responses {
-  max-width: 45%;
+.cd-soft-footer .cd-soft-footer__nav-responses nav {
+  padding: 1rem;
+  color: var(--brand-highlight-contrast);
+  border: 1px solid #707070;
+  background-color: var(--brand-highlight);
 }
-.cd-soft-footer .cd-soft-footer__inner .cd-soft-footer__nav-wrapper nav {
+
+@media screen and (min-width: 576px) {
+  .cd-soft-footer .cd-soft-footer__inner .cd-soft-footer__nav-responses {
+    max-width: 45%;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .cd-soft-footer .cd-soft-footer__nav-responses {
+    margin-top: -18px;
+    /* Height of nav h2 and its bottom margin */
+    max-width: unset;
+  }
+}
+
+.cd-soft-footer .cd-soft-footer__nav-responses a {
+  color: var(--cd-white);
+}
+
+.cd-soft-footer .cd-soft-footer__nav-responses h2 {
+  color: var(--brand-primary--dark);
+}
+
+.cd-soft-footer .cd-soft-footer__nav-wrapper > nav {
   margin-bottom: 3rem;
 }
 
@@ -145,14 +171,6 @@ body {
 .cd-soft-footer a:hover,
 .cd-soft-footer a:focus {
   color: var(--cd-default-text-color);
-}
-
-.cd-soft-footer .cd-soft-footer__nav-responses a {
-  color: var(--cd-white);
-}
-
-.cd-soft-footer .cd-soft-footer__nav-responses h2 {
-  color: var(--brand-primary--dark);
 }
 
 a.cd-footer-social__link svg {

--- a/html/themes/custom/common_design_subtheme/components/uno-card-list/uno-card-list.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-card-list/uno-card-list.css
@@ -112,8 +112,23 @@ article.node--type-story.node--view-mode-card .field--name-body {
   }
 }
 
+/* Promoted item to span full width */
+.page-node-type-basic .paragraph--type--content-list article.node--type-story.node--sticky.node--view-mode-card:first-child,
+.path-frontpage .paragraph--type--content-list article.node--type-story.node--sticky.node--view-mode-card:first-child,
+.page-node-type-region .paragraph--type--content-list article.node--type-story.node--sticky.node--view-mode-card:first-child {
+  border: 3px solid var(--brand-grey);
+}
+
+.node--sticky.node--view-mode-card.cd-card--clickable:first-child .cd-card__title a:hover::after {
+  outline: 3px solid var(--brand-primary--light);
+}
+
+.node--sticky.node--view-mode-card.cd-card--clickable:first-child .cd-card__title a:focus::after,
+.node--sticky.node--view-mode-card.cd-card--clickable:first-child .cd-card__title a:active::after {
+  outline: 3px solid var(--brand-primary--light);
+}
+
 @media screen and (min-width: 768px) {
-  /* Promoted item to span full width */
   .page-node-type-basic .paragraph--type--content-list article.node--type-story.node--sticky.node--view-mode-card:first-child,
   .path-frontpage .paragraph--type--content-list article.node--type-story.node--sticky.node--view-mode-card:first-child,
   .page-node-type-region .paragraph--type--content-list article.node--type-story.node--sticky.node--view-mode-card:first-child {

--- a/html/themes/custom/common_design_subtheme/components/uno-cta/uno-cta.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-cta/uno-cta.css
@@ -5,6 +5,12 @@
   padding: 3rem 2rem 4rem;
 }
 
+.paragraph--type--call-to-action.cd-bleed {
+  margin-right: calc(50% - 50vw + var(--cd-bleed-scrollbar-width) / 2);
+  margin-left: calc(50% - 50vw + var(--cd-bleed-scrollbar-width) / 2);
+  background-color: var(--brand-grey);
+}
+
 .cd-article .paragraph--type--call-to-action p {
   max-width: var(--cd-max-content-width);
   margin-right: auto;

--- a/html/themes/custom/common_design_subtheme/components/uno-layout/uno-layout.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-layout/uno-layout.css
@@ -24,7 +24,7 @@
   flex: 0 1 calc((100% / var(--uno-card-list-num-cols)) - var(--uno-card-list-gap-size) + var(--uno-card-list-gap-size) / var(--uno-card-list-num-cols));
 }
 
-@media screen and (min-width: 480px) {
+@media screen and (min-width: 576px) {
   .layout--twocol > .layout__region {
     --uno-card-list-num-cols: 2;
   }

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
@@ -53,3 +53,53 @@
 .uno-leader--title .field--name-field-leader-portrait {
   grid-area: image;
 }
+
+/* In a Two Column Layout */
+.layout--twocol .uno-leader--teaser {
+  display: flex;
+  flex-direction: column;
+}
+
+.uno-leader--teaser .uno-leader__name {
+  margin: 0;
+}
+
+.uno-leader--teaser .field--name-field-leader-title {
+  grid-area: title;
+  font-size: var(--cd-font-size--medium);
+}
+
+.uno-leader--teaser .cd-read-more {
+  grid-area: link;
+}
+
+.uno-leader--teaser .field--name-field-leader-portrait {
+  grid-area: image;
+}
+
+.uno-leader--title {
+  display: grid;
+  grid-template-areas: "image name" "image title" "image link";
+  grid-template-rows: 1fr auto 1fr;
+  grid-template-columns: 20% 80%;
+  gap: 1rem 1rem;
+}
+
+.uno-leader--title .uno-leader__name {
+  grid-area: name;
+  align-self: end;
+  margin: 0;
+}
+
+.uno-leader--title .field--name-field-leader-title {
+  grid-area: title;
+  font-size: var(--cd-font-size--base);
+}
+
+.uno-leader--title .cd-read-more {
+  grid-area: link;
+}
+
+.uno-leader--title .field--name-field-leader-portrait {
+  grid-area: image;
+}

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
@@ -1,57 +1,103 @@
-.uno-leader--full .field--name-field-leader-title {
-  margin-bottom: 2rem;
-  font-size: var(--cd-font-size--large);
-}
-.uno-leader--full .field--name-field-leader-portrait {
-  float: left;
-  max-width: 30%;
-  margin: 0 2rem 2rem 0;
-}
-
-.uno-leader--teaser {
-  display: grid;
-  grid-template-areas: "image name" "image title" "image link";
-  grid-template-rows: 1fr auto 1fr;
-  grid-template-columns: 25% 75%;
-  gap: 1rem 2rem;
-}
-.uno-leader--teaser .uno-leader__name {
-  grid-area: name;
-  align-self: end;
-  margin: 0;
-}
-.uno-leader--teaser .field--name-field-leader-title {
-  grid-area: title;
+.field--name-field-leader-title {
+  margin-bottom: 1rem;
+  text-align: center;
   font-size: var(--cd-font-size--medium);
-}
-.uno-leader--teaser .cd-read-more {
-  grid-area: link;
-}
-.uno-leader--teaser .field--name-field-leader-portrait {
-  grid-area: image;
 }
 
 .uno-leader--title {
-  display: grid;
-  grid-template-areas: "image name" "image title" "image link";
-  grid-template-rows: 1fr auto 1fr;
-  grid-template-columns: 20% 80%;
-  gap: 1rem 1rem;
+  text-align: center;
 }
-.uno-leader--title .uno-leader__name {
-  grid-area: name;
-  align-self: end;
-  margin: 0;
+
+.uno-leader--full .field--name-field-leader-portrait {
+  margin-bottom: 2rem;
+  text-align: center;
 }
-.uno-leader--title .field--name-field-leader-title {
-  grid-area: title;
-  font-size: var(--cd-font-size--base);
+
+@media screen and (min-width: 576px) {
+  .uno-leader--full .cd-layout-main-content {
+    display: grid;
+    grid-template-areas: "image name" "image title";
+    grid-template-rows: 1fr auto;
+    grid-template-columns: 33% 66%;
+    gap: 1rem 2rem;
+  }
+
+  .uno-leader--full .field--name-field-leader-title {
+    grid-area: name;
+    padding-inline-end: 2rem;
+  }
+
+  .uno-leader--full .field--name-field-leader-portrait {
+    grid-area: image;
+  }
+
+  .uno-leader--full .field--name-body {
+    padding-inline-end: 2rem;
+  }
+
+  .field--name-field-leader-title,
+  .uno-leader--title {
+    text-align: left;
+  }
+
+  .uno-leader--title {
+    padding-inline-end: 2rem;
+  }
+
+  .uno-leader--teaser .field--name-field-leader-title {
+    text-align: center;
+  }
+
+  .uno-leader--teaser {
+    display: grid;
+    grid-template-areas: "image name" "image title" "image link";
+    grid-template-rows: 1fr auto 1fr;
+    grid-template-columns: 33% 66%;
+    gap: 1rem 2rem;
+  }
+  .uno-leader--teaser .uno-leader__name {
+    grid-area: name;
+    align-self: end;
+    margin: 0;
+  }
+  .uno-leader--teaser .field--name-field-leader-title {
+    grid-area: title;
+  }
+  .uno-leader--teaser .cd-read-more {
+    grid-area: link;
+  }
+  .uno-leader--teaser .field--name-field-leader-portrait {
+    grid-area: image;
+  }
+
+  .uno-leader--title {
+    display: grid;
+    grid-template-areas: "image name" "image title" "image link";
+    grid-template-rows: 1fr auto 1fr;
+    grid-template-columns: 33% 66%;
+    gap: 1rem 1rem;
+  }
+  .uno-leader--title .uno-leader__name {
+    grid-area: name;
+    align-self: end;
+    margin: 0;
+  }
+  .uno-leader--title .field--name-field-leader-title {
+    grid-area: title;
+  }
+  .uno-leader--title .cd-read-more {
+    grid-area: link;
+    justify-self: flex-start;
+  }
+  .uno-leader--title .field--name-field-leader-portrait {
+    grid-area: image;
+  }
 }
-.uno-leader--title .cd-read-more {
-  grid-area: link;
-}
-.uno-leader--title .field--name-field-leader-portrait {
-  grid-area: image;
+
+@media screen and (min-width: 768px) {
+  .uno-leader--title {
+    grid-template-columns: 20% 80%;
+  }
 }
 
 /* Two column layout for USG, ASG */
@@ -84,4 +130,10 @@
   margin-bottom: 4rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--brand-grey);
+}
+
+.paragraph--type--leader.paragraph--view-mode--small:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: 0 solid var(--brand-grey);
 }

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
@@ -1,10 +1,10 @@
 .field--name-field-leader-title {
   margin-bottom: 1rem;
-  text-align: center;
   font-size: var(--cd-font-size--medium);
 }
 
-.uno-leader--title {
+.uno-leader--title,
+.uno-leader--teaser {
   text-align: center;
 }
 
@@ -35,6 +35,7 @@
     padding-inline-end: 2rem;
   }
 
+  .uno-leader--teaser,
   .field--name-field-leader-title,
   .uno-leader--title {
     text-align: left;
@@ -42,10 +43,6 @@
 
   .uno-leader--title {
     padding-inline-end: 2rem;
-  }
-
-  .uno-leader--teaser .field--name-field-leader-title {
-    text-align: center;
   }
 
   .uno-leader--teaser {
@@ -105,6 +102,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.layout--twocol .uno-leader--teaser .field--name-field-leader-title {
+  text-align: center;
 }
 
 .layout--twocol .uno-leader--teaser .uno-leader__name {

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
@@ -103,3 +103,41 @@
 .uno-leader--title .field--name-field-leader-portrait {
   grid-area: image;
 }
+
+/* Two column layout for USG, ASG */
+.layout--twocol .uno-leader--teaser {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.layout--twocol .uno-leader--teaser .uno-leader__name {
+  align-self: unset;
+}
+
+/* Rounded portraits */
+.layout--twocol .field--name-field-leader-portrait img {
+  display: block;
+  width: 100%;
+  max-width: 360px;
+  height: auto ;
+  margin: 0 auto;
+  border-radius: 50%;
+}
+
+.field--name-field-custom-content .paragraph--type--leader,
+.field--name-field-custom-content .paragraph--type--leader:last-child {
+  margin-bottom: 6rem;
+}
+
+.paragraph--type--leader.paragraph--view-mode--small {
+  margin-bottom: 4rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--brand-grey);
+}
+
+.layout--twocol .cd-block-title {
+  font-size: var(--cd-font-size--large);
+  text-align: center;
+  margin-bottom: 2rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
@@ -54,56 +54,6 @@
   grid-area: image;
 }
 
-/* In a Two Column Layout */
-.layout--twocol .uno-leader--teaser {
-  display: flex;
-  flex-direction: column;
-}
-
-.uno-leader--teaser .uno-leader__name {
-  margin: 0;
-}
-
-.uno-leader--teaser .field--name-field-leader-title {
-  grid-area: title;
-  font-size: var(--cd-font-size--medium);
-}
-
-.uno-leader--teaser .cd-read-more {
-  grid-area: link;
-}
-
-.uno-leader--teaser .field--name-field-leader-portrait {
-  grid-area: image;
-}
-
-.uno-leader--title {
-  display: grid;
-  grid-template-areas: "image name" "image title" "image link";
-  grid-template-rows: 1fr auto 1fr;
-  grid-template-columns: 20% 80%;
-  gap: 1rem 1rem;
-}
-
-.uno-leader--title .uno-leader__name {
-  grid-area: name;
-  align-self: end;
-  margin: 0;
-}
-
-.uno-leader--title .field--name-field-leader-title {
-  grid-area: title;
-  font-size: var(--cd-font-size--base);
-}
-
-.uno-leader--title .cd-read-more {
-  grid-area: link;
-}
-
-.uno-leader--title .field--name-field-leader-portrait {
-  grid-area: image;
-}
-
 /* Two column layout for USG, ASG */
 .layout--twocol .uno-leader--teaser {
   display: flex;

--- a/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-leader/uno-leader.css
@@ -85,9 +85,3 @@
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--brand-grey);
 }
-
-.layout--twocol .cd-block-title {
-  font-size: var(--cd-font-size--large);
-  text-align: center;
-  margin-bottom: 2rem;
-}

--- a/html/themes/custom/common_design_subtheme/components/uno-nav/uno-nav.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-nav/uno-nav.css
@@ -7,19 +7,6 @@
   --uno-nav-list-gap-size: 2rem;
 }
 
-.uno-nav {
-  padding: 1rem;
-  color: var(--brand-highlight-contrast);
-  border: 1px solid #707070;
-  background-color: var(--brand-highlight);
-}
-
-@media screen and (min-width: 768px) {
-  .uno-nav {
-    margin-top: -18px; /* Height of nav h2 and its bottom margin */
-  }
-}
-
 .uno-nav__list {
   margin: 0;
   padding: 0;

--- a/html/themes/custom/common_design_subtheme/components/uno-text-image/uno-text-image.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-text-image/uno-text-image.css
@@ -1,0 +1,67 @@
+
+/* Paragraph Text and Image with alignment */
+@media screen and (min-width: 768px) {
+  .paragraph--type--text-and-image.paragraph--view-mode--image-align-left,
+  .paragraph--type--text-and-image.paragraph--view-mode--image-align-right {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .paragraph--view-mode--image-align-left .field--name-field-image,
+  .paragraph--view-mode--image-align-right .field--name-field-image {
+    flex: 0 1 50%;
+  }
+  .paragraph--view-mode--image-align-left .field--name-field-text,
+  .paragraph--view-mode--image-align-right .field--name-field-text {
+    flex: 0 1 50%;
+  }
+
+  /* 33/66 image text */
+  /* .paragraph--view-mode--image-align-left .field--name-field-image,
+  .paragraph--view-mode--image-align-right .field--name-field-image {
+    flex: 0 1 33%;
+  }
+  .paragraph--view-mode--image-align-left .field--name-field-text,
+  .paragraph--view-mode--image-align-right .field--name-field-text {
+    flex: 0 1 66%;
+  } */
+  /* 33/66 text image */
+  /* .paragraph--view-mode--image-align-left .field--name-field-image,
+  .paragraph--view-mode--image-align-right .field--name-field-image {
+    flex: 0 1 66%;
+  }
+  .paragraph--view-mode--image-align-left .field--name-field-text,
+  .paragraph--view-mode--image-align-right .field--name-field-text {
+    flex: 0 1 33%;
+  } */
+
+  .paragraph--type--text-and-image .field--name-field-title {
+    flex: 1 0 100%;
+  }
+
+  .paragraph--view-mode--image-align-left .field--name-field-text {
+    padding-inline-start: 2rem;
+  }
+
+  .paragraph--view-mode--image-align-right .field--name-field-text,
+  .paragraph--view-mode--image-align-right .field--name-field-title {
+    padding-inline-end: 2rem;
+    text-align: left;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .paragraph--view-mode--image-align-right .field--name-field-text,
+  .paragraph--view-mode--image-align-right .field--name-field-title {
+    text-align: left;
+  }
+}
+
+.paragraph__image--align-center .field--name-field-title,
+.paragraph__image--align-center .field--name-field-text {
+  text-align: left;
+}
+
+.paragraph__image--align-center .field--name-field-media-image .field__item img {
+  display: inline-block;
+  margin: 0 auto;
+}

--- a/html/themes/custom/common_design_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/styles.css
@@ -267,12 +267,12 @@
 
 @media screen and (min-width: 1024px) {
   .paragraph--view-mode--image-align-left .field--name-field-text {
-    padding-inline-start: 4rem;
+    padding-inline-start: 3rem;
   }
 
   .paragraph--view-mode--image-align-right .field--name-field-text,
   .paragraph--view-mode--image-align-right .field--name-field-title {
-    padding-inline-end: 4rem;
+    padding-inline-end: 3rem;
     text-align: left;
   }
 }

--- a/html/themes/custom/common_design_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/styles.css
@@ -235,63 +235,6 @@
   }
 }
 
-/* Paragraph Text and Image with alignment */
-@media screen and (min-width: 768px) {
-  .paragraph--type--text-and-image.paragraph--view-mode--image-align-left,
-  .paragraph--type--text-and-image.paragraph--view-mode--image-align-right {
-    display: flex;
-    flex-wrap: wrap;
-  }
-  .paragraph--view-mode--image-align-left .field--name-field-image,
-  .paragraph--view-mode--image-align-right .field--name-field-image {
-    flex: 0 1 50%;
-  }
-  .paragraph--view-mode--image-align-left .field--name-field-text,
-  .paragraph--view-mode--image-align-right .field--name-field-text {
-    flex: 0 1 50%;
-  }
-
-  .paragraph--type--text-and-image .field--name-field-title {
-    flex: 1 0 100%;
-  }
-
-  .paragraph--view-mode--image-align-left .field--name-field-text {
-    padding-inline-start: 2rem;
-  }
-  .paragraph--view-mode--image-align-right .field--name-field-text,
-  .paragraph--view-mode--image-align-right .field--name-field-title {
-    padding-inline-end: 2rem;
-    text-align: left;
-  }
-}
-
-@media screen and (min-width: 1024px) {
-  .paragraph--view-mode--image-align-left .field--name-field-text {
-    padding-inline-start: 3rem;
-  }
-
-  .paragraph--view-mode--image-align-right .field--name-field-text,
-  .paragraph--view-mode--image-align-right .field--name-field-title {
-    padding-inline-end: 3rem;
-    text-align: left;
-  }
-}
-
-.paragraph__image--align-center .field--name-field-title,
-.paragraph__image--align-center .field--name-field-text {
-  text-align: left;
-}
-.paragraph__image--align-center .field--name-field-media-image .field__item img {
-  display: inline-block;
-  margin: 0 auto;
-}
-
-.paragraph--type--call-to-action.cd-bleed {
-  margin-right: calc(50% - 50vw + var(--cd-bleed-scrollbar-width) / 2);
-  margin-left: calc(50% - 50vw + var(--cd-bleed-scrollbar-width) / 2);
-  background-color: var(--brand-grey);
-}
-
 /* Video embed aspect ratio is calculated in the oembed-video field template. */
 .field--name-field-video .field--name-field-media-oembed-video {
   position: relative;

--- a/html/themes/custom/common_design_subtheme/templates/content/node--leader--teaser.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--leader--teaser.html.twig
@@ -82,19 +82,17 @@
     'uno-leader--teaser',
   ]
 %}
-
-{{ attach_library('common_design/cd-article') }}
-{{ attach_library('common_design/cd-bleed') }}
-{{ attach_library('common_design/cd-typography') }}
 {{ attach_library('common_design_subtheme/uno-leader') }}
 
 <article{{ attributes.addClass(classes) }}>
+
+  {{ content.field_leader_portrait }}
 
   {{ title_prefix }}
   <h2{{ title_attributes.addClass('uno-leader__name') }}>{{ label }}</h2>
   {{ title_suffix }}
 
-  {{ content }}
+  {{ content|without('field_leader_portrait') }}
 
   {% block read_more %}
   <a href="{{ url }}" class="cd-card__link cd-read-more">

--- a/html/themes/custom/common_design_subtheme/templates/content/node--leader--title.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--leader--title.html.twig
@@ -83,18 +83,17 @@
   ]
 %}
 
-{{ attach_library('common_design/cd-article') }}
-{{ attach_library('common_design/cd-bleed') }}
-{{ attach_library('common_design/cd-typography') }}
 {{ attach_library('common_design_subtheme/uno-leader') }}
 
 <article{{ attributes.addClass(classes) }}>
+
+  {{ content.field_leader_portrait }}
 
   {{ title_prefix }}
   <h3{{ title_attributes.addClass('uno-leader__name') }}>{{ label }}</a></h3>
   {{ title_suffix }}
 
-  {{ content }}
+  {{ content|without('field_leader_portrait') }}
 
   {% block read_more %}
   <a href="{{ url }}" class="cd-card__link cd-read-more">

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--text-and-image.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--text-and-image.html.twig
@@ -47,6 +47,8 @@
 ]
 %}
 
+{{ attach_library('common_design_subtheme/uno-text-image') }}
+
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}


### PR DESCRIPTION
UNO-638 Styles for Leadership page - paragraph type and full node, in a 2 column layout for USG/ASG

UNO-575 More responsive related items and refactoring based on VRT screenshots

Import config for 
1. adding alignment (left, center) to CK Editor WYSIWYG
2. Rearranging Leader field order in display
3. Displaying Response region on Full for label in template
