### PR TITLE
[UNO-684] Events

### DIFF
--- a/config/field.field.paragraph.events.field_events.yml
+++ b/config/field.field.paragraph.events.field_events.yml
@@ -19,7 +19,7 @@ translatable: true
 default_value:
   -
     display_id: upcoming_events
-    data: 'a:5:{s:5:"title";N;s:5:"pager";N;s:6:"offset";N;s:8:"argument";N;s:5:"limit";N;}'
+    data: 'a:5:{s:8:"argument";N;s:5:"title";N;s:5:"limit";N;s:5:"pager";N;s:6:"offset";N;}'
     target_uuid: e2493c2d-7b66-4f27-a5a1-a27b2e7dedd2
 default_value_callback: ''
 settings:
@@ -45,10 +45,11 @@ settings:
     responses: 0
     stories: 0
     user_admin_people: 0
+    watchdog: 0
   enabled_settings:
+    argument: argument
+    limit: limit
+    pager: pager
     title: 0
-    pager: 0
     offset: 0
-    argument: 0
-    limit: 0
 field_type: viewsreference

--- a/config/views.view.events.yml
+++ b/config/views.view.events.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.card
     - node.type.event
     - taxonomy.vocabulary.country
     - taxonomy.vocabulary.event_type
@@ -160,7 +160,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: teaser
+          view_mode: card
       query:
         type: views_query
         options:

--- a/config/views.view.events.yml
+++ b/config/views.view.events.yml
@@ -575,6 +575,42 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+      arguments:
+        field_event_type_target_id:
+          id: field_event_type_target_id
+          table: node__field_event_type
+          field: field_event_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: 'Event type'
+          plugin_id: numeric
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         status:
           id: status
@@ -649,6 +685,7 @@ display:
         title: false
         relationships: false
         sorts: false
+        arguments: false
         filters: false
         filter_groups: false
       relationships: {  }
@@ -659,6 +696,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Menu\MenuLinkInterface;
 use Drupal\Core\Menu\MenuLinkTreeElement;
@@ -338,4 +339,84 @@ function unocha_paragraphs_get_nodes_from_menu_links(array $menu_links) {
       ->loadMultiple($node_ids);
   }
   return [];
+}
+
+/**
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
+ *
+ * Show a list of event type terms as options for the view argument of
+ * the events paragraph type's field_events.
+ */
+function unocha_paragraphs_field_widget_single_element_viewsreference_select_form_alter(array &$element, FormStateInterface $form_state, array $context) {
+  if (isset($context['items'], $element['options']) && $context['items']->getName() === 'field_events') {
+    $entity_type_manager = \Drupal::entityTypeManager();
+
+    $element['options']['#type'] = 'fieldset';
+
+    // Show the available event types to pass as argument to filter the view.
+    if (isset($element['options']['argument'])) {
+      $entity_type_manager = \Drupal::entityTypeManager();
+
+      $element['options']['argument']['#title'] = t('Event type');
+      $element['options']['argument']['#weight'] = -2;
+
+      $terms = $entity_type_manager->getStorage('taxonomy_term')->loadByProperties([
+        'vid' => 'event_type',
+      ]);
+
+      if (!empty($terms)) {
+        $options = array_map(function ($term) {
+          return $term->label();
+        }, $terms);
+
+        $element['options']['argument']['#type'] = 'select';
+        $element['options']['argument']['#options'] = $options;
+        $element['options']['argument']['#empty_value'] = '';
+        $element['options']['argument']['#empty_option'] = t('All');
+
+        // Retrieve the list of view display IDs that accept an event type
+        // term as argument. We'll only show the argument field for those.
+        $event_type_condition = [];
+        if (isset($element['display_id'])) {
+          $view_id = $element['target_id']['#default_value'];
+          $view = $entity_type_manager->getStorage('view')->load($view_id);
+          if (isset($view)) {
+            foreach ($element['display_id']['#options'] as $display_id => $label) {
+              $display = $view->getDisplay($display_id);
+              if (!empty($display['display_options']['arguments']['field_event_type_target_id'])) {
+                if (!empty($event_type_condition)) {
+                  $event_type_condition[] = 'or';
+                }
+                $event_type_condition[] = ['value' => $display_id];
+              }
+            }
+          }
+        }
+        if (!empty($event_type_condition)) {
+          $element['options']['argument']['#states']['visible'] = [
+            ':input[name="field_events[0][display_id]"]' => $event_type_condition,
+          ];
+        }
+      }
+      else {
+        $element['options']['argument']['#access'] = FALSE;
+      }
+    }
+
+    // Limit the pagination options.
+    if (isset($element['options']['pager']['#options'])) {
+      $element['options']['pager']['#weight'] = -1;
+      $element['options']['pager']['#options'] = [
+        'none' => t('Display all'),
+        'some' => t('Fixed number in total'),
+        'full' => t('Fixed number per page'),
+      ];
+
+      if (isset($element['options']['limit'])) {
+        $element['options']['limit']['#states']['invisible'] = [
+          ':input[name="field_events[0][options][pager]"]' => ['value' => 'none'],
+        ];
+      }
+    }
+  }
 }

--- a/html/themes/custom/common_design_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/styles.css
@@ -403,7 +403,7 @@
   margin-bottom: 2rem;
  }
 
-@media (min-width: 768px) {
+@media screen and (min-width: 768px) {
   .view-filters {
     margin-bottom: 4rem;
   }
@@ -450,7 +450,7 @@
   }
 }
 
-@media (min-width: 767px) {
+@media screen and (min-width: 768px) {
   .views-exposed-form.cd-form .cd-form--inline > .cd-form__item {
     flex: 1 0 20%;
     max-width: 20%;
@@ -459,6 +459,15 @@
 
   .views-exposed-form.cd-form .cd-form--inline .form-actions {
     padding-inline-end: 0;
+  }
+}
+
+.pager {
+  margin-top: 3rem;
+}
+@media screen and (min-width: 768px) {
+  .pager {
+    margin-top: 6rem;
   }
 }
 


### PR DESCRIPTION
Refs: UNO-684

This adds a contextual filter for the "upcoming events" view block that can be used to filter the list of events based on the event type (default  = no filter = all events).

This goes with some form manipulations for the events field of the events paragraph type to show a dropdown to select the event type when "upcoming events" is selected.

It also exposes pagination settings so that editors can select whether to show all events, all events with pagination or a limited number of events.

**Note**

It's possible to add other blocks to the "events" view and enable the selection of the event type by adding the contextual filter as the "upcoming events" block's one.

### Tests

1. Checkout, clear the cache and import the config
2. Create some events
3. Edit a page and add an "events" paragraph type
4. Try different options and check that you get what you expect