### PR TITLE
[UNO-695] Order tabs by menu weight

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -198,14 +198,14 @@ function common_design_subtheme_preprocess_field__field_children_menu(array &$va
     $content = [
       '#theme' => 'menu_local_tasks__children_menu',
     ];
-    foreach ($links as $index => $link) {
+    foreach ($links as $link) {
       $content['#primary'][] = [
         '#theme' => 'menu_local_task__children_menu',
         '#link' => [
           'title' => $link->getTitle(),
           'url' => $link->getUrlObject(),
         ],
-        '#weight' => $index,
+        '#weight' => $link->getWeight(),
         '#active' => $current_menu_link->getPluginId() === $link->getPluginId(),
       ];
     }


### PR DESCRIPTION
Refs: UNO-695

This uses the menu weight to order the tabs for example on the News and stories page. So order is the same as the order of the children menu links and can be adjusted in `/admin/structure/menu/manage/main` or by changing the weight in the children node forms.