### PR TITLE
[UNO-651] Media image field description

### DIFF
--- a/config/field.field.media.image.field_media_image.yml
+++ b/config/field.field.media.image.field_media_image.yml
@@ -19,7 +19,7 @@ field_name: field_media_image
 entity_type: media
 bundle: image
 label: Image
-description: ''
+description: "Please make sure that the image to upload doesn't have 2 extensions (ex: <code>image.jpg.webp</code>). If that's the case, rename the file before uploading it (ex:  <code>image.jpg.webp</code> → <code>image.webp</code>)."
 required: true
 translatable: true
 default_value: {  }


### PR DESCRIPTION
Refs: UNO-651

Add description to media image field to indicate that files with 2 extensions should be renamed
