### PR TITLE
[UNO-648] Menu tabs

### DIFF
--- a/config/core.entity_form_display.node.basic.default.yml
+++ b/config/core.entity_form_display.node.basic.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.basic.body
     - field.field.node.basic.field_basic_image
+    - field.field.node.basic.field_children_menu
     - field.field.node.basic.field_custom_content
     - node.type.basic
   module:
@@ -35,10 +36,17 @@ content:
     third_party_settings: {  }
   field_basic_image:
     type: media_library_widget
-    weight: 1
+    weight: 2
     region: content
     settings:
       media_types: {  }
+    third_party_settings: {  }
+  field_children_menu:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_custom_content:
     type: layout_paragraphs

--- a/config/core.entity_view_display.node.basic.card.yml
+++ b/config/core.entity_view_display.node.basic.card.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.card
     - field.field.node.basic.body
     - field.field.node.basic.field_basic_image
+    - field.field.node.basic.field_children_menu
     - field.field.node.basic.field_custom_content
     - node.type.basic
   module:
@@ -39,6 +40,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_children_menu: true
   field_custom_content: true
   langcode: true
   layout_builder__layout: true

--- a/config/core.entity_view_display.node.basic.default.yml
+++ b/config/core.entity_view_display.node.basic.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.basic.body
     - field.field.node.basic.field_basic_image
+    - field.field.node.basic.field_children_menu
     - field.field.node.basic.field_custom_content
     - node.type.basic
   module:
@@ -38,6 +39,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_children_menu: true
   field_custom_content: true
   langcode: true
   layout_builder__layout: true

--- a/config/core.entity_view_display.node.basic.full.yml
+++ b/config/core.entity_view_display.node.basic.full.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.basic.body
     - field.field.node.basic.field_basic_image
+    - field.field.node.basic.field_children_menu
     - field.field.node.basic.field_custom_content
     - node.type.basic
   module:
@@ -27,7 +28,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_basic_image:
     type: entity_reference_entity_view
@@ -38,6 +39,16 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_children_menu:
+    type: boolean
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_custom_content:
     type: layout_paragraphs
     label: hidden
@@ -45,7 +56,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
 hidden:
   langcode: true

--- a/config/core.entity_view_display.node.basic.teaser.yml
+++ b/config/core.entity_view_display.node.basic.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.basic.body
     - field.field.node.basic.field_basic_image
+    - field.field.node.basic.field_children_menu
     - field.field.node.basic.field_custom_content
     - node.type.basic
   module:
@@ -34,6 +35,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_children_menu: true
   field_custom_content: true
   langcode: true
   links: true

--- a/config/field.field.node.basic.field_children_menu.yml
+++ b/config/field.field.node.basic.field_children_menu.yml
@@ -1,0 +1,23 @@
+uuid: e16681ba-3bfc-457e-85e1-8118ab2dca67
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_children_menu
+    - node.type.basic
+id: node.basic.field_children_menu
+field_name: field_children_menu
+entity_type: node
+bundle: basic
+label: 'Children Menu'
+description: 'Check to display a menu with the child pages of this page.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/field.storage.node.field_children_menu.yml
+++ b/config/field.storage.node.field_children_menu.yml
@@ -1,0 +1,18 @@
+uuid: e5159533-8771-4748-aafe-8284737e4d8c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_children_menu
+field_name: field_children_menu
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -198,7 +198,7 @@ function common_design_subtheme_preprocess_field__field_children_menu(array &$va
           'url' => $link->getUrlObject(),
         ],
         '#weight' => $index,
-        '#active' => $current_menu_link === $link,
+        '#active' => $current_menu_link->getPluginId() === $link->getPluginId(),
       ];
     }
 

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -5,6 +5,10 @@
  * Template overrides, preprocess, and hooks for the OCHA Common Design theme.
  */
 
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Menu\MenuLinkInterface;
+use Drupal\Core\Menu\MenuTreeParameters;
+
 /**
  * Implements hook_theme_suggestions_page_alter().
  */
@@ -76,4 +80,121 @@ function common_design_subtheme_preprocess_menu__main(array &$variables) {
       }
     }
   }
+}
+
+/**
+ * Implements hook_preprocess_field__field_children_menu().
+ *
+ * Display a menu of child pages of a basic page if "children menu" is selected.
+ */
+function common_design_subtheme_preprocess_field__field_children_menu(array &$variables) {
+  $field_item_list = $variables['element']['#items'];
+  $entity = $field_item_list->getEntity();
+  $value = $field_item_list->first()->value;
+
+  $links = [];
+  $current_menu_link = NULL;
+  $cache_metadata = CacheableMetadata::createFromRenderArray($variables);
+  $cache_metadata->addCacheableDependency($entity);
+
+  // Retrieve the menu link associated with the parent entity of the field.
+  // We'll display this menu or its parent as tabs.
+  if (isset($entity) && $entity->getEntityTypeId() === 'node') {
+    $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+
+    // Get the menu link referencing this node in the main menu.
+    $menu_links = $menu_link_manager->loadLinksByRoute('entity.node.canonical', [
+      'node' => $entity->id(),
+    ], 'main');
+    $current_menu_link = reset($menu_links);
+
+    // Get the menu link ID, it will be used to load the menu tree.
+    $menu_link_id = NULL;
+    if (!empty($current_menu_link)) {
+      // If the "children menu" is not checked, retrieve the parent menu item.
+      // If the parent entity attached to the menu item has the "children menu"
+      // checked then we display its menu. This ensures we see the same tabs
+      // on the parent and the children nodes.
+      if (empty($value)) {
+        $parent_menu_link = $menu_link_manager->createInstance($current_menu_link->getParent());
+
+        if (!empty($parent_menu_link) &&
+          $parent_menu_link instanceof MenuLinkInterface &&
+          $parent_menu_link->getRouteName() === 'entity.node.canonical' &&
+          !empty($parent_menu_link->getRouteParameters()['node'])
+        ) {
+          $node_id = $parent_menu_link->getRouteParameters()['node'];
+          $parent_entity = \Drupal::entityTypeManager()->getStorage('node')->load($node_id);
+
+          if (isset($parent_entity) && $parent_entity->hasField('field_children_menu')) {
+            $cache_metadata->addCacheableDependency($parent_entity);
+
+            if (!empty($parent_entity->field_children_menu->value)) {
+              $menu_link_id = $parent_menu_link->getPluginId();
+            }
+          }
+        }
+      }
+      else {
+        $menu_link_id = $current_menu_link->getPluginId();
+      }
+    }
+
+    // Load the menu links for the tree.
+    if (isset($menu_link_id)) {
+      $tree_parameters = new MenuTreeParameters();
+      $tree_parameters->setRoot($menu_link_id);
+      $tree_parameters->setMaxDepth(2);
+
+      // Get the child links.
+      /** @var \Drupal\Core\Menu\MenuLinkTreeElement[] $menu_elements. */
+      $menu_tree = \Drupal::service('menu.link_tree')->load('main', $tree_parameters);
+
+      // Flatten the tree links as they will be displayed as tabs (local tasks)
+      // without a hierarchy but with the parent as first link.
+      foreach ($menu_tree as $menu_tree_element) {
+        $links[] = $menu_tree_element->link;
+        if (!empty($menu_tree_element)) {
+          foreach ($menu_tree_element->subtree as $element) {
+            $links[] = $element->link;
+          }
+        }
+      }
+
+      // Add the cache metadata of the links and filter out links that are not
+      // accessible.
+      foreach ($links as $key => $link) {
+        $cache_metadata->addCacheableDependency($link);
+        if (!$link->getUrlObject()->access()) {
+          unset($links[$key]);
+        }
+      }
+    }
+  }
+
+  // Replace the field's content with a tabular menu (local tasks).
+  if (count($links) > 1) {
+    $content = [
+      '#theme' => 'menu_local_tasks__children_menu',
+    ];
+    foreach ($links as $index => $link) {
+      $content['#primary'][] = [
+        '#theme' => 'menu_local_task__children_menu',
+        '#link' => [
+          'title' => $link->getTitle(),
+          'url' => $link->getUrlObject(),
+        ],
+        '#weight' => $index,
+        '#active' => $current_menu_link === $link,
+      ];
+    }
+
+    $variables['items'] = [['content' => $content]];
+  }
+  // Hide the field.
+  else {
+    $variables['items'] = [];
+  }
+
+  $cache_metadata->applyTo($variables);
 }


### PR DESCRIPTION
Refs: UNO-648

This adds a "children menu" field to basic pages that, when checked, displays a menu of the page and its children as tabs (menu local tasks).

The logic is in a preprocess in the common_design_subtheme and the templates can be overridden:

1. `menu-local-tasks--children-menu.html.twig`
2. `menu-local-task--children-menu.html.twig`

For example (2) could be used to check the link "title" and the "active" state and alter the title:

```
{% if element['#link'].title == 'Publications'|t and element['#active'] is not empty %}
  {% set link = link|merge({'#title': 'Latest'|t}) %}
{% endif %}
<li{{ attributes }}>{{ link }}</li>
```

The menu (field_children_menu) is currently displayed below the title and hero image if there is one. This could be altered either in the basic page's display settings or in the node--basic--full.html.twig template to display above the title for example.

### Tests.

1. Checkout branch, clear cache, import config
2. Edit a basic page (ex:  publications), make sure it has a "menu link", check the "children menu" checkbox
3. Create some other basic pages and add them as children of the page from (2)
4. There should now be a menu (tabs) of the pages from (2) and (3) when visiting one of those pages