### PR TITLE
[UNO-653] CBPF visualisations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "drupal/datetime_range_timezone": "^1.0@alpha",
         "drupal/devel": "^5.0",
         "drupal/devel_php": "^1.3",
+        "drupal/double_field": "^4.1",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/geofield": "^1.53",
         "drupal/google_tag": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78ca31ba84c88d42967bacf31d4e1744",
+    "content-hash": "e489c623889d5e9694f7a7846bb17794",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3444,6 +3444,56 @@
             "homepage": "https://www.drupal.org/project/devel_php",
             "support": {
                 "source": "https://git.drupalcode.org/project/devel_php"
+            }
+        },
+        {
+            "name": "drupal/double_field",
+            "version": "4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/double_field.git",
+                "reference": "4.1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/double_field-4.1.1.zip",
+                "reference": "4.1.1",
+                "shasum": "4aeee34cbd2136af726d74e28222c2ab5e922d05"
+            },
+            "require": {
+                "drupal/core": "^8.9 || ^9 || ^10",
+                "php": ">=7.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.1.1",
+                    "datestamp": "1677408828",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://www.drupal.org/node/1162080/committers",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "Provides a field type with two separate sub-fields.",
+            "homepage": "https://www.drupal.org/project/double_field",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/double_field",
+                "issues": "https://www.drupal.org/project/issues/double_field"
             }
         },
         {

--- a/config/core.entity_form_display.paragraph.cbpf.default.yml
+++ b/config/core.entity_form_display.paragraph.cbpf.default.yml
@@ -1,0 +1,94 @@
+uuid: 42c0f9be-348b-4be7-87c8-d27ecf59946c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cbpf.field_cbpf_attributes
+    - field.field.paragraph.cbpf.field_cbpf_id
+    - field.field.paragraph.cbpf.field_height
+    - field.field.paragraph.cbpf.field_text
+    - field.field.paragraph.cbpf.field_title
+    - field.field.paragraph.cbpf.field_url
+    - field.field.paragraph.cbpf.field_width
+    - paragraphs.paragraphs_type.cbpf
+  module:
+    - double_field
+    - link
+    - text
+id: paragraph.cbpf.default
+targetEntityType: paragraph
+bundle: cbpf
+mode: default
+content:
+  field_cbpf_attributes:
+    type: double_field
+    weight: 3
+    region: content
+    settings:
+      first:
+        type: textfield
+        label_display: inline
+        size: 50
+        placeholder: ''
+        label: Ok
+        cols: 10
+        rows: 5
+      second:
+        type: textfield
+        label_display: inline
+        size: 60
+        placeholder: ''
+        label: Ok
+        cols: 10
+        rows: 5
+      inline: true
+    third_party_settings: {  }
+  field_cbpf_id:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_height:
+    type: number
+    weight: 5
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_url:
+    type: link_default
+    weight: 6
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_width:
+    type: number
+    weight: 4
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.cbpf.default.yml
+++ b/config/core.entity_view_display.paragraph.cbpf.default.yml
@@ -1,0 +1,53 @@
+uuid: ca54b841-27c8-43fd-b1a1-f10fb641b654
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cbpf.field_cbpf_attributes
+    - field.field.paragraph.cbpf.field_cbpf_id
+    - field.field.paragraph.cbpf.field_height
+    - field.field.paragraph.cbpf.field_text
+    - field.field.paragraph.cbpf.field_title
+    - field.field.paragraph.cbpf.field_url
+    - field.field.paragraph.cbpf.field_width
+    - paragraphs.paragraphs_type.cbpf
+  module:
+    - link
+    - text
+id: paragraph.cbpf.default
+targetEntityType: paragraph
+bundle: cbpf
+mode: default
+content:
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_url:
+    type: link
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: _blank
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  field_cbpf_attributes: true
+  field_cbpf_id: true
+  field_height: true
+  field_width: true

--- a/config/core.entity_view_display.paragraph.cbpf.preview.yml
+++ b/config/core.entity_view_display.paragraph.cbpf.preview.yml
@@ -1,0 +1,106 @@
+uuid: 247ea3fd-fa95-4839-9943-d347e561e8b7
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.cbpf.field_cbpf_attributes
+    - field.field.paragraph.cbpf.field_cbpf_id
+    - field.field.paragraph.cbpf.field_height
+    - field.field.paragraph.cbpf.field_text
+    - field.field.paragraph.cbpf.field_title
+    - field.field.paragraph.cbpf.field_url
+    - field.field.paragraph.cbpf.field_width
+    - paragraphs.paragraphs_type.cbpf
+  module:
+    - double_field
+    - layout_builder
+    - link
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.cbpf.preview
+targetEntityType: paragraph
+bundle: cbpf
+mode: preview
+content:
+  field_cbpf_attributes:
+    type: double_field_unformatted_list
+    label: above
+    settings:
+      first:
+        format_type: medium
+        link: false
+        hidden: false
+        key: false
+        decimal_separator: .
+        thousand_separator: ''
+        scale: 2
+      second:
+        format_type: medium
+        link: false
+        hidden: false
+        key: false
+        decimal_separator: .
+        thousand_separator: ''
+        scale: 2
+      inline: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_cbpf_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_height:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_text:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_url:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_width:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+hidden: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -19,6 +19,7 @@ module:
   datetime_range_timezone: 0
   devel: 0
   devel_generate: 0
+  double_field: 0
   dynamic_page_cache: 0
   editor: 0
   entity_reference_revisions: 0

--- a/config/field.field.paragraph.cbpf.field_cbpf_attributes.yml
+++ b/config/field.field.paragraph.cbpf.field_cbpf_attributes.yml
@@ -1,0 +1,39 @@
+uuid: a3f3cfc8-b660-41a7-9ded-45834cca2849
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_cbpf_attributes
+    - paragraphs.paragraphs_type.cbpf
+  module:
+    - double_field
+id: paragraph.cbpf.field_cbpf_attributes
+field_name: field_cbpf_attributes
+entity_type: paragraph
+bundle: cbpf
+label: 'CBPF Attributes'
+description: "Extra data attributes for the chart/visualisation. Ex: \"data-regions\", \"data-showmap\". \r\nNote: if the \"date-year\" is not specified, it will default to the current year."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  first:
+    label: ''
+    list: false
+    allowed_values: {  }
+    max: null
+    min: null
+    required: true
+    on_label: 'On'
+    off_label: 'Off'
+  second:
+    label: ''
+    list: false
+    allowed_values: {  }
+    max: null
+    min: null
+    required: true
+    on_label: 'On'
+    off_label: 'Off'
+field_type: double_field

--- a/config/field.field.paragraph.cbpf.field_cbpf_id.yml
+++ b/config/field.field.paragraph.cbpf.field_cbpf_id.yml
@@ -1,0 +1,19 @@
+uuid: f1ebcc19-2d24-4fe2-b950-e968391140db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_cbpf_id
+    - paragraphs.paragraphs_type.cbpf
+id: paragraph.cbpf.field_cbpf_id
+field_name: field_cbpf_id
+entity_type: paragraph
+bundle: cbpf
+label: 'CBPF ID'
+description: 'ID of the chart/visualisation from https://github.com/CBPFGMS/cbpfgms.github.io/.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.cbpf.field_height.yml
+++ b/config/field.field.paragraph.cbpf.field_height.yml
@@ -1,0 +1,23 @@
+uuid: 004575de-496e-4f29-ba11-8b665f78be2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_height
+    - paragraphs.paragraphs_type.cbpf
+id: paragraph.cbpf.field_height
+field_name: field_height
+entity_type: paragraph
+bundle: cbpf
+label: Height
+description: 'Combined with the "width" field to determine the aspect ratio used to display the graphic.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.field.paragraph.cbpf.field_text.yml
+++ b/config/field.field.paragraph.cbpf.field_text.yml
@@ -1,0 +1,26 @@
+uuid: 4cc65ad2-e753-4d22-8961-864e65a95d70
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.cbpf
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - text_editor_simple
+id: paragraph.cbpf.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: cbpf
+label: Text
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/field.field.paragraph.cbpf.field_title.yml
+++ b/config/field.field.paragraph.cbpf.field_title.yml
@@ -1,0 +1,19 @@
+uuid: b5b41870-b916-48d9-ba82-4676189236ef
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.cbpf
+id: paragraph.cbpf.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: cbpf
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.cbpf.field_url.yml
+++ b/config/field.field.paragraph.cbpf.field_url.yml
@@ -1,0 +1,23 @@
+uuid: bde837a0-19cb-43ed-bddb-a570d5685253
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_url
+    - paragraphs.paragraphs_type.cbpf
+  module:
+    - link
+id: paragraph.cbpf.field_url
+field_name: field_url
+entity_type: paragraph
+bundle: cbpf
+label: Link
+description: 'Optional link to the source data (ex: https://cbpf.data.unocha.org/).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 16
+field_type: link

--- a/config/field.field.paragraph.cbpf.field_width.yml
+++ b/config/field.field.paragraph.cbpf.field_width.yml
@@ -1,0 +1,23 @@
+uuid: 108eb73c-9ae4-4908-bcf2-085641c56058
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_width
+    - paragraphs.paragraphs_type.cbpf
+id: paragraph.cbpf.field_width
+field_name: field_width
+entity_type: paragraph
+bundle: cbpf
+label: Width
+description: 'Combined with the "height" field to determine the aspect ratio used to display the graphic.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.storage.paragraph.field_cbpf_attributes.yml
+++ b/config/field.storage.paragraph.field_cbpf_attributes.yml
@@ -1,0 +1,32 @@
+uuid: 4f294e76-3dc3-47ac-93fd-dfc3ef2c9771
+langcode: en
+status: true
+dependencies:
+  module:
+    - double_field
+    - paragraphs
+id: paragraph.field_cbpf_attributes
+field_name: field_cbpf_attributes
+entity_type: paragraph
+type: double_field
+settings:
+  storage:
+    first:
+      type: string
+      maxlength: 128
+      precision: 10
+      scale: 2
+      datetime_type: datetime
+    second:
+      type: string
+      maxlength: 255
+      precision: 10
+      scale: 2
+      datetime_type: datetime
+module: double_field
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_cbpf_id.yml
+++ b/config/field.storage.paragraph.field_cbpf_id.yml
@@ -1,0 +1,21 @@
+uuid: 80f5714f-ec38-4adc-9bfa-af417264572b
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_cbpf_id
+field_name: field_cbpf_id
+entity_type: paragraph
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_height.yml
+++ b/config/field.storage.paragraph.field_height.yml
@@ -1,0 +1,20 @@
+uuid: e13cd6c9-9bde-490d-9ae0-9ea76055b2e4
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_height
+field_name: field_height
+entity_type: paragraph
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_width.yml
+++ b/config/field.storage.paragraph.field_width.yml
@@ -1,0 +1,20 @@
+uuid: ad21b6ed-009f-403b-8a72-b9e5251a333d
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_width
+field_name: field_width
+entity_type: paragraph
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.cbpf.yml
+++ b/config/paragraphs.paragraphs_type.cbpf.yml
@@ -1,0 +1,10 @@
+uuid: c64731d4-298d-44bc-a187-720f24cf3ae2
+langcode: en
+status: true
+dependencies: {  }
+id: cbpf
+label: CBPF
+icon_uuid: null
+icon_default: null
+description: 'CBPF interactive graphic from https://github.com/CBPFGMS/cbpfgms.github.io/.'
+behavior_plugins: {  }

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--cbpf.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--cbpf.html.twig
@@ -64,7 +64,7 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      {% set ratio = paragraph.field_height.value ~ ' / ' ~ paragraph.field_width.value %}
+      {% set ratio = paragraph.field_width.value ~ ' / ' ~ paragraph.field_height.value %}
       {% set srcdoc = _self.cbpf(paragraph.field_cbpf_id.0.value, paragraph.field_cbpf_attributes) %}
       <div{{ create_attribute().addClass('iframe-wrapper', 'iframe-wrapper--responsive').setAttribute('style', 'aspect-ratio: ' ~ ratio) }}>
         <iframe

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--cbpf.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--cbpf.html.twig
@@ -1,0 +1,93 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+
+{% import _self as self %}
+{% macro cbpf(id, attributes) %}
+  {% set iframe_attributes = create_attribute().setAttribute('id', 'd3chartcontainer' ~ id) %}
+  {% for attribute in attributes %}
+    {% set iframe_attributes = iframe_attributes.setAttribute(attribute.first, attribute.second) %}
+  {% endfor %}
+
+  <div{{ iframe_attributes
+    .setAttribute('data-year', iframe_attributes.offsetGet('data-year') ?? 'now'|date('Y', 'UTC'))
+    .setAttribute('data-responsive', true)
+    .setAttribute('data-lazyload', true)
+  }}></div><script type="text/javascript" src="https://cbpfgms.github.io/{{ id }}/src/d3chart{{ id }}.js"></script>
+{% endmacro %}
+
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {% set ratio = paragraph.field_height.value ~ ' / ' ~ paragraph.field_width.value %}
+      {% set srcdoc = _self.cbpf(paragraph.field_cbpf_id.0.value, paragraph.field_cbpf_attributes) %}
+      <div{{ create_attribute().addClass('iframe-wrapper', 'iframe-wrapper--responsive').setAttribute('style', 'aspect-ratio: ' ~ ratio) }}>
+        <iframe
+          title="{{ paragraph.field_url.title }}"
+          {# This replaces the default html escaping by the attributes one so
+             that we can display the HTML returned by the macro. Otherwise
+             html tags are escaped. #}
+          srcdoc="{{ srcdoc|escape('html_attr')|raw }}"
+          {# @todo depending on what CBPF visualizations we end up using we may
+             want to enable scrolling as some of them like the covid map shows
+             "popups" that need scrolling. #}
+          scrolling="no"
+          frameborder="0"
+          style="width: 100%; height: 100%"
+          {# @todo having both allow-same-origin and allow-scripts kinds of
+             defeats the purpose of the sandbox as the embedded content can
+             remove the "sandbox" attribute of the iframe". It's just there
+             until we can replace the "allow-same-origin" with something like
+             "allow-storage-access-by-user-activation" to allow access to the
+             local storage which some CBPF scripts require. #}
+          sandbox="allow-downloads allow-same-origin allow-scripts"
+        ></iframe>
+      </div>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Refs: UNO-653

This adds a "CBPF" paragraph type to display a visualisation from https://github.com/CBPFGMS/cbpfgms.github.io/.

The paragraph requires a visualisation ID from the link above and dimensions (to determine the aspect ratio).

After that the visualisation is displayed via an iframe.

### Tests

Make a backup of the DB before testing because, this PR adds a new module and paragraph type so switching back to another branch without merging this PR will make Drupal complain when importing the config.

1. Checkout the branch
2. Run `composer install`, clear the cache and import the config
3. Edit/create a page (ex: basic page)
4. Add a CBPF paragraph, select an ID from https://github.com/CBPFGMS/cbpfgms.github.io/, for example the ID of the graph shown on https://www.unocha.org/our-work/humanitarian-financing/country-based-pooled-funds-cbpf is `cbpfbp`.
5. Check the details of the visualisation on the github page for required attributes and recommended dimensions
6. Save and check that the visualisation shows properly