### PR TITLE
[UNO-667] Add has response and office type fields and vocabulary

### DIFF
--- a/config/core.entity_form_display.node.response.default.yml
+++ b/config/core.entity_form_display.node.response.default.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.node.response.field_active_response
     - field.field.node.response.field_country
     - field.field.node.response.field_custom_content
+    - field.field.node.response.field_has_response
+    - field.field.node.response.field_office_type
     - field.field.node.response.field_region
     - field.field.node.response.field_response_image
     - field.field.node.response.field_response_link
@@ -35,20 +37,20 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   field_active_response:
     type: boolean_checkbox
-    weight: 5
+    weight: 6
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_country:
     type: choices_widget
-    weight: 7
+    weight: 8
     region: content
     settings:
       configuration_options: ''
@@ -63,9 +65,22 @@ content:
       require_layouts: 0
       empty_message: 'Placeholder message to display when field is empty'
     third_party_settings: {  }
+  field_has_response:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_office_type:
+    type: options_buttons
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_region:
     type: choices_widget
-    weight: 6
+    weight: 7
     region: content
     settings:
       configuration_options: ''
@@ -87,34 +102,34 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 8
+    weight: 10
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 11
+    weight: 14
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 15
+    weight: 18
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 12
+    weight: 15
     region: content
     settings:
       display_label: true
@@ -127,9 +142,14 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
@@ -138,7 +158,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 14
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_view_display.node.response.card.yml
+++ b/config/core.entity_view_display.node.response.card.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.response.field_active_response
     - field.field.node.response.field_country
     - field.field.node.response.field_custom_content
+    - field.field.node.response.field_has_response
+    - field.field.node.response.field_office_type
     - field.field.node.response.field_region
     - field.field.node.response.field_response_image
     - field.field.node.response.field_response_link
@@ -47,6 +49,8 @@ hidden:
   body: true
   field_country: true
   field_custom_content: true
+  field_has_response: true
+  field_office_type: true
   field_region: true
   field_response_link: true
   langcode: true

--- a/config/core.entity_view_display.node.response.default.yml
+++ b/config/core.entity_view_display.node.response.default.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.node.response.field_active_response
     - field.field.node.response.field_country
     - field.field.node.response.field_custom_content
+    - field.field.node.response.field_has_response
+    - field.field.node.response.field_office_type
     - field.field.node.response.field_region
     - field.field.node.response.field_response_image
     - field.field.node.response.field_response_link
@@ -40,6 +42,8 @@ hidden:
   field_active_response: true
   field_country: true
   field_custom_content: true
+  field_has_response: true
+  field_office_type: true
   field_region: true
   field_response_link: true
   langcode: true

--- a/config/core.entity_view_display.node.response.full.yml
+++ b/config/core.entity_view_display.node.response.full.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.response.field_active_response
     - field.field.node.response.field_country
     - field.field.node.response.field_custom_content
+    - field.field.node.response.field_has_response
+    - field.field.node.response.field_office_type
     - field.field.node.response.field_region
     - field.field.node.response.field_response_image
     - field.field.node.response.field_response_link
@@ -68,5 +70,7 @@ hidden:
   body: true
   field_active_response: true
   field_country: true
+  field_has_response: true
+  field_office_type: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.node.response.map.yml
+++ b/config/core.entity_view_display.node.response.map.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.response.field_active_response
     - field.field.node.response.field_country
     - field.field.node.response.field_custom_content
+    - field.field.node.response.field_has_response
+    - field.field.node.response.field_office_type
     - field.field.node.response.field_region
     - field.field.node.response.field_response_image
     - field.field.node.response.field_response_link
@@ -46,6 +48,8 @@ hidden:
   field_active_response: true
   field_country: true
   field_custom_content: true
+  field_has_response: true
+  field_office_type: true
   field_region: true
   field_response_link: true
   langcode: true

--- a/config/core.entity_view_display.node.response.teaser.yml
+++ b/config/core.entity_view_display.node.response.teaser.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.response.field_active_response
     - field.field.node.response.field_country
     - field.field.node.response.field_custom_content
+    - field.field.node.response.field_has_response
+    - field.field.node.response.field_office_type
     - field.field.node.response.field_region
     - field.field.node.response.field_response_image
     - field.field.node.response.field_response_link
@@ -46,6 +48,8 @@ hidden:
   field_active_response: true
   field_country: true
   field_custom_content: true
+  field_has_response: true
+  field_office_type: true
   field_region: true
   field_response_link: true
   langcode: true

--- a/config/core.entity_view_display.node.response.title.yml
+++ b/config/core.entity_view_display.node.response.title.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.response.field_active_response
     - field.field.node.response.field_country
     - field.field.node.response.field_custom_content
+    - field.field.node.response.field_has_response
+    - field.field.node.response.field_office_type
     - field.field.node.response.field_region
     - field.field.node.response.field_response_image
     - field.field.node.response.field_response_link
@@ -29,6 +31,8 @@ hidden:
   field_active_response: true
   field_country: true
   field_custom_content: true
+  field_has_response: true
+  field_office_type: true
   field_region: true
   field_response_image: true
   field_response_link: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -79,6 +79,7 @@ module:
   unocha_donors: 0
   unocha_figures: 0
   unocha_maps: 0
+  unocha_menus: 0
   unocha_migrate: 0
   unocha_paragraphs: 0
   unocha_reliefweb: 0

--- a/config/field.field.node.response.field_has_response.yml
+++ b/config/field.field.node.response.field_has_response.yml
@@ -1,0 +1,23 @@
+uuid: 80cd62cc-51cf-4c7b-b489-72bf88bfca73
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_has_response
+    - node.type.response
+id: node.response.field_has_response
+field_name: field_has_response
+entity_type: node
+bundle: response
+label: 'Has response'
+description: 'Check this field if the response has a HRP, FA or is listed on GHO.'
+required: true
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/field.field.node.response.field_has_response.yml
+++ b/config/field.field.node.response.field_has_response.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: response
 label: 'Has response'
 description: 'Check this field if the response has a HRP, FA or is listed on GHO.'
-required: true
+required: false
 translatable: false
 default_value:
   -

--- a/config/field.field.node.response.field_office_type.yml
+++ b/config/field.field.node.response.field_office_type.yml
@@ -1,0 +1,29 @@
+uuid: 8154c535-80a5-4a85-a90a-bd2d543d3576
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_office_type
+    - node.type.response
+    - taxonomy.vocabulary.office_type
+id: node.response.field_office_type
+field_name: field_office_type
+entity_type: node
+bundle: response
+label: 'Office type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      office_type: office_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.storage.node.field_has_response.yml
+++ b/config/field.storage.node.field_has_response.yml
@@ -1,0 +1,18 @@
+uuid: 17e6694d-1ad5-4740-925e-6b35d21f2c14
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_has_response
+field_name: field_has_response
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_office_type.yml
+++ b/config/field.storage.node.field_office_type.yml
@@ -1,0 +1,20 @@
+uuid: f6249742-1a80-4b5a-a0c3-3179bb15b663
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_office_type
+field_name: field_office_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/language.content_settings.taxonomy_term.office_type.yml
+++ b/config/language.content_settings.taxonomy_term.office_type.yml
@@ -1,0 +1,16 @@
+uuid: 7cd6bb61-c90e-4c2d-983e-7b7c02c141be
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.office_type
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.office_type
+target_entity_type_id: taxonomy_term
+target_bundle: office_type
+default_langcode: site_default
+language_alterable: false

--- a/config/taxonomy.vocabulary.office_type.yml
+++ b/config/taxonomy.vocabulary.office_type.yml
@@ -1,0 +1,8 @@
+uuid: b71843cf-c05c-471a-aa8d-60d885e16c82
+langcode: en
+status: true
+dependencies: {  }
+name: 'Office type'
+vid: office_type
+description: ''
+weight: 0

--- a/html/modules/custom/unocha_maps/unocha_maps.module
+++ b/html/modules/custom/unocha_maps/unocha_maps.module
@@ -52,13 +52,35 @@ function unocha_maps_preprocess_paragraph__response_map(array &$variables) {
         // Get the associated nodes.
         $responses = unocha_paragraphs_get_nodes_from_menu_links($menu_links);
         $title = t('Regional coverage');
+
+        // Remove responses that are tagged only with Liaison Office.
+        if (!empty($responses)) {
+          $terms = $entity_type_manager->getStorage('taxonomy_term')->loadByProperties([
+            'vid' => 'office_type',
+            'name' => 'Liaison Office',
+            'langcode' => 'en',
+          ]);
+          if (!empty($terms)) {
+            foreach ($responses as $key => $response) {
+              if (isset($response->field_office_type) && !$response->field_office_type->isEmpty()) {
+                foreach ($response->field_office_type as $item) {
+                  if (!isset($terms[$item->target_id])) {
+                    continue 2;
+                  }
+                }
+                unset($responses[$key]);
+              }
+            }
+          }
+        }
       }
     }
     else {
-      // @todo should we filter more?
+      // Get the list of responses that have an actual response.
       $responses = $entity_type_manager->getStorage('node')->loadByProperties([
         'type' => 'response',
         'status' => 1,
+        'field_has_response' => 1,
       ]);
       $title = t('Current responses');
     }

--- a/html/modules/custom/unocha_menus/README.md
+++ b/html/modules/custom/unocha_menus/README.md
@@ -1,0 +1,4 @@
+UNOCHA - Menus module
+=====================
+
+This module handles customisations of menus.

--- a/html/modules/custom/unocha_menus/unocha_menus.info.yml
+++ b/html/modules/custom/unocha_menus/unocha_menus.info.yml
@@ -1,0 +1,8 @@
+type: module
+name: UNOCHA menus
+description: 'Provides customization of menus.'
+package: unocha
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:menu_link_content
+  - drupal:menu_ui

--- a/html/modules/custom/unocha_menus/unocha_menus.module
+++ b/html/modules/custom/unocha_menus/unocha_menus.module
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * @file
+ * Module file for unocha_menus.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\NodeInterface;
+
+/**
+ * Helper function to create or update a menu link for a node.
+ *
+ * Note: this is a copy of `_menu_ui_node_save()` but which allows to save
+ * additional fields.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   Node entity.
+ * @param array $values
+ *   Values for the menu link.
+ *
+ * @see _menu_ui_node_save()
+ */
+function unocha_menus_node_save(NodeInterface $node, array $values) {
+  /** @var \Drupal\menu_link_content\MenuLinkContentInterface $entity */
+  if (!empty($values['entity_id'])) {
+    $entity = MenuLinkContent::load($values['entity_id']);
+    if ($entity->isTranslatable()) {
+      if (!$entity->hasTranslation($node->language()->getId())) {
+        $entity = $entity->addTranslation($node->language()->getId(), $entity->toArray());
+      }
+      else {
+        $entity = $entity->getTranslation($node->language()->getId());
+      }
+    }
+  }
+  else {
+    // Create a new menu_link_content entity.
+    $entity = MenuLinkContent::create([
+      'link' => ['uri' => 'entity:node/' . $node->id()],
+      'langcode' => $node->language()->getId(),
+    ]);
+    $entity->enabled->value = 1;
+  }
+  $entity->title->value = trim($values['title']);
+  $entity->description->value = trim($values['description']);
+  $entity->menu_name->value = $values['menu_name'];
+  $entity->parent->value = $values['parent'];
+  $entity->weight->value = $values['weight'] ?? 0;
+  $entity->isDefaultRevision($node->isDefaultRevision());
+
+  // Extra menu fields.
+  $entity->expanded->value = !empty($values['expanded']);
+  $entity->enabled->value = !empty($values['visible']);
+
+  $entity->save();
+}
+
+/**
+ * Returns the menu for the given node.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node entity.
+ *
+ * @return \Drupal\menu_link_content\Entity\MenuLinkContent|null
+ *   The menu link for the given node.
+ */
+function unocha_menus_get_node_menu_link(NodeInterface $node) {
+  if ($node->id()) {
+    $node_type = $node->type->entity;
+    $menu_name = strtok($node_type->getThirdPartySetting('menu_ui', 'parent', 'main:'), ':');
+    $available_menus = $node_type->getThirdPartySetting('menu_ui', 'available_menus', ['main']);
+    if (empty($available_menus)) {
+      return NULL;
+    }
+
+    // Give priority to the default menu.
+    if (in_array($menu_name, $available_menus)) {
+      $id = unocha_menus_get_node_menu_link_id($node, [$menu_name]);
+    }
+    // Check all allowed menus if a link does not exist in the default menu.
+    if (empty($id)) {
+      $id = unocha_menus_get_node_menu_link_id($node, $menus);
+    }
+    if (!empty($id)) {
+      return \Drupal::service('entity.repository')->getActive('menu_link_content', $id);
+    }
+  }
+  return NULL;
+}
+
+/**
+ * Returns the ID of the menu for the given node.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node entity.
+ * @param array $menus
+ *   List of menus in which to look for a menu link for the node.
+ *
+ * @return int|false
+ *   The menu link ID or FALSE if none could be found.
+ */
+function unocha_menus_get_node_menu_link_id(NodeInterface $node, array $menus) {
+  $ids = \Drupal::entityQuery('menu_link_content')
+    ->accessCheck(TRUE)
+    ->condition('link.uri', 'entity:node/' . $node->id())
+    ->condition('menu_name', array_values($menus), 'IN')
+    ->sort('id', 'ASC')
+    ->range(0, 1)
+    ->execute();
+  return empty($ids) ? FALSE : reset($ids);
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter() for \Drupal\node\NodeForm.
+ *
+ * Display extra fields for the menu link in the node form.
+ *
+ * @see menu_ui_form_node_form_alter()
+ */
+function unocha_menus_form_node_form_alter(&$form, FormStateInterface $form_state) {
+  if (!isset($form['menu']['link'])) {
+    return;
+  }
+
+  $node = $form_state->getFormObject()->getEntity();
+  $menu_link = unocha_menus_get_node_menu_link($node);
+
+  $form['menu']['link']['expanded'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show as expanded'),
+    '#description' => t('If selected and this menu link has children, the menu will always appear expanded.'),
+    '#default_value' => $menu_link?->isExpanded() ?? FALSE,
+  ];
+
+  $form['menu']['link']['visible'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Visible'),
+    '#description' => t('If unchecked, this menu link will not be displayed in the menu.'),
+    '#default_value' => $menu_link?->isEnabled() ?? TRUE,
+  ];
+
+  // Replace the menu_ui submit callback with ours so we can add the extra
+  // fields.
+  foreach (array_keys($form['actions']) as $action) {
+    if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+      if (!empty($form['actions'][$action]['#submit'])) {
+        foreach ($form['actions'][$action]['#submit'] as $key => $callback) {
+          if ($callback === 'menu_ui_form_node_form_submit') {
+            $form['actions'][$action]['#submit'][$key] = 'unocha_menus_form_node_form_submit';
+          }
+        }
+      }
+
+    }
+  }
+}
+
+/**
+ * Form submission handler for menu item field on the node form.
+ *
+ * Note: this is a copy of `menu_ui_form_node_form_submit()` that calls our
+ * node_save() function instead of the menu_ui one.
+ *
+ * @see menu_ui_form_node_form_submit()
+ */
+function unocha_menus_form_node_form_submit($form, FormStateInterface $form_state) {
+  $node = $form_state->getFormObject()->getEntity();
+  if (!$form_state->isValueEmpty('menu')) {
+    $values = $form_state->getValue('menu');
+    if (empty($values['enabled'])) {
+      if ($values['entity_id']) {
+        $entity = MenuLinkContent::load($values['entity_id']);
+        $entity->delete();
+      }
+    }
+    elseif (trim($values['title'])) {
+      // Decompose the selected menu parent option into 'menu_name' and
+      // 'parent', if the form used the default parent selection widget.
+      if (!empty($values['menu_parent'])) {
+        [$menu_name, $parent] = explode(':', $values['menu_parent'], 2);
+        $values['menu_name'] = $menu_name;
+        $values['parent'] = $parent;
+      }
+      unocha_menus_node_save($node, $values);
+    }
+  }
+}


### PR DESCRIPTION
Refs: UNO-667

This PR adds the "has response" and "office type" fields to the response content type. It also adds the "Office type" taxonomy vocabulary.

The "has response" field is used to flag a response as having an actual current response. Responses with that flag appear on the map on the homepage.

The "office type" is used as a filter for the regional maps where responses with **only** a liaison office don't appear on the map.

The PR also exposes the `expanded` and `enabled` properties of the menu link items on the node form. `Expanded` should notably selected for regions to show their children in the "where we work" mega menu. 

The `enabled` field is named "visible" in the form and is selected by default. When unchecked, the menu will not appear in the main navigation menu. This can be used to select what responses to feature in the mega menu.

**Office types**

This was tested with the following taxonomy terms added to the `Office type` vocabulary:

- Country office
- HAT
- Liaison office
- Regional office