### PR TITLE
[UNO-705] Show percentage unit - option 2

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/modules/ocha_key_figures/ocha-key-figures-figure.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/ocha_key_figures/ocha-key-figures-figure.html.twig
@@ -22,6 +22,7 @@
 {% set label_attributes = label_attributes ?? create_attribute() %}
 {% set value_attributes = value_attributes ?? create_attribute() %}
 {% set unit_attributes = unit_attributes ?? create_attribute() %}
+{% set value = figure.value_type == 'percentage' ? value ~ '%' : value %}
 <div{{ attributes.addClass('uno-figure') }}>
   <dt{{ label_attributes.addClass('uno-figure__label-wrapper') }}>
     <span{{ label_attributes.addClass('uno-figure__label') }}>{{ label }}</span>


### PR DESCRIPTION
Refs: UNO-705

This is an alternative of https://github.com/UN-OCHA/unocha-site/pull/215 that shows the `%` after the value:

<img width="289" alt="Screenshot 2023-07-05 at 9 07 29" src="https://github.com/UN-OCHA/unocha-site/assets/696348/44dbe125-2e12-4a61-b6ce-51e66c70010b">
