### PR TITLE
[UNO-635] Donors paragraph type

### DIFF
--- a/config/core.entity_form_display.paragraph.donors.default.yml
+++ b/config/core.entity_form_display.paragraph.donors.default.yml
@@ -1,0 +1,31 @@
+uuid: 2547a4d7-b54c-4166-bb38-217fcba305a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.donors.field_countries
+    - field.field.paragraph.donors.field_donor_type
+    - paragraphs.paragraphs_type.donors
+  module:
+    - choices
+id: paragraph.donors.default
+targetEntityType: paragraph
+bundle: donors
+mode: default
+content:
+  field_countries:
+    type: choices_widget
+    weight: 1
+    region: content
+    settings:
+      configuration_options: ''
+    third_party_settings: {  }
+  field_donor_type:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.donors.default.yml
+++ b/config/core.entity_view_display.paragraph.donors.default.yml
@@ -1,0 +1,16 @@
+uuid: 73596594-1db3-45c2-8530-f0d140aa47f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.donors.field_countries
+    - field.field.paragraph.donors.field_donor_type
+    - paragraphs.paragraphs_type.donors
+id: paragraph.donors.default
+targetEntityType: paragraph
+bundle: donors
+mode: default
+content: {  }
+hidden:
+  field_countries: true
+  field_donor_type: true

--- a/config/core.entity_view_display.paragraph.donors.preview.yml
+++ b/config/core.entity_view_display.paragraph.donors.preview.yml
@@ -1,0 +1,37 @@
+uuid: bcadb00d-b911-4876-b812-f2f6a1901e7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.donors.field_countries
+    - field.field.paragraph.donors.field_donor_type
+    - paragraphs.paragraphs_type.donors
+  module:
+    - layout_builder
+    - options
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.donors.preview
+targetEntityType: paragraph
+bundle: donors
+mode: preview
+content:
+  field_countries:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_donor_type:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -76,6 +76,7 @@ module:
   toolbar: 0
   unocha_breadcrumbs: 0
   unocha_canto: 0
+  unocha_donors: 0
   unocha_figures: 0
   unocha_maps: 0
   unocha_migrate: 0

--- a/config/field.field.paragraph.donors.field_countries.yml
+++ b/config/field.field.paragraph.donors.field_countries.yml
@@ -1,0 +1,29 @@
+uuid: 9462ed70-2e9b-4d09-a7e2-9b38309d861b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_countries
+    - paragraphs.paragraphs_type.donors
+    - taxonomy.vocabulary.country
+id: paragraph.donors.field_countries
+field_name: field_countries
+entity_type: paragraph
+bundle: donors
+label: Countries
+description: 'Countries for which to retrieve the donor data.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.paragraph.donors.field_donor_type.yml
+++ b/config/field.field.paragraph.donors.field_donor_type.yml
@@ -1,0 +1,21 @@
+uuid: db3f7fb6-65d9-4e76-936e-d2d82c89a3ba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_donor_type
+    - paragraphs.paragraphs_type.donors
+  module:
+    - options
+id: paragraph.donors.field_donor_type
+field_name: field_donor_type
+entity_type: paragraph
+bundle: donors
+label: Type
+description: 'Data source.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/field.storage.paragraph.field_countries.yml
+++ b/config/field.storage.paragraph.field_countries.yml
@@ -1,0 +1,20 @@
+uuid: 41cfcf76-eb22-4f60-968a-5d7814f729e0
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_countries
+field_name: field_countries
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_donor_type.yml
+++ b/config/field.storage.paragraph.field_donor_type.yml
@@ -1,0 +1,36 @@
+uuid: 76007fc8-ccd3-44b3-b858-af476d72324b
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_donor_type
+field_name: field_donor_type
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: fts_top_donors
+      label: 'FTS top donors'
+    -
+      value: fts_top_sectors
+      label: 'FTS top sectors'
+    -
+      value: cbpf_top_donors
+      label: 'CBPF top donors'
+    -
+      value: oct_earmarked_donors
+      label: 'OCT earmarked donors'
+    -
+      value: oct_unearmarked_donors
+      label: 'OCT unearmarked donors'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.donors.yml
+++ b/config/paragraphs.paragraphs_type.donors.yml
@@ -1,0 +1,10 @@
+uuid: 8e6ef1d7-639a-4290-a731-8e14be220063
+langcode: en
+status: true
+dependencies: {  }
+id: donors
+label: Donors
+icon_uuid: null
+icon_default: null
+description: 'Top donors, earmarked donors etc.'
+behavior_plugins: {  }

--- a/html/modules/custom/unocha_donors/README.md
+++ b/html/modules/custom/unocha_donors/README.md
@@ -1,0 +1,4 @@
+UNOCHA - Donors module
+======================
+
+This module handles `donors` paragraph types.

--- a/html/modules/custom/unocha_donors/templates/unocha-donors-list.html.twig
+++ b/html/modules/custom/unocha_donors/templates/unocha-donors-list.html.twig
@@ -1,0 +1,29 @@
+{#
+
+/**
+ * @file
+ * Template for a list of donors/sectors.
+ *
+ * Available variables:
+ * - type: type of donor data
+ * - attributes: attributes for the container
+ * - level: heading level for the title
+ * - title: list's title
+ * - title_attributes: title attributes
+ * - list: list of donors/sectors with name and optional pledged/paid amounts
+ * - list_attributes: attributes for the list
+ * - item_attributes: attributes for the list items
+ */
+
+#}
+{% if list is not empty %}
+<section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class)}}>
+  <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+  <ul{{ list_attributes.addClass('uno-donors__list') }}>
+    {% for item in list %}
+    <li{{ item_attributes.addClass('uno-donors__list__item') }}>{{ item.name }}</li>
+    {% endfor %}
+  <ul>
+</section>
+{% endif %}
+

--- a/html/modules/custom/unocha_donors/unocha_donors.info.yml
+++ b/html/modules/custom/unocha_donors/unocha_donors.info.yml
@@ -1,0 +1,8 @@
+type: module
+name: UNOCHA Donors
+description: 'Handles donors.'
+package: unocha
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:ocha_key_figures
+  - drupal:unocha_utility

--- a/html/modules/custom/unocha_donors/unocha_donors.module
+++ b/html/modules/custom/unocha_donors/unocha_donors.module
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * @file
+ * Module file for the unocha_donors module.
+ */
+
+use Drupal\unocha_utility\Helpers\LocalizationHelper;
+
+/**
+ * Implements hook_theme().
+ */
+function unocha_donors_theme() {
+  $themes = [
+    // Theme for a list of donors/sectors.
+    'unocha_donors_list' => [
+      'variables' => [
+        // Type of donor data.
+        'type' => NULL,
+        // Wrapper attributes.
+        'attributes' => NULL,
+        // Heading level.
+        'level' => 2,
+        // Title.
+        'title' => NULL,
+        // Title attributes.
+        'title_attributes' => NULL,
+        // List of donors/sectors with name and optional pledged/paid amounts.
+        'list' => NULL,
+        // List attributes.
+        'list_attributes' => NULL,
+        // List item attributes.
+        'item_attributes' => NULL,
+      ],
+    ],
+  ];
+
+  return $themes;
+}
+
+/**
+ * Implements hook_preprocess_paragraph__type().
+ */
+function unocha_donors_preprocess_paragraph__donors(array &$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+  $view_mode = $variables['view_mode'];
+  $donor_type = $paragraph->field_donor_type->value;
+
+  $iso3s = [];
+  if (!empty($donor_type) && isset($paragraph->field_countries)) {
+    foreach ($paragraph->field_countries as $item) {
+      $country = $item->entity ?? NULL;
+      if (isset($country) && $country->hasField('field_iso3') && !empty($country->field_iso3->value)) {
+        $iso3 = strtolower($country->field_iso3->value);
+        $iso3s[$iso3] = $iso3;
+      }
+    }
+  }
+
+  if (!empty($iso3s)) {
+    $donors = unocha_donors_get_donors($donor_type, $iso3s, $view_mode);
+    if (!empty($donors)) {
+      $variables['content']['donors'] = $donors;
+    }
+  }
+
+  // The API caches the data more granularly. The code here is not compute
+  // heavy so we can simply cache it with the root key figures tag to ensure
+  // it's always refreshed when key figures change.
+  $variables['#cache']['tags'][] = 'keyfigures';
+}
+
+/**
+ * Get the donors/sectors for the given countries.
+ *
+ * @param string $type
+ *   Donor data type.
+ * @param array $iso3s
+ *   List of ISO3 country codes.
+ * @param string $view_mode
+ *   View mode of the paragraph.
+ *
+ * @return array
+ *   Render array for the FTS top donors.
+ */
+function unocha_donors_get_donors($type, array $iso3s, $view_mode) {
+  $mapping = [
+    'fts_top_donors' => [
+      'title' => t('Top donors'),
+      'provider' => 'fts',
+      'pattern' => '/^fts_.+_YEAR_top_donors$/i',
+      'property' => 'donors',
+      'keys' => ['total_funding' => TRUE],
+      'sort' => 'total_funding',
+    ],
+    'fts_top_sectors' => [
+      'title' => t('Top sectors'),
+      'provider' => 'fts',
+      'pattern' => '/^fts_.+_YEAR_top_sectors$/i',
+      'property' => 'donors',
+      'keys' => ['total_funding' => TRUE],
+      'sort' => 'total_funding',
+    ],
+    'cbpf_top_donors' => [
+      'title' => t('Top donors'),
+      'provider' => 'cbpf',
+      'pattern' => '/^cbpf_.+_YEAR_top_donors$/i',
+      'property' => 'donors',
+      'keys' => ['paid' => TRUE, 'pledged' => TRUE],
+      'sort' => 'pledged',
+    ],
+    'oct_earmarked_donors' => [
+      'title' => t('Earmarked donors'),
+      'provider' => 'oct',
+      'pattern' => '/^oct_.+_YEAR_earmarkeddonors$/i',
+      'property' => 'donors',
+      'keys' => ['earmarked' => TRUE, 'unearmarked' => TRUE, 'total' => TRUE],
+      'sort' => 'total',
+    ],
+    'oct_unearmarked_donors' => [
+      'title' => t('Unearmarked donors'),
+      'provider' => 'oct',
+      'pattern' => '/^oct_.+_YEAR_unearmarkeddonors$/i',
+      'property' => 'value',
+      'keys' => [],
+      'sort' => NULL,
+    ],
+  ];
+
+  if (!isset($mapping[$type])) {
+    return [];
+  }
+
+  // Get the data for the current year.
+  $year = gmdate('Y');
+
+  // Get $title, $provider, $pattern, $property, $keys, $sort, $use_value.
+  extract($mapping[$type]);
+  $pattern = str_replace('YEAR', $year, $pattern);
+
+  // Retrieve the data from the OCHA Key Figures API.
+  $figures = unocha_donors_fetch_figures($provider, array_keys($iso3s), $year);
+
+  // Only keep the donor figures for the provider, year and countries.
+  $figures = array_filter($figures, function ($figure) use ($iso3s, $pattern, $property) {
+    return preg_match($pattern, $figure['id']) &&
+      isset($iso3s[strtolower($figure['iso3'])]) &&
+      !empty($figure[$property]);
+  });
+  if (empty($figures)) {
+    return [];
+  }
+
+  $donors = [];
+  foreach ($figures as $figure) {
+    if (is_array($figure[$property])) {
+      $figure_donors = $figure[$property];
+    }
+    // If the property with the list of donors is not an array, we assume it's
+    // a comma separated list.
+    else {
+      foreach (preg_split('/,\s+/', $figure[$property]) as $value) {
+        $figure_donors[$value]['name'] = $value;
+      }
+    }
+
+    // Copy over the donor properies and sum funding amounts.
+    foreach ($figure_donors as $item) {
+      if (isset($item['name'])) {
+        $name = $item['name'];
+        $donors[$name]['name'] = $name;
+
+        foreach ($keys as $key => $sum) {
+          if ($sum) {
+            $donors[$name][$key] = ($donors[$name][$key] ?? 0) + ($item[$key] ?? 0);
+          }
+          else {
+            $donors[$name][$key] = $item[$key] ?? '';
+          }
+        }
+      }
+    }
+  }
+  if (empty($donors)) {
+    return [];
+  }
+
+  // Sort the donors by a property (ex: pledged amount).
+  if (!empty($sort)) {
+    uasort($donors, function ($a, $b) use ($sort) {
+      return $b[$sort] <=> $a[$sort];
+    });
+  }
+  // Otherwise sort by name.
+  else {
+    LocalizationHelper::collatedKsort($donors);
+  }
+
+  return [
+    '#theme' => 'unocha_donors_list__' . $type . '__' . $view_mode,
+    '#type' => $type,
+    '#title' => $title ?: t('Top donors'),
+    '#list' => $donors,
+  ];
+}
+
+/**
+ * Fetch Key Figures.
+ *
+ * @param string $provider
+ *   API data provider.
+ * @param array $iso3s
+ *   List of the ISO3s of the countries we want Key Figures for.
+ * @param string $year
+ *   Year for the figures.
+ *
+ * @return array
+ *   API figures keyed by ID.
+ */
+function unocha_donors_fetch_figures($provider, array $iso3s, $year = NULL) {
+  $client = \Drupal::service('ocha_key_figures.key_figures_controller');
+
+  $query = [
+    'iso3' => $iso3s,
+    'year' => $year ?? gmdate('Y'),
+    'archived' => FALSE,
+  ];
+
+  $data = $client->query($provider, '', $query);
+
+  $results = [];
+  foreach ($data as $row) {
+    $results[strtolower($row['id'])] = $row;
+  }
+
+  return $results;
+}

--- a/html/modules/custom/unocha_utility/src/TwigExtension.php
+++ b/html/modules/custom/unocha_utility/src/TwigExtension.php
@@ -5,6 +5,7 @@ namespace Drupal\unocha_utility;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\unocha_utility\Helpers\HtmlSanitizer;
 use Drupal\unocha_utility\Helpers\LocalizationHelper;
+use Drupal\unocha_utility\Helpers\NumberFormatter;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -26,6 +27,8 @@ class TwigExtension extends AbstractExtension {
       new TwigFilter('dpm', 'dpm'),
       new TwigFilter('values', 'array_values'),
       new TwigFilter('hide_nested_label', [$this, 'hideNestedLabel']),
+      new TwigFilter('format_number_compact', [$this, 'formatNumberCompact']),
+      new TwigFilter('format_number_decimal', [$this, 'formatNumberDecimal']),
     ];
   }
 
@@ -181,6 +184,47 @@ class TwigExtension extends AbstractExtension {
       }
     }
     return $element;
+  }
+
+  /**
+   * Format a number with language aware compact decimal formatting.
+   *
+   * If the language is not supported or no pattern was found, the returned
+   * number will be formatted with the grouped thousands formatting.
+   *
+   * @param float|int $number
+   *   Number to format.
+   * @param string $langcode
+   *   Language code. Defaults to the current one.
+   * @param string $type
+   *   Either 'short' or 'long' (default).
+   * @param int $precision
+   *   Precision for the rounding of the number once compacted.
+   * @param bool $use_gho_specifics
+   *   When TRUE, apply some extra transformations like on the GHO site.
+   *
+   * @return string
+   *   Formatted number.
+   */
+  public static function formatNumberCompact($number, $langcode = NULL, $type = 'long', $precision = 2, $use_gho_specifics = FALSE) {
+    $langcode = $langcode ?? \Drupal::languageManager()->getCurrentLanguage()->getId();
+    return NumberFormatter::formatNumberCompact($number, $langcode, $type, $precision, $use_gho_specifics);
+  }
+
+  /**
+   * Format a number with grouped thousands.
+   *
+   * @param float|int $number
+   *   Number to format. Defaults to the current one.
+   * @param string $langcode
+   *   Language code.
+   *
+   * @return string
+   *   Formatted number.
+   */
+  public static function formatNumberDecimal($number, $langcode) {
+    $langcode = $langcode ?? \Drupal::languageManager()->getCurrentLanguage()->getId();
+    return NumberFormatter::formatNumberDecimal($number, $langcode);
   }
 
 }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -153,6 +153,11 @@ uno-embed:
   js:
     components/uno-embed/uno-embed.js: {}
 
+uno-donors:
+  css:
+    theme:
+      components/uno-donors/uno-donors.css: {}
+
 uno-figures:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/components/uno-donors/README.md
+++ b/html/themes/custom/common_design_subtheme/components/uno-donors/README.md
@@ -1,0 +1,4 @@
+UNOCHA Donors
+=============
+
+This component provides styling for top donors/sectors.

--- a/html/themes/custom/common_design_subtheme/components/uno-donors/uno-donors.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-donors/uno-donors.css
@@ -1,0 +1,20 @@
+.uno-donors__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.uno-donors__list--with-figures .uno-donors__list__item {
+  display: grid;
+  grid-template-columns: auto min-content;
+}
+.uno-donors__list--with-figures .uno-donors__amount {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.uno-donors--oct-unearmarked-donors .uno-donors__list__item {
+  display: inline;
+}
+.uno-donors--oct-unearmarked-donors .uno-donors__list__item + .uno-donors__list__item:before {
+  content: ", ";
+}

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--cbpf-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--cbpf-top-donors.html.twig
@@ -1,0 +1,38 @@
+{#
+
+/**
+ * @file
+ * Template for a list of donors/sectors.
+ *
+ * Available variables:
+ * - type: type of donor data
+ * - attributes: attributes for the container
+ * - level: heading level for the title
+ * - title: list's title
+ * - title_attributes: title attributes
+ * - list: list of donors/sectors with name and optional pledged/paid amounts
+ * - list_attributes: attributes for the list
+ * - item_attributes: attributes for the list items
+ */
+
+#}
+{% if list is not empty %}
+{{ attach_library('common_design_subtheme/uno-donors') }}
+{% set title = 'Top 5 donors' %}
+<section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class)}}>
+  <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+  {% apply spaceless %}
+  <ul{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>
+    {% for item in list|slice(0, 5) %}
+    {% set amount = item.paid ? item.paid : item.pledged %}
+    {% set suffix = item.paid ? 'paid'|t : 'pledged'|t %}
+    <li{{ item_attributes.addClass('uno-donors__list__item') }}>
+      <span class="uno-donors__country">{{ item.name }}</span>
+      <span class="uno-donors__amount"> ${{ amount|format_number_compact(null, 'long', 1, true)  }} <small class="uno-donors__amount__suffix">({{ suffix }})</small></span>
+    </li>
+    {% endfor %}
+  <ul>
+  {% endapply %}
+</section>
+{% endif %}
+

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-donors.html.twig
@@ -1,0 +1,36 @@
+{#
+
+/**
+ * @file
+ * Template for a list of donors/sectors.
+ *
+ * Available variables:
+ * - type: type of donor data
+ * - attributes: attributes for the container
+ * - level: heading level for the title
+ * - title: list's title
+ * - title_attributes: title attributes
+ * - list: list of donors/sectors with name and optional pledged/paid amounts
+ * - list_attributes: attributes for the list
+ * - item_attributes: attributes for the list items
+ */
+
+#}
+{% if list is not empty %}
+{{ attach_library('common_design_subtheme/uno-donors') }}
+{% set title = 'Top 5 donors' %}
+<section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class)}}>
+  <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+  {% apply spaceless %}
+  <ul{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>
+    {% for item in list|slice(0, 5) %}
+    <li{{ item_attributes.addClass('uno-donors__list__item') }}>
+      <span class="uno-donors__donor">{{ item.name }}</span>
+      <span class="uno-donors__amount"> ${{ item.total_funding|format_number_compact(null, 'long', 1, true)  }}</span>
+    </li>
+    {% endfor %}
+  <ul>
+  {% endapply %}
+</section>
+{% endif %}
+

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-sectors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-sectors.html.twig
@@ -1,0 +1,35 @@
+{#
+
+/**
+ * @file
+ * Template for a list of donors/sectors.
+ *
+ * Available variables:
+ * - type: type of donor data
+ * - attributes: attributes for the container
+ * - level: heading level for the title
+ * - title: list's title
+ * - title_attributes: title attributes
+ * - list: list of donors/sectors with name and optional pledged/paid amounts
+ * - list_attributes: attributes for the list
+ * - item_attributes: attributes for the list items
+ */
+
+#}
+{% if list is not empty %}
+{{ attach_library('common_design_subtheme/uno-donors') }}
+{% set title = 'Top 5 sectors' %}
+<section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class)}}>
+  <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+  {% apply spaceless %}
+  <ul{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>
+    {% for item in list|slice(0, 5) %}
+    <li{{ item_attributes.addClass('uno-donors__list__item') }}>
+      <span class="uno-donors__donor">{{ item.name }}</span>
+      <span class="uno-donors__amount"> ${{ item.total_funding|format_number_compact(null, 'long', 1, true)  }}</span>
+    </li>
+    {% endfor %}
+  <ul>
+  {% endapply %}
+</section>
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-earmarked.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-earmarked.html.twig
@@ -1,0 +1,31 @@
+{#
+
+/**
+ * @file
+ * Template for a list of donors/sectors.
+ *
+ * Available variables:
+ * - type: type of donor data
+ * - attributes: attributes for the container
+ * - level: heading level for the title
+ * - title: list's title
+ * - title_attributes: title attributes
+ * - list: list of donors/sectors with name and optional pledged/paid amounts
+ * - list_attributes: attributes for the list
+ * - item_attributes: attributes for the list items
+ */
+
+#}
+{% if list is not empty %}
+{{ attach_library('common_design_subtheme/uno-donors') }}
+<section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class)}}>
+  <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+  {% apply spaceless %}
+  <ul{{ list_attributes.addClass('uno-donors__list') }}>
+    {% for item in list %}
+    <li{{ item_attributes.addClass('uno-donors__list__item') }}>{{ item.name }}</li>
+    {% endfor %}
+  <ul>
+  {% endapply %}
+</section>
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
@@ -1,0 +1,31 @@
+{#
+
+/**
+ * @file
+ * Template for a list of donors/sectors.
+ *
+ * Available variables:
+ * - type: type of donor data
+ * - attributes: attributes for the container
+ * - level: heading level for the title
+ * - title: list's title
+ * - title_attributes: title attributes
+ * - list: list of donors/sectors with name and optional pledged/paid amounts
+ * - list_attributes: attributes for the list
+ * - item_attributes: attributes for the list items
+ */
+
+#}
+{% if list is not empty %}
+{{ attach_library('common_design_subtheme/uno-donors') }}
+<section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class)}}>
+  <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+  {% apply spaceless %}
+  <ul{{ list_attributes.addClass('uno-donors__list') }}>
+    {% for item in list %}
+    <li{{ item_attributes.addClass('uno-donors__list__item') }}>{{ item.name }}</li>
+    {% endfor %}
+  <ul>
+  {% endapply %}
+</section>
+{% endif %}


### PR DESCRIPTION
Refs: UNO-635

This PR adds a `donors` paragraph type and the `unocha_donors` module with the logic to get the donors data from the OCHA API.

### Workflow

1. Add a "Donors" paragraph type
2. Select the data source (ex: FTS)
3. Select the country or countries for which to get the data

### Styling

There are templates in `common_design_subtheme/templates/modules/unocha_donors` for the 5 types of donors/sectors data and a `uno-donors` component but there almost zero styling currently. 

### Tests

1. Checkout the branch, clear the cache and import the config
2. Follow the "wokflow" steps