### PR TITLE
[UNO-652] Check access to nodes

### DIFF
--- a/html/modules/custom/unocha_maps/unocha_maps.module
+++ b/html/modules/custom/unocha_maps/unocha_maps.module
@@ -67,7 +67,7 @@ function unocha_maps_preprocess_paragraph__response_map(array &$variables) {
     // on the map.
     if (!empty($responses)) {
       foreach ($responses as $key => $response) {
-        if (!isset($response->field_country) || $response->field_country->isEmpty()) {
+        if (!$response->access('view') || !isset($response->field_country) || $response->field_country->isEmpty()) {
           unset($responses[$key]);
         }
       }

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -5,6 +5,7 @@
  * Module file for the unocha_paragraphs module.
  */
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Menu\MenuLinkInterface;
 use Drupal\Core\Menu\MenuLinkTreeElement;
 use Drupal\Core\Link;
@@ -103,6 +104,15 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
     $stories = unocha_paragraphs_get_stories([], $limit);
   }
 
+  // Filter out stories that cannot be accessed by the current user.
+  if (!empty($stories)) {
+    foreach ($stories as $key => $story) {
+      if (!$story->access('view')) {
+        unset($stories[$key]);
+      }
+    }
+  }
+
   // Add the renderable stories.
   if (!empty($stories)) {
     $view_all_url = Url::fromUserInput('/latest/news-and-stories', [
@@ -120,6 +130,8 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
  * Implements hook_preprocess_paragraph__type().
  */
 function unocha_paragraphs_preprocess_paragraph__resources(array &$variables) {
+  $cache_metadata = CacheableMetadata::createFromRenderArray($variables);
+
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
 
@@ -162,10 +174,13 @@ function unocha_paragraphs_preprocess_paragraph__resources(array &$variables) {
       $links = [];
       foreach ($nodes as $node) {
         if ($node->bundle() === 'resource') {
-          $links[] = [
-            'title' => $node->label(),
-            'url' => $node->toUrl(),
-          ];
+          $cache_metadata->addCacheableDependency($node);
+          if ($node->access('view')) {
+            $links[] = [
+              'title' => $node->label(),
+              'url' => $node->toUrl(),
+            ];
+          }
         }
       }
 
@@ -177,6 +192,8 @@ function unocha_paragraphs_preprocess_paragraph__resources(array &$variables) {
       }
     }
   }
+
+  $cache_metadata->applyTo($variables);
 }
 
 /**

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -217,6 +217,7 @@ function unocha_paragraphs_get_stories(array $conditions = [], $limit = 3, $excl
     ->getQuery()
     ->accessCheck(TRUE)
     ->condition('type', 'story')
+    ->condition('status', 1)
     ->sort('sticky', 'desc')
     ->sort('promote', 'desc')
     ->sort('created', 'desc')


### PR DESCRIPTION
Refs: UNO-652

This adds access checks for the maps, resources and stories used in the corresponding paragraph types.

### Tests

1. Checkout the branch, clear the cache
2. Unpublish a response that appears in a region's map, check that it appears on the map when logged in as an editor but is not present when viewing the map as an anonymous user
3. Unpublish a story that appears in a "latest updates" section of a region, check that it doesn't appear anymore in that section (whether logged in or not)
4. Unpublish a resource that appears in a response's resources section, check that it's visible in the resources section as en editor but not when viewing it as anonymous

Note: regarding (3) above and stories. The behavior is a bit different from the maps and resources where unpublished nodes still appear to editors because, there is query to retrieve a defined number stories (ex: 4 for the Latest Updates section) that does a prefiltering by checking the publication status while for the maps and resources, the logic is to get all of those but display them based on the access check. **TL;DR;** it's different but it's normal.