### PR TITLE
[UNO-702] Allow selection of top sectors

### DIFF
--- a/config/field.field.paragraph.donors.field_country_donors.yml
+++ b/config/field.field.paragraph.donors.field_country_donors.yml
@@ -19,5 +19,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_providers: 'cbpf,fts,oct'
-  allowed_figure_ids: 'top-donors,earmarked-donors,unearmarked-donors'
+  allowed_figure_ids: 'top-donors,top-sectors,earmarked-donors,unearmarked-donors'
 field_type: key_figure

--- a/config/field.field.paragraph.donors.field_presence_donors.yml
+++ b/config/field.field.paragraph.donors.field_presence_donors.yml
@@ -19,5 +19,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_providers: 'cbpf,fts,oct'
-  allowed_figure_ids: 'top-donors,earmarked-donors,unearmarked-donors'
+  allowed_figure_ids: 'top-donors,top-sectors,earmarked-donors,unearmarked-donors'
 field_type: key_figure_presence


### PR DESCRIPTION
Refs: UNO-702

The config was missing the `top-sectors` in the allowed list of figures.