### PR TITLE
feat: add social share links to RW document pages

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/cd-social-links/cd-social-links.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-social-links/cd-social-links.css
@@ -204,7 +204,9 @@
   transform: translateX(50%) translateY(-10px);
 }
 
-.cd-social-links + .cd-layout-main-content {
+.cd-social-links + .unocha-reliefweb-document__content,
+.cd-social-links + .cd-layout-main-content,
+.unocha-reliefweb-document .unocha-reliefweb-document__content {
   border-top: 1px solid var(--brand-grey);
   padding-top: 2rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
@@ -3,10 +3,10 @@
  */
 
 /* Date. */
-.unocha-reliefweb-document__date {
+/* .unocha-reliefweb-document__date {
   font-weight: bold;
   font-style: italic;
-}
+} */
 
 /* Lists in content. */
 .unocha-reliefweb-document li {
@@ -59,8 +59,15 @@
 }
 
 /* Reading width. */
-.unocha-reliefweb-document {
+.unocha-reliefweb-document .unocha-reliefweb-document__content ul,
+.unocha-reliefweb-document .unocha-reliefweb-document__content ol,
+.unocha-reliefweb-document .unocha-reliefweb-document__content p {
   max-width: var(--cd-max-content-width);
+}
+
+.unocha-reliefweb-document .unocha-reliefweb-document__content p:first-child,
+.unocha-reliefweb-document .unocha-reliefweb-document__content > .unocha-reliefweb-attachment-list + p {
+  margin-top: 0;
 }
 
 /* .unocha-reliefweb-document .cd-page-title {

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-document.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-document.html.twig
@@ -2,4 +2,23 @@
 
 {% set title_attributes = title_attributes.addClass('cd-page-title') %}
 
-{% include '@unocha_reliefweb/unocha-reliefweb-document.html.twig' %}
+<article{{ attributes.addClass('unocha-reliefweb-document')}}>
+  <header class="unocha-reliefweb-document__header">
+    <h{{ level }}{{ title_attributes.addClass('unocha-reliefweb-document__title') }}>{{ title }}</h{{ level }}>
+    <time class="unocha-reliefweb-document__date" datetime="{{ date|date('c') }} ">{{ date|date('j M Y') }}</time>
+
+    {% if componentsModule %}
+      {%
+        include '@uno-components/cd-social-links/cd-social-links.html.twig' with {
+          'label': title,
+          'title': title,
+          'url': path('<current>')
+        }
+      %}
+    {% endif %}
+  </header>
+  <div{{ content_attributes.addClass('unocha-reliefweb-document__content') }}>
+    {{- content|without('body') -}}
+    {{- content.body|render|sanitize_html(false, level + 1) -}}
+  </div>
+</article>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-document.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-document.html.twig
@@ -5,8 +5,6 @@
 <article{{ attributes.addClass('unocha-reliefweb-document')}}>
   <header class="unocha-reliefweb-document__header">
     <h{{ level }}{{ title_attributes.addClass('unocha-reliefweb-document__title') }}>{{ title }}</h{{ level }}>
-    <time class="unocha-reliefweb-document__date" datetime="{{ date|date('c') }} ">{{ date|date('j M Y') }}</time>
-
     {% if componentsModule %}
       {%
         include '@uno-components/cd-social-links/cd-social-links.html.twig' with {
@@ -21,4 +19,9 @@
     {{- content|without('body') -}}
     {{- content.body|render|sanitize_html(false, level + 1) -}}
   </div>
+  <footer class="cd-author node__meta [ cd-bumper ]">
+    <div class="cd-author__content">
+      <time class="unocha-reliefweb-document__date" datetime="{{ date|date('c') }} ">{{ date|date('j F Y') }}</time>
+    </div>
+  </footer>
 </article>


### PR DESCRIPTION
Refs: UNO-675

This updates the RW document template to add the social share links.

### Tests

1. Visit a whitelabeled RW document page, check that the social links appear and have the proper query parameters.