### PR TITLE
[UNO-705] Show percentage unit

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/modules/ocha_key_figures/ocha-key-figures-figure.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/ocha_key_figures/ocha-key-figures-figure.html.twig
@@ -22,6 +22,7 @@
 {% set label_attributes = label_attributes ?? create_attribute() %}
 {% set value_attributes = value_attributes ?? create_attribute() %}
 {% set unit_attributes = unit_attributes ?? create_attribute() %}
+{% set unit = unit ?: (figure.value_type == 'percentage' ? '%' : '') %}
 <div{{ attributes.addClass('uno-figure') }}>
   <dt{{ label_attributes.addClass('uno-figure__label-wrapper') }}>
     <span{{ label_attributes.addClass('uno-figure__label') }}>{{ label }}</span>


### PR DESCRIPTION
Refs: UNO-705

This shows the `%` unit after the figure label as per the other non percentage figures:

<img width="264" alt="Screenshot 2023-07-05 at 9 07 53" src="https://github.com/UN-OCHA/unocha-site/assets/696348/157667f3-8b57-48f9-a496-79d0a6be3f26">

See https://github.com/UN-OCHA/unocha-site/pull/216 for an alternative.
