### PR TITLE
[UNO-668] Curated RW river

### DIFF
--- a/config/core.entity_form_display.paragraph.reliefweb_river.default.yml
+++ b/config/core.entity_form_display.paragraph.reliefweb_river.default.yml
@@ -54,13 +54,13 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 5
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_form_display.paragraph.reliefweb_river_curated.default.yml
+++ b/config/core.entity_form_display.paragraph.reliefweb_river_curated.default.yml
@@ -1,0 +1,65 @@
+uuid: 2ee7cdb2-243a-4aed-aaff-5bf91d767ea2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.reliefweb_river_curated.field_limit
+    - field.field.paragraph.reliefweb_river_curated.field_reliefweb_documents
+    - field.field.paragraph.reliefweb_river_curated.field_text
+    - field.field.paragraph.reliefweb_river_curated.field_title
+    - field.field.paragraph.reliefweb_river_curated.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+  module:
+    - paragraph_view_mode
+    - text
+    - unocha_reliefweb
+id: paragraph.reliefweb_river_curated.default
+targetEntityType: paragraph
+bundle: reliefweb_river_curated
+mode: default
+content:
+  field_limit:
+    type: number
+    weight: 2
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_reliefweb_documents:
+    type: reliefweb_document
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  paragraph_view_mode:
+    type: paragraph_view_mode
+    weight: -100
+    region: content
+    settings:
+      view_modes:
+        default: Default
+        cards: Cards
+        default_paginated: 'Default (paginated)'
+        teasers: Teasers
+      default_view_mode: default
+      form_mode_bind: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.reliefweb_river.cards.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_river.cards.yml
@@ -28,6 +28,7 @@ content:
     settings:
       white_label: true
       view_all_link: false
+      paginated: false
       ocha_only: true
     third_party_settings: {  }
     weight: 2

--- a/config/core.entity_view_display.paragraph.reliefweb_river_curated.cards.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_river_curated.cards.yml
@@ -1,14 +1,15 @@
-uuid: ee828711-2d2f-4ce2-bbf9-5a4d13021ef0
+uuid: 0a092f08-3c8f-4c56-97a3-068b2060d06c
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.paragraph.teasers
-    - field.field.paragraph.reliefweb_river.field_reliefweb_river
-    - field.field.paragraph.reliefweb_river.field_text
-    - field.field.paragraph.reliefweb_river.field_title
-    - field.field.paragraph.reliefweb_river.paragraph_view_mode
-    - paragraphs.paragraphs_type.reliefweb_river
+    - core.entity_view_mode.paragraph.cards
+    - field.field.paragraph.reliefweb_river_curated.field_limit
+    - field.field.paragraph.reliefweb_river_curated.field_reliefweb_documents
+    - field.field.paragraph.reliefweb_river_curated.field_text
+    - field.field.paragraph.reliefweb_river_curated.field_title
+    - field.field.paragraph.reliefweb_river_curated.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river_curated
   module:
     - layout_builder
     - text
@@ -17,19 +18,19 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-id: paragraph.reliefweb_river.teasers
+id: paragraph.reliefweb_river_curated.cards
 targetEntityType: paragraph
-bundle: reliefweb_river
-mode: teasers
+bundle: reliefweb_river_curated
+mode: cards
 content:
-  field_reliefweb_river:
-    type: reliefweb_river
+  field_reliefweb_documents:
+    type: reliefweb_document_river
     label: hidden
     settings:
       white_label: true
+      ocha_only: true
       view_all_link: false
       paginated: false
-      ocha_only: true
     third_party_settings: {  }
     weight: 2
     region: content
@@ -49,4 +50,5 @@ content:
     weight: 0
     region: content
 hidden:
+  field_limit: true
   paragraph_view_mode: true

--- a/config/core.entity_view_display.paragraph.reliefweb_river_curated.default.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_river_curated.default.yml
@@ -1,0 +1,48 @@
+uuid: f00193f5-76d9-4867-a421-a7d1bf506c6b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.reliefweb_river_curated.field_limit
+    - field.field.paragraph.reliefweb_river_curated.field_reliefweb_documents
+    - field.field.paragraph.reliefweb_river_curated.field_text
+    - field.field.paragraph.reliefweb_river_curated.field_title
+    - field.field.paragraph.reliefweb_river_curated.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+  module:
+    - text
+    - unocha_reliefweb
+id: paragraph.reliefweb_river_curated.default
+targetEntityType: paragraph
+bundle: reliefweb_river_curated
+mode: default
+content:
+  field_reliefweb_documents:
+    type: reliefweb_document_river
+    label: hidden
+    settings:
+      white_label: true
+      ocha_only: true
+      view_all_link: false
+      paginated: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_limit: true
+  paragraph_view_mode: true

--- a/config/core.entity_view_display.paragraph.reliefweb_river_curated.default_paginated.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_river_curated.default_paginated.yml
@@ -1,0 +1,54 @@
+uuid: 4c0439f4-61d1-4908-9c77-ec93d307d1d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.default_paginated
+    - field.field.paragraph.reliefweb_river_curated.field_limit
+    - field.field.paragraph.reliefweb_river_curated.field_reliefweb_documents
+    - field.field.paragraph.reliefweb_river_curated.field_text
+    - field.field.paragraph.reliefweb_river_curated.field_title
+    - field.field.paragraph.reliefweb_river_curated.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+  module:
+    - layout_builder
+    - text
+    - unocha_reliefweb
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.reliefweb_river_curated.default_paginated
+targetEntityType: paragraph
+bundle: reliefweb_river_curated
+mode: default_paginated
+content:
+  field_reliefweb_documents:
+    type: reliefweb_document_river
+    label: hidden
+    settings:
+      white_label: '1'
+      ocha_only: '1'
+      paginated: '1'
+      view_all_link: 0
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_limit: true
+  paragraph_view_mode: true

--- a/config/core.entity_view_display.paragraph.reliefweb_river_curated.teasers.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_river_curated.teasers.yml
@@ -1,14 +1,15 @@
-uuid: ee828711-2d2f-4ce2-bbf9-5a4d13021ef0
+uuid: 56d99469-180b-49d3-acab-95000fe9153f
 langcode: en
 status: true
 dependencies:
   config:
     - core.entity_view_mode.paragraph.teasers
-    - field.field.paragraph.reliefweb_river.field_reliefweb_river
-    - field.field.paragraph.reliefweb_river.field_text
-    - field.field.paragraph.reliefweb_river.field_title
-    - field.field.paragraph.reliefweb_river.paragraph_view_mode
-    - paragraphs.paragraphs_type.reliefweb_river
+    - field.field.paragraph.reliefweb_river_curated.field_limit
+    - field.field.paragraph.reliefweb_river_curated.field_reliefweb_documents
+    - field.field.paragraph.reliefweb_river_curated.field_text
+    - field.field.paragraph.reliefweb_river_curated.field_title
+    - field.field.paragraph.reliefweb_river_curated.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river_curated
   module:
     - layout_builder
     - text
@@ -17,19 +18,19 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-id: paragraph.reliefweb_river.teasers
+id: paragraph.reliefweb_river_curated.teasers
 targetEntityType: paragraph
-bundle: reliefweb_river
+bundle: reliefweb_river_curated
 mode: teasers
 content:
-  field_reliefweb_river:
-    type: reliefweb_river
+  field_reliefweb_documents:
+    type: reliefweb_document_river
     label: hidden
     settings:
       white_label: true
+      ocha_only: true
       view_all_link: false
       paginated: false
-      ocha_only: true
     third_party_settings: {  }
     weight: 2
     region: content
@@ -49,4 +50,5 @@ content:
     weight: 0
     region: content
 hidden:
+  field_limit: true
   paragraph_view_mode: true

--- a/config/field.field.paragraph.reliefweb_river_curated.field_limit.yml
+++ b/config/field.field.paragraph.reliefweb_river_curated.field_limit.yml
@@ -1,0 +1,25 @@
+uuid: a70433a0-2643-4ca1-9512-0568a794ce86
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_limit
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+id: paragraph.reliefweb_river_curated.field_limit
+field_name: field_limit
+entity_type: paragraph
+bundle: reliefweb_river_curated
+label: Limit
+description: 'Maximum number of documents to show at once in the list.'
+required: true
+translatable: true
+default_value:
+  -
+    value: 5
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.field.paragraph.reliefweb_river_curated.field_reliefweb_documents.yml
+++ b/config/field.field.paragraph.reliefweb_river_curated.field_reliefweb_documents.yml
@@ -1,0 +1,22 @@
+uuid: a0501eab-e0c7-4d24-9abf-209525bebaac
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_reliefweb_documents
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+  module:
+    - unocha_reliefweb
+id: paragraph.reliefweb_river_curated.field_reliefweb_documents
+field_name: field_reliefweb_documents
+entity_type: paragraph
+bundle: reliefweb_river_curated
+label: Documents
+description: 'ReliefWeb document URLs.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  river: updates
+field_type: reliefweb_document

--- a/config/field.field.paragraph.reliefweb_river_curated.field_text.yml
+++ b/config/field.field.paragraph.reliefweb_river_curated.field_text.yml
@@ -1,0 +1,26 @@
+uuid: 37699d21-70fb-46b1-8022-5c3f96b9986f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - text_editor_simple
+id: paragraph.reliefweb_river_curated.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: reliefweb_river_curated
+label: Text
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/field.field.paragraph.reliefweb_river_curated.field_title.yml
+++ b/config/field.field.paragraph.reliefweb_river_curated.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 4c7fdc9e-135e-43df-aa4a-381d25bd8ca3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+id: paragraph.reliefweb_river_curated.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: reliefweb_river_curated
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.reliefweb_river_curated.paragraph_view_mode.yml
+++ b/config/field.field.paragraph.reliefweb_river_curated.paragraph_view_mode.yml
@@ -1,0 +1,21 @@
+uuid: 16c84c85-b42f-4a8b-94a4-b09982ed2116
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.paragraph_view_mode
+    - paragraphs.paragraphs_type.reliefweb_river_curated
+  module:
+    - paragraph_view_mode
+id: paragraph.reliefweb_river_curated.paragraph_view_mode
+field_name: paragraph_view_mode
+entity_type: paragraph
+bundle: reliefweb_river_curated
+label: 'Paragraph view mode'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: paragraph_view_mode

--- a/config/field.storage.paragraph.field_reliefweb_documents.yml
+++ b/config/field.storage.paragraph.field_reliefweb_documents.yml
@@ -1,0 +1,19 @@
+uuid: f6afc0e3-4e89-4f97-938c-ca36e10fd2ae
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - unocha_reliefweb
+id: paragraph.field_reliefweb_documents
+field_name: field_reliefweb_documents
+entity_type: paragraph
+type: reliefweb_document
+settings: {  }
+module: unocha_reliefweb
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.reliefweb_river_curated.yml
+++ b/config/paragraphs.paragraphs_type.reliefweb_river_curated.yml
@@ -1,0 +1,10 @@
+uuid: c586820d-3b51-4972-9289-85abe40773a0
+langcode: en
+status: true
+dependencies: {  }
+id: reliefweb_river_curated
+label: 'ReliefWeb - River - Curated'
+icon_uuid: null
+icon_default: null
+description: 'Manually curated list of ReliefWeb documents.'
+behavior_plugins: {  }

--- a/html/modules/custom/unocha_reliefweb/config/schema/unocha_reliefweb.schema.yml
+++ b/html/modules/custom/unocha_reliefweb/config/schema/unocha_reliefweb.schema.yml
@@ -30,18 +30,36 @@ unocha_reliefweb.settings:
       type: boolean
       label: 'Also use the "redirects" field for URL lookups.'
 
+field.field_settings.reliefweb_document:
+  type: mapping
+  mapping:
+    river:
+      type: string
+      label: 'Allowed river'
+
 field.field_settings.reliefweb_river:
   type: mapping
   mapping:
-    url:
+    rivers:
       type: string
-      label: 'ReliefWeb River URL'
-    title:
-      type: string
-      label: 'River Title'
-    limit:
-      type: integer
-      label: 'Maximum number of documents to request'
+      label: 'Allowed rivers'
+
+field.formatter.settings.reliefweb_document_river:
+  type: mapping
+  label: 'ReliefWeb River formatter settings'
+  mapping:
+    white_label:
+      type: boolean
+      label: 'Convert ReliefWeb URLs to UNOCHA URLs'
+    ocha_only:
+      type: boolean
+      label: 'Only include OCHA documents'
+    view_all_link:
+      type: boolean
+      label: 'Display a link to the full list of articles'
+    paginated:
+      type: boolean
+      label: 'User a pager to navigate the list'
 
 field.formatter.settings.reliefweb_river:
   type: mapping
@@ -50,6 +68,9 @@ field.formatter.settings.reliefweb_river:
     white_label:
       type: boolean
       label: 'Convert ReliefWeb URLs to UNOCHA URLs'
+    ocha_only:
+      type: boolean
+      label: 'Only include OCHA documents'
     view_all_link:
       type: boolean
       label: 'Display a link to the full list of articles'

--- a/html/modules/custom/unocha_reliefweb/src/Plugin/Field/FieldFormatter/ReliefWebDocumentRiver.php
+++ b/html/modules/custom/unocha_reliefweb/src/Plugin/Field/FieldFormatter/ReliefWebDocumentRiver.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\unocha_reliefweb\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+
+/**
+ * Plugin implementation of the 'reliefweb_document_river' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "reliefweb_document_river",
+ *   label = @Translation("ReliefWeb Document River"),
+ *   field_types = {
+ *     "reliefweb_document"
+ *   }
+ * )
+ */
+class ReliefWebDocumentRiver extends ReliefWebRiver {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $white_label = !empty($this->getSetting('white_label'));
+    $paginated = !empty($this->getSetting('paginated'));
+    $river = $this->getFieldSetting('river');
+
+    // Retrieve the limit from a potential river limit field on the parent
+    // entity.
+    $entity = $items->getEntity();
+    if ($entity->hasField('field_limit')) {
+      $limit = $entity->field_limit?->value;
+    }
+    $limit = $limit ?? 5;
+
+    // Get the list of RW document URLs.
+    $urls = [];
+    /** @var \Drupal\unocha_reliefweb\Plugin\Field\FieldType\ReliefWebRiver $item */
+    foreach ($items as $item) {
+      $url = $item->getUrl();
+      if (!empty($url)) {
+        $urls[] = $url;
+      }
+    }
+    if (empty($urls)) {
+      return [];
+    }
+
+    $pager_id = NULL;
+    if ($paginated) {
+      $pager_id = $this->pagerManager->getMaxPagerElementId() + 1;
+    }
+
+    $offset = (isset($pager_id) ? $this->pagerManager->findPage($pager_id) : 0) * $limit;
+
+    $data = $this->getReliefWebDocuments()->getRiverDataFromDocumentUrls($river, $urls, $limit, $offset, NULL, $white_label);
+    if (empty($data['entities'])) {
+      return [];
+    }
+
+    $elements = [
+      '#theme' => 'unocha_reliefweb_river__' . $this->viewMode,
+      '#resource' => $data['river']['resource'],
+      '#title' => '',
+      '#entities' => $data['entities'],
+    ];
+
+    // Initialize the pager.
+    if (isset($pager_id) && !empty($data['total'])) {
+      $pager = $this->pagerManager->createPager($data['total'], $limit, $pager_id);
+
+      // Add the pager.
+      $elements['#pager'] = [
+        '#type' => 'pager',
+        '#element' => $pager_id,
+      ];
+
+      // Add the results.
+      $elements['#results'] = $this->getRiverResults($pager, count($data['entities']));
+    }
+
+    return $elements;
+  }
+
+}

--- a/html/modules/custom/unocha_reliefweb/src/Plugin/Field/FieldFormatter/ReliefWebRiver.php
+++ b/html/modules/custom/unocha_reliefweb/src/Plugin/Field/FieldFormatter/ReliefWebRiver.php
@@ -172,7 +172,7 @@ class ReliefWebRiver extends FormatterBase {
         $pager_id = $this->pagerManager->getMaxPagerElementId() + 1;
       }
 
-      $offset = isset($pager_id) ? $this->pagerManager->findPage($pager_id) : 0;
+      $offset = (isset($pager_id) ? $this->pagerManager->findPage($pager_id) : 0) * $limit;
 
       $data = $this->getReliefWebDocuments()->getRiverDataFromUrl($url, $limit, $offset, NULL, $white_label);
       if (empty($data['entities'])) {

--- a/html/modules/custom/unocha_reliefweb/src/Plugin/Validation/Constraint/ReliefWebDocumentUrlConstraint.php
+++ b/html/modules/custom/unocha_reliefweb/src/Plugin/Validation/Constraint/ReliefWebDocumentUrlConstraint.php
@@ -33,6 +33,6 @@ class ReliefWebDocumentUrlConstraint extends Constraint {
    *
    * @var string
    */
-  public $mustBeValidRiverUrl = 'The %field is not a valid ReliefWeb Document URL such as https://reliefweb.int/report/country/title';
+  public $mustBeValidDocumentUrl = 'The %field is not a valid ReliefWeb Document URL such as https://reliefweb.int/report/country/title';
 
 }

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--reliefweb-river-curated.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--reliefweb-river-curated.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/uno-river') }}
+
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'paragraph--type--reliefweb-river',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Refs: UNO-668

This PR adds a new "ReliefWeb - River - Curated" paragraph type which allows to create a list of RW documents by providing individual document URLs.

### Notes

It uses the same template as the the normal RW river paragraph type so no styling changes. 

The river also uses the same ordering by publication date than automated rivers so the order of the RW document URLs in the form doesn't matter.

The PR includes a few fixes for the rivers notably for the pagination.

### Tests

1. Checkout, clear the cache, import the config
2. Edit a page (ex: press releases page)
3. Add a "ReliefWeb - River - Curated" paragraph type, add some OCHA documents on https://reliefweb.int, select default (paginated)  as view mode to be able to confirm the list contains all the selected documents.
4. Save and check that the list contains the proper documents.