### PR TITLE
[UNO-635] Donors fixes

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-earmarked-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-earmarked-donors.html.twig
@@ -25,7 +25,7 @@
     {% for item in list %}
     <div{{item_attributes.addClass('uno-donor')}}>
       <dt class="uno-donors__donor">{{ item.name }}</dt>
-      <dd class="uno-donors__amount"> $placeholder</dd>
+      <dd class="uno-donors__amount"> ${{ item.total|format_number_compact(null, 'long', 1, true)  }}</dd>
     </div>
     {% endfor %}
   <dl>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
@@ -25,7 +25,7 @@
     {% for item in list %}
     <li{{ item_attributes.addClass('uno-donors__list__item') }}>{{ item.name }}</li>
     {% endfor %}
-  <ul>
+  </ul>
   {% endapply %}
 </section>
 {% endif %}


### PR DESCRIPTION
Refs: UNO-635

Fixes for the OCT donors:

1. show amount for OCT earmarked donors
2. closing tag for the OCT unearmarked list