### PR TITLE
[UNO-710] Stories - multiple regions/responses

### DIFF
--- a/config/core.entity_form_display.node.story.default.yml
+++ b/config/core.entity_form_display.node.story.default.yml
@@ -7,7 +7,9 @@ dependencies:
     - field.field.node.story.field_country
     - field.field.node.story.field_custom_content
     - field.field.node.story.field_region
+    - field.field.node.story.field_regions
     - field.field.node.story.field_response
+    - field.field.node.story.field_responses
     - field.field.node.story.field_story_image
     - field.field.node.story.field_story_type
     - field.field.node.story.field_theme
@@ -35,7 +37,7 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -56,14 +58,14 @@ content:
       require_layouts: 0
       empty_message: 'Placeholder message to display when field is empty'
     third_party_settings: {  }
-  field_region:
+  field_regions:
     type: choices_widget
     weight: 6
     region: content
     settings:
       configuration_options: ''
     third_party_settings: {  }
-  field_response:
+  field_responses:
     type: choices_widget
     weight: 7
     region: content
@@ -99,27 +101,27 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 12
+    weight: 13
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 16
+    weight: 17
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 13
+    weight: 14
     region: content
     settings:
       display_label: true
@@ -133,7 +135,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -148,8 +150,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_region: true
+  field_response: true

--- a/config/core.entity_view_display.node.story.campaign.yml
+++ b/config/core.entity_view_display.node.story.campaign.yml
@@ -8,7 +8,9 @@ dependencies:
     - field.field.node.story.field_country
     - field.field.node.story.field_custom_content
     - field.field.node.story.field_region
+    - field.field.node.story.field_regions
     - field.field.node.story.field_response
+    - field.field.node.story.field_responses
     - field.field.node.story.field_story_image
     - field.field.node.story.field_story_type
     - field.field.node.story.field_theme
@@ -38,7 +40,9 @@ hidden:
   field_country: true
   field_custom_content: true
   field_region: true
+  field_regions: true
   field_response: true
+  field_responses: true
   field_story_image: true
   field_story_type: true
   field_theme: true

--- a/config/core.entity_view_display.node.story.card.yml
+++ b/config/core.entity_view_display.node.story.card.yml
@@ -8,7 +8,9 @@ dependencies:
     - field.field.node.story.field_country
     - field.field.node.story.field_custom_content
     - field.field.node.story.field_region
+    - field.field.node.story.field_regions
     - field.field.node.story.field_response
+    - field.field.node.story.field_responses
     - field.field.node.story.field_story_image
     - field.field.node.story.field_story_type
     - field.field.node.story.field_theme
@@ -47,7 +49,9 @@ hidden:
   field_country: true
   field_custom_content: true
   field_region: true
+  field_regions: true
   field_response: true
+  field_responses: true
   field_theme: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.node.story.default.yml
+++ b/config/core.entity_view_display.node.story.default.yml
@@ -7,7 +7,9 @@ dependencies:
     - field.field.node.story.field_country
     - field.field.node.story.field_custom_content
     - field.field.node.story.field_region
+    - field.field.node.story.field_regions
     - field.field.node.story.field_response
+    - field.field.node.story.field_responses
     - field.field.node.story.field_story_image
     - field.field.node.story.field_story_type
     - field.field.node.story.field_theme
@@ -41,7 +43,9 @@ hidden:
   field_country: true
   field_custom_content: true
   field_region: true
+  field_regions: true
   field_response: true
+  field_responses: true
   field_story_type: true
   field_theme: true
   langcode: true

--- a/config/core.entity_view_display.node.story.full.yml
+++ b/config/core.entity_view_display.node.story.full.yml
@@ -8,7 +8,9 @@ dependencies:
     - field.field.node.story.field_country
     - field.field.node.story.field_custom_content
     - field.field.node.story.field_region
+    - field.field.node.story.field_regions
     - field.field.node.story.field_response
+    - field.field.node.story.field_responses
     - field.field.node.story.field_story_image
     - field.field.node.story.field_story_type
     - field.field.node.story.field_theme
@@ -55,7 +57,9 @@ content:
 hidden:
   field_country: true
   field_region: true
+  field_regions: true
   field_response: true
+  field_responses: true
   field_story_type: true
   field_theme: true
   langcode: true

--- a/config/core.entity_view_display.node.story.teaser.yml
+++ b/config/core.entity_view_display.node.story.teaser.yml
@@ -8,7 +8,9 @@ dependencies:
     - field.field.node.story.field_country
     - field.field.node.story.field_custom_content
     - field.field.node.story.field_region
+    - field.field.node.story.field_regions
     - field.field.node.story.field_response
+    - field.field.node.story.field_responses
     - field.field.node.story.field_story_image
     - field.field.node.story.field_story_type
     - field.field.node.story.field_theme
@@ -49,7 +51,9 @@ content:
 hidden:
   field_custom_content: true
   field_region: true
+  field_regions: true
   field_response: true
+  field_responses: true
   field_story_type: true
   field_theme: true
   langcode: true

--- a/config/field.field.node.story.field_regions.yml
+++ b/config/field.field.node.story.field_regions.yml
@@ -1,29 +1,29 @@
-uuid: 7c9da489-b905-485c-9e5b-41a24a0526bc
+uuid: e813ff24-a09a-447b-adf4-ddb46b192f03
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_country
+    - field.storage.node.field_regions
+    - node.type.region
     - node.type.story
-    - taxonomy.vocabulary.country
-id: node.story.field_country
-field_name: field_country
+id: node.story.field_regions
+field_name: field_regions
 entity_type: node
 bundle: story
-label: Countries
+label: Regions
 description: ''
 required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:taxonomy_term'
+  handler: 'default:node'
   handler_settings:
     target_bundles:
-      country: country
+      region: region
     sort:
-      field: name
-      direction: asc
+      field: title
+      direction: ASC
     auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/field.field.node.story.field_responses.yml
+++ b/config/field.field.node.story.field_responses.yml
@@ -1,29 +1,29 @@
-uuid: 7c9da489-b905-485c-9e5b-41a24a0526bc
+uuid: e4bba94e-3da4-4075-a101-4050e58e6c8c
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_country
+    - field.storage.node.field_responses
+    - node.type.response
     - node.type.story
-    - taxonomy.vocabulary.country
-id: node.story.field_country
-field_name: field_country
+id: node.story.field_responses
+field_name: field_responses
 entity_type: node
 bundle: story
-label: Countries
+label: Responses
 description: ''
 required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:taxonomy_term'
+  handler: 'default:node'
   handler_settings:
     target_bundles:
-      country: country
+      response: response
     sort:
-      field: name
-      direction: asc
+      field: _none
+      direction: ASC
     auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/field.storage.node.field_regions.yml
+++ b/config/field.storage.node.field_regions.yml
@@ -1,0 +1,19 @@
+uuid: 107d93c0-44e0-4faf-839b-9d2083231bce
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_regions
+field_name: field_regions
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_responses.yml
+++ b/config/field.storage.node.field_responses.yml
@@ -1,0 +1,19 @@
+uuid: 25a1d8b5-2176-40fb-98cd-e975c83d264f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_responses
+field_name: field_responses
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/views.view.stories.yml
+++ b/config/views.view.stories.yml
@@ -269,10 +269,10 @@ display:
             story_type: '0'
             theme: '0'
           show_unpublished: 0
-        field_response_target_id_verf:
-          id: field_response_target_id_verf
-          table: node__field_response
-          field: field_response_target_id_verf
+        field_responses_target_id_verf:
+          id: field_responses_target_id_verf
+          table: node__field_responses
+          field: field_responses_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
@@ -282,11 +282,11 @@ display:
           group: 2
           exposed: true
           expose:
-            operator_id: field_response_target_id_verf_op
+            operator_id: field_responses_target_id_verf_op
             label: Response
             description: ''
             use_operator: false
-            operator: field_response_target_id_verf_op
+            operator: field_responses_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: response
@@ -315,14 +315,16 @@ display:
             response: response
             basic: '0'
             event: '0'
+            leader: '0'
+            media_collection: '0'
             region: '0'
             resource: '0'
             story: '0'
           show_unpublished: 0
-        field_region_target_id_verf:
-          id: field_region_target_id_verf
-          table: node__field_region
-          field: field_region_target_id_verf
+        field_regions_target_id_verf:
+          id: field_regions_target_id_verf
+          table: node__field_regions
+          field: field_regions_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
@@ -332,11 +334,11 @@ display:
           group: 2
           exposed: true
           expose:
-            operator_id: field_region_target_id_verf_op
+            operator_id: field_regions_target_id_verf_op
             label: Region
             description: ''
             use_operator: false
-            operator: field_region_target_id_verf_op
+            operator: field_regions_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: region
@@ -365,6 +367,8 @@ display:
             region: region
             basic: '0'
             event: '0'
+            leader: '0'
+            media_collection: '0'
             resource: '0'
             response: '0'
             story: '0'
@@ -560,10 +564,10 @@ display:
             story_type: '0'
             theme: '0'
           show_unpublished: 0
-        field_response_target_id_verf:
-          id: field_response_target_id_verf
-          table: node__field_response
-          field: field_response_target_id_verf
+        field_responses_target_id_verf:
+          id: field_responses_target_id_verf
+          table: node__field_responses
+          field: field_responses_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
@@ -573,11 +577,11 @@ display:
           group: 2
           exposed: true
           expose:
-            operator_id: field_response_target_id_verf_op
+            operator_id: field_responses_target_id_verf_op
             label: Response
             description: ''
             use_operator: false
-            operator: field_response_target_id_verf_op
+            operator: field_responses_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: response
@@ -606,14 +610,16 @@ display:
             response: response
             basic: '0'
             event: '0'
+            leader: '0'
+            media_collection: '0'
             region: '0'
             resource: '0'
             story: '0'
           show_unpublished: 0
-        field_region_target_id_verf:
-          id: field_region_target_id_verf
-          table: node__field_region
-          field: field_region_target_id_verf
+        field_regions_target_id_verf:
+          id: field_regions_target_id_verf
+          table: node__field_regions
+          field: field_regions_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
@@ -623,11 +629,11 @@ display:
           group: 2
           exposed: true
           expose:
-            operator_id: field_region_target_id_verf_op
+            operator_id: field_regions_target_id_verf_op
             label: Region
             description: ''
             use_operator: false
-            operator: field_region_target_id_verf_op
+            operator: field_regions_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: region
@@ -656,6 +662,8 @@ display:
             region: region
             basic: '0'
             event: '0'
+            leader: '0'
+            media_collection: '0'
             resource: '0'
             response: '0'
             story: '0'
@@ -851,10 +859,10 @@ display:
             story_type: '0'
             theme: '0'
           show_unpublished: 0
-        field_response_target_id_verf:
-          id: field_response_target_id_verf
-          table: node__field_response
-          field: field_response_target_id_verf
+        field_responses_target_id_verf:
+          id: field_responses_target_id_verf
+          table: node__field_responses
+          field: field_responses_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
@@ -864,11 +872,11 @@ display:
           group: 2
           exposed: true
           expose:
-            operator_id: field_response_target_id_verf_op
+            operator_id: field_responses_target_id_verf_op
             label: Response
             description: ''
             use_operator: false
-            operator: field_response_target_id_verf_op
+            operator: field_responses_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: response
@@ -897,14 +905,16 @@ display:
             response: response
             basic: '0'
             event: '0'
+            leader: '0'
+            media_collection: '0'
             region: '0'
             resource: '0'
             story: '0'
           show_unpublished: 0
-        field_region_target_id_verf:
-          id: field_region_target_id_verf
-          table: node__field_region
-          field: field_region_target_id_verf
+        field_regions_target_id_verf:
+          id: field_regions_target_id_verf
+          table: node__field_regions
+          field: field_regions_target_id_verf
           relationship: none
           group_type: group
           admin_label: ''
@@ -914,11 +924,11 @@ display:
           group: 2
           exposed: true
           expose:
-            operator_id: field_region_target_id_verf_op
+            operator_id: field_regions_target_id_verf_op
             label: Region
             description: ''
             use_operator: false
-            operator: field_region_target_id_verf_op
+            operator: field_regions_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: region
@@ -947,6 +957,8 @@ display:
             region: region
             basic: '0'
             event: '0'
+            leader: '0'
+            media_collection: '0'
             resource: '0'
             response: '0'
             story: '0'

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -35,7 +35,7 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
     if ($parent->bundle() === 'response') {
       // Get the stories tagged with the response.
       $stories = unocha_paragraphs_get_stories([
-        ['field_response', $parent->id(), '='],
+        ['field_responses', $parent->id(), '='],
       ], $limit);
 
       // Filter the News and Stories page by the response.
@@ -47,7 +47,7 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
         $region = unocha_paragraphs_get_node_parent_node($parent);
         if (isset($region) && $region->bundle() === 'region') {
           $stories += unocha_paragraphs_get_stories([
-            ['field_region', $region->id(), '='],
+            ['field_regions', $region->id(), '='],
           ], $limit - count($stories));
 
           // Also add the region as filter to have consistent results in the
@@ -59,7 +59,7 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
     elseif ($parent->bundle() === 'region') {
       // Get the stories tagged with the region.
       $stories = unocha_paragraphs_get_stories([
-        ['field_region', $parent->id(), '='],
+        ['field_regions', $parent->id(), '='],
       ], $limit);
 
       // Filter the News and Stories page by the region.
@@ -72,8 +72,8 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       // Add conditions on the referenced entities.
       $conditions = [];
       $fields = [
-        'field_response' => 'response',
-        'field_region' => 'region',
+        'field_responses' => 'response',
+        'field_regions' => 'region',
         'field_country' => 'country',
       ];
       foreach ($fields as $field => $filter) {


### PR DESCRIPTION
Refs: UNO-710

This adds 2 new fields: `field_regions` and `field_responses` on the story content type to replace the `field_region` and `field_response` which accepted only 1 value; and update the logic for the stories paragraph type and views to use those new fields.

### Deployment

The  `field_region` and `field_response` are hidden but not removed otherwise that may break the deployment on the preview site.

So before deploying, manually delete the **story** `field_region` and `field_response` on the preview site. They will be recreated as part of the deployment but that will ensure there is no leftover.

As a follow-up **after** the deployment of this branch, we'll have to create a PR that actually removes those fields for the **story** content type.

### Tests

1. Checkout the branch, clear the cache, import the config.
2. Tag some stories with several regions and responses.
3. Edit the corresponding regions and responses, add a `Stories` paragraph type if they don't already have one, save.
4. Check that the stories appear in those pages.
5. Check that the "view all" links link to the news and stories page with the proper filters selected.