### PR TITLE
[UNO-648] Fix publications menu

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -85,7 +85,15 @@ function common_design_subtheme_preprocess_menu__main(array &$variables) {
     foreach ($variables['items'] as $key => $item) {
       if (!empty($item['below'])) {
         foreach ($item['below'] as $child) {
-          if (!empty($child['below'])) {
+          // When the current page corresponds to the $child menu item or one of
+          // its children and the menu item has enabled children then Drupal
+          // marks it as expanded and populates the `below` property regardless
+          // of the `expanded` property of the menu item. So to have a bit of
+          // control on what is displayed as a mega menu, we explicitly check
+          // the menu link item's `expanded` property to decide whether to
+          // display it as a mega menu or not.
+          // @see \Drupal\Core\Menu\MenuLinkTree::buildItems()
+          if (!empty($child['below']) && isset($child['original_link']) && $child['original_link']->isExpanded()) {
             $variables['items'][$key]['is_mega_menu'] = TRUE;
             $variables['items'][$key]['max_level'] = 2;
           }


### PR DESCRIPTION
Refs: UNO-648

This PR ensures a menu is not displayed as mega menu when its expanded property is unchecked.

### Notes

Make sure that menus that should show their children have the `Show as expanded` property checked. Currently that means the menu items for the region pages (it seems to be already the case on dev, but to also do when populating the preview site).

<img width="725" alt="Screenshot 2023-06-10 at 8 26 32" src="https://github.com/UN-OCHA/unocha-site/assets/696348/f7f23613-6f5d-485e-a25b-1c4fdc4b0f1a">

### Tests

**Before checking out the branch**

1. Confirm, the "latest" menu appears as a mega menu on your local when visiting `/publications`
2. If not, import the latest dev DB backup

**After checking out the branch**

1. Checkout the branch and clear the cache.
2. Check that the "latest" menu is not a mega menu anymore when visiting `/publications` and its children pages
3. Check some other pages like a response and confirm that "latest" is not a mega menu
4. Check that the "Where we work" is still a mega menu, regardless of the page