### PR TITLE
[UNO-703] Regional figures

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -22,6 +22,9 @@
     },
     "drupal/xmlsitemap": {
       "https://www.drupal.org/project/xmlsitemap/issues/3323148": "https://git.drupalcode.org/project/xmlsitemap/-/merge_requests/23.diff"
+    },
+    "unocha/ocha_key_figures": {
+      "Temporary fix for OCHA presence figures": "patches/ocha_key_figures-ocha-presence-figures.patch"
     }
   }
 }

--- a/config/core.entity_form_display.paragraph.figures.default.yml
+++ b/config/core.entity_form_display.paragraph.figures.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.figures.field_figures
     - field.field.paragraph.figures.field_figures_footnote
+    - field.field.paragraph.figures.field_presence_figures
     - field.field.paragraph.figures.field_reliefweb_document
     - field.field.paragraph.figures.field_text
     - field.field.paragraph.figures.field_title
@@ -29,15 +30,22 @@ content:
     third_party_settings: {  }
   field_figures_footnote:
     type: string_textarea
-    weight: 4
+    weight: 6
     region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_presence_figures:
+    type: key_figure_presence
+    weight: 4
+    region: content
+    settings:
+      allow_manual: 'yes'
+    third_party_settings: {  }
   field_reliefweb_document:
     type: reliefweb_document
-    weight: 5
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -72,13 +80,13 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 9
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 6
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_view_display.paragraph.figures.default.yml
+++ b/config/core.entity_view_display.paragraph.figures.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.figures.field_figures
     - field.field.paragraph.figures.field_figures_footnote
+    - field.field.paragraph.figures.field_presence_figures
     - field.field.paragraph.figures.field_reliefweb_document
     - field.field.paragraph.figures.field_text
     - field.field.paragraph.figures.field_title
@@ -35,6 +36,17 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 5
+    region: content
+  field_presence_figures:
+    type: key_figure_presence
+    label: hidden
+    settings:
+      format: decimal
+      precision: 1
+      percentage: 'yes'
+      currency_symbol: 'yes'
+    third_party_settings: {  }
     weight: 3
     region: content
   field_reliefweb_document:
@@ -44,7 +56,7 @@ content:
       white_label: true
       ocha_only: true
     third_party_settings: {  }
-    weight: 4
+    weight: 6
     region: content
   field_text:
     type: text_default

--- a/config/core.entity_view_display.paragraph.figures.figures.yml
+++ b/config/core.entity_view_display.paragraph.figures.figures.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.paragraph.figures
     - field.field.paragraph.figures.field_figures
     - field.field.paragraph.figures.field_figures_footnote
+    - field.field.paragraph.figures.field_presence_figures
     - field.field.paragraph.figures.field_reliefweb_document
     - field.field.paragraph.figures.field_text
     - field.field.paragraph.figures.field_title
@@ -41,6 +42,17 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 5
+    region: content
+  field_presence_figures:
+    type: key_figure_presence
+    label: hidden
+    settings:
+      format: decimal
+      precision: 1
+      percentage: 'yes'
+      currency_symbol: 'yes'
+    third_party_settings: {  }
     weight: 3
     region: content
   field_reliefweb_document:
@@ -50,7 +62,7 @@ content:
       white_label: true
       ocha_only: true
     third_party_settings: {  }
-    weight: 4
+    weight: 6
     region: content
   field_text:
     type: text_default

--- a/config/core.entity_view_display.paragraph.figures.figures_compact_long.yml
+++ b/config/core.entity_view_display.paragraph.figures.figures_compact_long.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.paragraph.figures_compact_long
     - field.field.paragraph.figures.field_figures
     - field.field.paragraph.figures.field_figures_footnote
+    - field.field.paragraph.figures.field_presence_figures
     - field.field.paragraph.figures.field_reliefweb_document
     - field.field.paragraph.figures.field_text
     - field.field.paragraph.figures.field_title
@@ -41,6 +42,17 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 5
+    region: content
+  field_presence_figures:
+    type: key_figure_presence
+    label: hidden
+    settings:
+      format: long
+      precision: 2
+      percentage: 'yes'
+      currency_symbol: 'yes'
+    third_party_settings: {  }
     weight: 3
     region: content
   field_reliefweb_document:
@@ -50,7 +62,7 @@ content:
       white_label: true
       ocha_only: true
     third_party_settings: {  }
-    weight: 4
+    weight: 6
     region: content
   field_text:
     type: text_default

--- a/config/core.entity_view_display.paragraph.figures.figures_compact_short.yml
+++ b/config/core.entity_view_display.paragraph.figures.figures_compact_short.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.paragraph.figures_compact_short
     - field.field.paragraph.figures.field_figures
     - field.field.paragraph.figures.field_figures_footnote
+    - field.field.paragraph.figures.field_presence_figures
     - field.field.paragraph.figures.field_reliefweb_document
     - field.field.paragraph.figures.field_text
     - field.field.paragraph.figures.field_title
@@ -41,6 +42,17 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 5
+    region: content
+  field_presence_figures:
+    type: key_figure_presence
+    label: hidden
+    settings:
+      format: short
+      precision: 2
+      percentage: 'yes'
+      currency_symbol: 'yes'
+    third_party_settings: {  }
     weight: 3
     region: content
   field_reliefweb_document:
@@ -50,7 +62,7 @@ content:
       white_label: true
       ocha_only: true
     third_party_settings: {  }
-    weight: 4
+    weight: 6
     region: content
   field_text:
     type: text_default

--- a/config/field.field.paragraph.figures.field_figures.yml
+++ b/config/field.field.paragraph.figures.field_figures.yml
@@ -11,8 +11,8 @@ id: paragraph.figures.field_figures
 field_name: field_figures
 entity_type: paragraph
 bundle: figures
-label: Figures
-description: ''
+label: 'Country figures'
+description: 'Use this field for country figures.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/field.field.paragraph.figures.field_presence_figures.yml
+++ b/config/field.field.paragraph.figures.field_presence_figures.yml
@@ -1,0 +1,23 @@
+uuid: ec8a9d0c-442b-4243-8361-11aa456b5ddd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_presence_figures
+    - paragraphs.paragraphs_type.figures
+  module:
+    - ocha_key_figures
+id: paragraph.figures.field_presence_figures
+field_name: field_presence_figures
+entity_type: paragraph
+bundle: figures
+label: 'Regional / country office figures'
+description: 'Use this field for regional or country office figures.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_providers: ''
+  allowed_figure_ids: ''
+field_type: key_figure_presence

--- a/config/field.storage.paragraph.field_presence_figures.yml
+++ b/config/field.storage.paragraph.field_presence_figures.yml
@@ -1,0 +1,19 @@
+uuid: 4c49e2fd-4a4d-4209-9487-89498c061638
+langcode: en
+status: true
+dependencies:
+  module:
+    - ocha_key_figures
+    - paragraphs
+id: paragraph.field_presence_figures
+field_name: field_presence_figures
+entity_type: paragraph
+type: key_figure_presence
+settings: {  }
+module: ocha_key_figures
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/patches/ocha_key_figures-ocha-presence-figures.patch
+++ b/patches/ocha_key_figures-ocha-presence-figures.patch
@@ -1,0 +1,240 @@
+From 9b46345e683c27f47c8264ad8a01f1654269b1a1 Mon Sep 17 00:00:00 2001
+From: "Peter Droogmans (attiks)" <peter@attiks.com>
+Date: Thu, 29 Jun 2023 09:53:34 +0200
+Subject: [PATCH 1/3] Use figure id in theme suggestions
+
+---
+ ocha_key_figures.module                       | 58 +++++++++++++++++++
+ .../Field/FieldFormatter/KeyFigureBase.php    | 14 ++++-
+ .../FieldFormatter/KeyFigureCondensed.php     |  2 +
+ .../KeyFigurePresenceCondensed.php            |  2 +
+ 4 files changed, 74 insertions(+), 2 deletions(-)
+
+diff --git a/ocha_key_figures.module b/ocha_key_figures.module
+index c959b92..1153124 100644
+--- a/ocha_key_figures.module
++++ b/ocha_key_figures.module
+@@ -45,6 +45,8 @@ function ocha_key_figures_theme($existing, $type, $theme, $path) {
+         'value' => NULL,
+         'unit' => NULL,
+         'country' => NULL,
++        'figure' => NULL,
++        'figure_id' => NULL,
+         'year' => NULL,
+         'value_prefix' => NULL,
+         'value_suffix' => NULL,
+@@ -79,3 +81,59 @@ function ocha_key_figures_system_breadcrumb_alter(\Drupal\Core\Breadcrumb\Breadc
+     'id' => $id,
+   ]));
+ }
++
++/**
++ * Implements hook_theme_suggestions_HOOK().
++ */
++function ocha_key_figures_theme_suggestions_ocha_key_figures_extended_figure(array $variables) {
++  if (!isset($variables['figure']['figure_id'])) {
++    return [];
++  }
++
++  if (empty($variables['figure']['figure_id'])) {
++    return [];
++  }
++
++  $suggestions = [
++    'ocha_key_figures_extended_figure__' . $variables['figure']['figure_id'],
++  ];
++
++  $parts = explode('__', $variables['theme_hook_original']);
++  array_shift($parts);
++
++  $new = 'ocha_key_figures_extended_figure__' . $variables['figure']['figure_id'];
++  foreach ($parts as $part) {
++    $new .= '__' . $part;
++    $suggestions[] = $new;
++  }
++
++  return $suggestions;
++}
++
++/**
++ * Implements hook_theme_suggestions_HOOK().
++ */
++function ocha_key_figures_theme_suggestions_ocha_key_figures_figure(array $variables) {
++  if (!isset($variables['figure_id'])) {
++    return [];
++  }
++
++  if (empty($variables['figure_id'])) {
++    return [];
++  }
++
++  $suggestions = [
++    'ocha_key_figures_extended_figure__' . $variables['figure_id'],
++  ];
++
++  $parts = explode('__', $variables['theme_hook_original']);
++  array_shift($parts);
++
++  $new = 'ocha_key_figures_extended_figure__' . $variables['figure_id'];
++  foreach ($parts as $part) {
++    $new .= '__' . $part;
++    $suggestions[] = $new;
++  }
++
++  return $suggestions;
++}
+diff --git a/src/Plugin/Field/FieldFormatter/KeyFigureBase.php b/src/Plugin/Field/FieldFormatter/KeyFigureBase.php
+index 08f1ef6..2eb2a2d 100644
+--- a/src/Plugin/Field/FieldFormatter/KeyFigureBase.php
++++ b/src/Plugin/Field/FieldFormatter/KeyFigureBase.php
+@@ -150,11 +150,21 @@ public function viewElements(FieldItemListInterface $items, $langcode) {
+    *   Associative array keyed by figure ID and with figures data as values.
+    */
+   protected function getFigures($provider, $country, $year) {
+-    $data = $this->ochaKeyFiguresApiClient->query($provider, '', [
++    $query = [
+       'iso3' => $country,
+       'year' => $year,
+       'archived' => 0,
+-    ]);
++    ];
++
++    // Special case for year.
++    if ($year == 1) {
++      unset($query['year']);
++    }
++    elseif ($year == 2) {
++      $query['year'] = date('Y');
++    }
++
++    $data = $this->ochaKeyFiguresApiClient->query($provider, '', $query);
+ 
+     $figures = [];
+ 
+diff --git a/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php b/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
+index 58c380a..083422e 100644
+--- a/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
++++ b/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
+@@ -68,6 +68,8 @@ public function viewElements(FieldItemListInterface $items, $langcode) {
+           '#value' => $value,
+           '#unit' => $figure['unit'] ?? '',
+           '#country' => $figure['country'],
++          '#figure_id' => $figure['figure_id'] ?? '',
++          '#figure' => $figure,
+           '#year' => $figure['year'],
+           '#value_prefix' => $figure['prefix'] ?? '',
+           '#value_suffix' => $figure['suffix'] ?? '',
+diff --git a/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php b/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php
+index 35769c2..60010cd 100644
+--- a/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php
++++ b/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php
+@@ -87,6 +87,8 @@ public function viewElements(FieldItemListInterface $items, $langcode) {
+         '#value' => $figure['value'],
+         '#unit' => $figure['unit'],
+         '#country' => $figure['country'],
++        '#figure_id' => $figure['figure_id'] ?? '',
++        '#figure' => $figure,
+         '#year' => $figure['year'],
+         '#value_prefix' => $figure['prefix'] ?? '',
+         '#value_suffix' => $figure['suffix'] ?? '',
+
+From d234ef0036bed26dc6366932941df66f81d803b2 Mon Sep 17 00:00:00 2001
+From: "Peter Droogmans (attiks)" <peter@attiks.com>
+Date: Thu, 29 Jun 2023 10:54:11 +0200
+Subject: [PATCH 2/3] Use figure id in theme suggestions
+
+---
+ ocha_key_figures.module                                | 8 ++++----
+ src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php | 5 ++++-
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/ocha_key_figures.module b/ocha_key_figures.module
+index 1153124..63e9ea0 100644
+--- a/ocha_key_figures.module
++++ b/ocha_key_figures.module
+@@ -94,14 +94,14 @@ function ocha_key_figures_theme_suggestions_ocha_key_figures_extended_figure(arr
+     return [];
+   }
+ 
++  $new = 'ocha_key_figures_extended_figure__' . str_replace('-', '_', $variables['figure']['figure_id']);
+   $suggestions = [
+-    'ocha_key_figures_extended_figure__' . $variables['figure']['figure_id'],
++    $new,
+   ];
+ 
+   $parts = explode('__', $variables['theme_hook_original']);
+   array_shift($parts);
+ 
+-  $new = 'ocha_key_figures_extended_figure__' . $variables['figure']['figure_id'];
+   foreach ($parts as $part) {
+     $new .= '__' . $part;
+     $suggestions[] = $new;
+@@ -122,14 +122,14 @@ function ocha_key_figures_theme_suggestions_ocha_key_figures_figure(array $varia
+     return [];
+   }
+ 
++  $new = 'ocha_key_figures_figure__' . str_replace('-', '_', $variables['figure_id']);
+   $suggestions = [
+-    'ocha_key_figures_extended_figure__' . $variables['figure_id'],
++    $new,
+   ];
+ 
+   $parts = explode('__', $variables['theme_hook_original']);
+   array_shift($parts);
+ 
+-  $new = 'ocha_key_figures_extended_figure__' . $variables['figure_id'];
+   foreach ($parts as $part) {
+     $new .= '__' . $part;
+     $suggestions[] = $new;
+diff --git a/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php b/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
+index 083422e..9cf3399 100644
+--- a/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
++++ b/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
+@@ -87,6 +87,7 @@ public function viewElements(FieldItemListInterface $items, $langcode) {
+         $value = $item->getFigureValue();
+         $unit = $item->getFigureUnit();
+ 
++        $data = [];
+         if ($item->getFigureProvider() != 'manual') {
+           $data = $this->ochaKeyFiguresApiClient->getFigure($item->getFigureProvider(), strtolower($item->getFigureId()));
+ 
+@@ -104,11 +105,13 @@ public function viewElements(FieldItemListInterface $items, $langcode) {
+         if (isset($label, $value)) {
+           $value = $this->formatNumber($value, $langcode);
+           $elements['#figures'][$delta] = [
+-            '#theme' => 'ocha_key_figures_figure__' . $this->viewMode,
++            '#theme' => 'ocha_key_figures_figure__' . $theme_suggestions,
+             '#label' => $label,
+             '#value' => $value,
+             '#unit' => $unit,
+             '#country' => $item->getFigureCountry(),
++            '#figure_id' => $data['figure_id'] ?? '',
++            '#figure' => $data,
+             '#year' => $item->getFigureYear(),
+             '#value_prefix' => $data['prefix'] ?? '',
+             '#value_suffix' => $data['suffix'] ?? '',
+
+From c89856714a15a4821d1fd3762fbbfa9ad30e27bb Mon Sep 17 00:00:00 2001
+From: "Peter Droogmans (attiks)" <peter@attiks.com>
+Date: Mon, 3 Jul 2023 16:31:57 +0200
+Subject: [PATCH 3/3] bug: Fix current year
+
+---
+ src/Controller/OchaKeyFiguresController.php | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/Controller/OchaKeyFiguresController.php b/src/Controller/OchaKeyFiguresController.php
+index 60196a3..813f2ee 100644
+--- a/src/Controller/OchaKeyFiguresController.php
++++ b/src/Controller/OchaKeyFiguresController.php
+@@ -846,6 +846,10 @@ public function setOchaPresenceExternal(string $id, $data, $new = FALSE) : array
+   public function getOchaPresenceFigures(string $provider, string $ocha_presence_id, string $year, $figure_ids = []) : array {
+     $prefix = $this->getPrefix($provider);
+ 
++    if ($year == 2) {
++      $year = date('Y');
++    }
++
+     $query = [];
+     if (!empty($figure_ids)) {
+       $query['figure_id'] = $figure_ids;


### PR DESCRIPTION
Refs: UNO-703

This PR adds a "Regional / country office figures" field to the `figures` paragraph type to be able to select ROAP funding figures from OCT for example.

## Notes

There is a `patch for the `ocha_key_figures` module that corresponds to this PR: https://github.com/UN-OCHA/ocha_key_figures/pull/13. Once it is merged and there is a new release please remove the patch and upgrade:

1. Remove `patches/ocha_key_figures-ocha-presence-figures.patch`
2. Remove the corresponding entry in `composer.patches.json`
3. Run `composer update unocha/ocha_key_figures`
4. Commit the change to `composer.json` and `composer.lock`

### Tests

1. Checkout the branch, run `composer install` to patch the `ocha_key_figures` module, clear the cache and import the config
2. Edit a region for example, and use the `Regional / country office figures` field to select regional funding figures
3. Save and check that the figures are displayed and correspond to the expected ones
