### PR TITLE
[UNO-670] Add news and stories paragraph type and change stories views

### DIFF
--- a/config/core.entity_form_display.paragraph.news_and_stories.default.yml
+++ b/config/core.entity_form_display.paragraph.news_and_stories.default.yml
@@ -1,0 +1,27 @@
+uuid: 6becc36a-a6ba-4ef4-967f-8497f2bdde57
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.news_and_stories.field_news_and_stories_list
+    - paragraphs.paragraphs_type.news_and_stories
+  module:
+    - viewsreference
+id: paragraph.news_and_stories.default
+targetEntityType: paragraph
+bundle: news_and_stories
+mode: default
+content:
+  field_news_and_stories_list:
+    type: viewsreference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.news_and_stories.default.yml
+++ b/config/core.entity_view_display.paragraph.news_and_stories.default.yml
@@ -1,0 +1,27 @@
+uuid: 30d2f2cf-fd3c-4d0d-bec9-af8663af208a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.news_and_stories.field_news_and_stories_list
+    - paragraphs.paragraphs_type.news_and_stories
+  module:
+    - viewsreference
+id: paragraph.news_and_stories.default
+targetEntityType: paragraph
+bundle: news_and_stories
+mode: default
+content:
+  field_news_and_stories_list:
+    type: viewsreference_formatter
+    label: hidden
+    settings:
+      plugin_types:
+        block: block
+        default: 0
+        page: 0
+        feed: 0
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/field.field.paragraph.news_and_stories.field_news_and_stories_list.yml
+++ b/config/field.field.paragraph.news_and_stories.field_news_and_stories_list.yml
@@ -1,0 +1,54 @@
+uuid: 59d5ad33-627b-4b50-ba6b-68ec87054dac
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_news_and_stories_list
+    - paragraphs.paragraphs_type.news_and_stories
+    - views.view.stories
+  module:
+    - viewsreference
+id: paragraph.news_and_stories.field_news_and_stories_list
+field_name: field_news_and_stories_list
+entity_type: paragraph
+bundle: news_and_stories
+label: 'News and Stories list'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    display_id: block_2
+    data: 'a:5:{s:8:"argument";N;s:5:"title";N;s:5:"limit";N;s:5:"pager";N;s:6:"offset";N;}'
+    target_uuid: a6a942f0-5613-4349-b330-78b17295967d
+default_value_callback: ''
+settings:
+  handler: 'default:view'
+  handler_settings:
+    target_bundles: null
+    auto_create: 0
+  plugin_types:
+    block: block
+    default: 0
+    page: 0
+    feed: 0
+  preselect_views:
+    stories: stories
+    content: 0
+    events: 0
+    files: 0
+    frontpage: 0
+    media: 0
+    media_library: 0
+    redirect: 0
+    regions: 0
+    responses: 0
+    user_admin_people: 0
+    watchdog: 0
+  enabled_settings:
+    argument: 0
+    title: 0
+    limit: 0
+    pager: 0
+    offset: 0
+field_type: viewsreference

--- a/config/field.storage.paragraph.field_news_and_stories_list.yml
+++ b/config/field.storage.paragraph.field_news_and_stories_list.yml
@@ -1,0 +1,21 @@
+uuid: f3b266bd-39a9-4f3c-8340-7933cdc670af
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - views
+    - viewsreference
+id: paragraph.field_news_and_stories_list
+field_name: field_news_and_stories_list
+entity_type: paragraph
+type: viewsreference
+settings:
+  target_type: view
+module: viewsreference
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.news_and_stories.yml
+++ b/config/paragraphs.paragraphs_type.news_and_stories.yml
@@ -1,0 +1,10 @@
+uuid: fec4ed6f-d7c6-4268-a297-9770763a85dd
+langcode: en
+status: true
+dependencies: {  }
+id: news_and_stories
+label: 'News and Stories'
+icon_uuid: null
+icon_default: null
+description: 'Displays a list of news and stories.'
+behavior_plugins: {  }

--- a/config/views.view.stories.yml
+++ b/config/views.view.stories.yml
@@ -178,310 +178,10 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  page__briefings:
-    id: page__briefings
-    display_title: Briefings
-    display_plugin: page
-    position: 1
-    display_options:
-      title: Briefings
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: '<p class="empty-results">No news and stories found for the selected filters.</p>'
-          tokenize: false
-      filters:
-        status:
-          id: status
-          table: node_field_data
-          field: status
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
-          value: '1'
-          group: 1
-          expose:
-            operator: ''
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          value:
-            story: story
-          group: 1
-        field_story_type_target_id_verf:
-          id: field_story_type_target_id_verf
-          table: node__field_story_type
-          field: field_story_type_target_id_verf
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: verf
-          operator: in
-          value:
-            324: '324'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: field_story_type_target_id_verf_op
-            label: 'Story type'
-            description: ''
-            use_operator: false
-            operator: field_story_type_target_id_verf_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            reduce: 0
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          verf_target_bundles:
-            story_type: story_type
-            country: '0'
-            event_type: '0'
-            regional_offices: '0'
-            response_type: '0'
-            theme: '0'
-          show_unpublished: 0
-        field_country_target_id_verf:
-          id: field_country_target_id_verf
-          table: node__field_country
-          field: field_country_target_id_verf
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: verf
-          operator: in
-          value: {  }
-          group: 2
-          exposed: true
-          expose:
-            operator_id: field_country_target_id_verf_op
-            label: Country
-            description: ''
-            use_operator: false
-            operator: field_country_target_id_verf_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: country
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            reduce: 0
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          verf_target_bundles:
-            country: country
-            event_type: '0'
-            regional_offices: '0'
-            response_type: '0'
-            story_type: '0'
-            theme: '0'
-          show_unpublished: 0
-        field_response_target_id_verf:
-          id: field_response_target_id_verf
-          table: node__field_response
-          field: field_response_target_id_verf
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: verf
-          operator: in
-          value: {  }
-          group: 2
-          exposed: true
-          expose:
-            operator_id: field_response_target_id_verf_op
-            label: Response
-            description: ''
-            use_operator: false
-            operator: field_response_target_id_verf_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: response
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            reduce: 0
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          verf_target_bundles:
-            response: response
-            basic: '0'
-            event: '0'
-            region: '0'
-            resource: '0'
-            story: '0'
-          show_unpublished: 0
-        field_region_target_id_verf:
-          id: field_region_target_id_verf
-          table: node__field_region
-          field: field_region_target_id_verf
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: verf
-          operator: in
-          value: {  }
-          group: 2
-          exposed: true
-          expose:
-            operator_id: field_region_target_id_verf_op
-            label: Region
-            description: ''
-            use_operator: false
-            operator: field_region_target_id_verf_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: region
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            reduce: 0
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          verf_target_bundles:
-            region: region
-            basic: '0'
-            event: '0'
-            resource: '0'
-            response: '0'
-            story: '0'
-          show_unpublished: 0
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-          2: OR
-      query:
-        type: views_query
-        options:
-          query_comment: ''
-          disable_sql_rewrite: false
-          distinct: true
-          replica: false
-          query_tags: {  }
-      defaults:
-        empty: false
-        query: false
-        title: false
-        relationships: false
-        filters: false
-        filter_groups: false
-        header: false
-      relationships: {  }
-      display_description: ''
-      header:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: result
-          empty: false
-          content: 'Displaying @start - @end of @total'
-      display_extenders: {  }
-      path: latest/news-and-stories/briefings
-      menu:
-        type: tab
-        title: Briefings
-        description: ''
-        weight: 3
-        expanded: false
-        menu_name: main
-        parent: ''
-        context: '0'
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - 'user.node_grants:view'
-        - user.permissions
-      tags:
-        - 'config:views.view.stories'
-        - node_list
-        - taxonomy_term_list
-  page__latest:
-    id: page__latest
+  block_2:
+    id: block_2
     display_title: Latest
-    display_plugin: page
+    display_plugin: block
     position: 1
     display_options:
       title: 'Latest news and stories'
@@ -754,21 +454,6 @@ display:
           empty: false
           content: 'Displaying @start - @end of @total'
       display_extenders: {  }
-      path: latest/news-and-stories
-      menu:
-        type: 'default tab'
-        title: Latest
-        description: ''
-        weight: 0
-        expanded: false
-        menu_name: main
-        parent: ''
-        context: '0'
-      tab_options:
-        type: none
-        title: ''
-        description: ''
-        weight: 0
     cache_metadata:
       max-age: -1
       contexts:
@@ -782,11 +467,11 @@ display:
         - 'config:views.view.stories'
         - node_list
         - taxonomy_term_list
-  page__news:
-    id: page__news
-    display_title: News
-    display_plugin: page
-    position: 1
+  block_3:
+    id: block_3
+    display_title: 'News and Briefings'
+    display_plugin: block
+    position: 2
     display_options:
       title: News
       empty:
@@ -833,6 +518,7 @@ display:
           plugin_id: verf
           operator: in
           value:
+            324: '324'
             65: '65'
           group: 1
           exposed: false
@@ -870,6 +556,7 @@ display:
             story_type: story_type
             country: '0'
             event_type: '0'
+            office_type: '0'
             regional_offices: '0'
             response_type: '0'
             theme: '0'
@@ -1059,16 +746,6 @@ display:
           empty: false
           content: 'Displaying @start - @end of @total'
       display_extenders: {  }
-      path: latest/news-and-stories/news
-      menu:
-        type: tab
-        title: News
-        description: ''
-        weight: 2
-        expanded: false
-        menu_name: main
-        parent: ''
-        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1082,11 +759,11 @@ display:
         - 'config:views.view.stories'
         - node_list
         - taxonomy_term_list
-  page__stories:
-    id: page__stories
+  block_4:
+    id: block_4
     display_title: Stories
-    display_plugin: page
-    position: 1
+    display_plugin: block
+    position: 3
     display_options:
       title: Stories
       empty:
@@ -1359,16 +1036,6 @@ display:
           empty: false
           content: 'Displaying @start - @end of @total'
       display_extenders: {  }
-      path: latest/news-and-stories/stories
-      menu:
-        type: tab
-        title: Stories
-        description: ''
-        weight: 1
-        expanded: false
-        menu_name: main
-        parent: ''
-        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/html/themes/custom/common_design_subtheme/templates/navigation/menu-local-task--children-menu.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/navigation/menu-local-task--children-menu.html.twig
@@ -17,4 +17,7 @@
 {% if element['#link'].title == 'Publications'|t and element['#active'] is not empty %}
   {% set link = link|merge({'#title': 'Latest'|t}) %}
 {% endif %}
+{% if element['#link'].title == 'News and stories'|t %}
+  {% set link = link|merge({'#title': 'Latest'|t}) %}
+{% endif %}
 <li{{ attributes }}>{{ link }}</li>


### PR DESCRIPTION
Refs: UNO-670

This adds a "News and Stories" paragraph type with a views reference field defaulting to the "Stories" view.

It also changes the "Stories" view to use blocks instead of pages.

So, with that, it's possible to show the list of news and stories via a paragraph on a basic page and use the "children menu" feature to display tabs for the different "news" pages.

**Note:** To use the children menu feature, the "News", "Stories", "Press releases" and "Statements" need to be added as child pages of the "Latest news and stories" page.

**Note:** Because there is path alias pattern for basic pages, the path alias on the node form needs to be set manually (ex: `/latest/stories`.

### Tests

1. Checkout the branch, clear the cache, import the config
2. Create the "Latest news and stories" page, add menu item under "Latest", add a "News and Stories" paragraph type with the "Latest" display, check "Children menu", adjust the path alias as appropriate, save
3. Create the "News" and "Stories" basic page, add a "News and Stories" paragraph type with the proper display. Add a menu item under "Latest > Latest news and stories", adjust the path alias as appropriate.
4. Create/edit the "Press releases" and "Speeches and Statements" pages and ensure they are children of the "Latest news and stories", adjust the path alias as appropriate.