### PR TITLE
[UNO-708][UNO-716][UNO-717] Figures and donors

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -13796,16 +13796,16 @@
         },
         {
             "name": "unocha/ocha_key_figures",
-            "version": "2.1.4",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/ocha_key_figures.git",
-                "reference": "f85dac14387b43693a598308778c51bf1f5a860e"
+                "reference": "8ec7383c445c6999213485d48a9f963b6f2c1901"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/ocha_key_figures/zipball/f85dac14387b43693a598308778c51bf1f5a860e",
-                "reference": "f85dac14387b43693a598308778c51bf1f5a860e",
+                "url": "https://api.github.com/repos/UN-OCHA/ocha_key_figures/zipball/8ec7383c445c6999213485d48a9f963b6f2c1901",
+                "reference": "8ec7383c445c6999213485d48a9f963b6f2c1901",
                 "shasum": ""
             },
             "require": {
@@ -13819,9 +13819,9 @@
             "description": "UNOCHA Key Figures",
             "support": {
                 "issues": "https://github.com/UN-OCHA/ocha_key_figures/issues",
-                "source": "https://github.com/UN-OCHA/ocha_key_figures/tree/2.1.4"
+                "source": "https://github.com/UN-OCHA/ocha_key_figures/tree/2.1.6"
             },
-            "time": "2023-07-04T06:26:42+00:00"
+            "time": "2023-07-07T02:24:14+00:00"
         },
         {
             "name": "unocha/ocha_search",

--- a/html/modules/custom/unocha_donors/src/Plugin/Field/FieldFormatter/Donors.php
+++ b/html/modules/custom/unocha_donors/src/Plugin/Field/FieldFormatter/Donors.php
@@ -65,6 +65,13 @@ class Donors extends KeyFigureBase {
           }
         }
       }
+      elseif (isset($data['sectors'])) {
+        foreach ($data['sectors'] as $sector) {
+          if (isset($sector['name'])) {
+            $donors[$sector['name']] = $sector;
+          }
+        }
+      }
       elseif (isset($data['value'])) {
         foreach (preg_split('/,\s+/', trim($data['value'])) as $name) {
           $donors[$name]['name'] = $name;

--- a/html/modules/custom/unocha_utility/src/Helpers/NumberFormatter.php
+++ b/html/modules/custom/unocha_utility/src/Helpers/NumberFormatter.php
@@ -291,7 +291,7 @@ class NumberFormatter {
    * @see http://st.unicode.org/cldr-apps/v#/fr/Compact_Decimal_Formatting
    */
   public static function formatNumberCompact($number, $langcode, $type = 'long', $precision = 2, $use_gho_specifics = FALSE) {
-    if ($number <= 0) {
+    if (!is_numeric($number) || $number < 0) {
       return '-';
     }
     elseif ($number < 1000) {

--- a/html/themes/custom/common_design_subtheme/templates/modules/ocha_key_figures/ocha-key-figures-figure.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/ocha_key_figures/ocha-key-figures-figure.html.twig
@@ -30,7 +30,7 @@
       <small{{ unit_attribute.addClass('uno-figure__unit') }}> ({{ unit }})</small>
     {%- endif -%}
   </dt>
-  <dd{{ value_attributes.addClass('uno-figure__value') }}>{{ value }}</dd>
+  <dd{{ value_attributes.addClass('uno-figure__value') }}>{{ value == 0 ? 0 : value }}</dd>
 </div>
 {% endif %}
 

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--cbpf-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--cbpf-top-donors.html.twig
@@ -29,7 +29,8 @@
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>
-    {% for item in list|slice(0, 5) %}
+    {# Sort by pledged amount descending. #}
+    {% for item in list|sort((a, b) => b.pledged <=> a.pledged)|slice(0, 5) %}
     {% set amount = item.paid ? item.paid : item.pledged %}
     {% set suffix = item.paid ? 'paid'|t : 'pledged'|t %}
     <div{{ item_attributes.addClass('uno-donor') }}>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-donors.html.twig
@@ -29,7 +29,8 @@
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>
-    {% for item in list|slice(0, 5) %}
+    {# Sort by funding amount descending. #}
+    {% for item in list|sort((a, b) => b.total_funding <=> a.total_funding)|slice(0, 5) %}
     <div{{ item_attributes.addClass('uno-donor') }}>
       <dt class="uno-donors__donor">{{ item.name }}</dt>
       <dd class="uno-donors__amount"> ${{ item.total_funding|format_number_compact(null, format ?? 'long', precision ?? 1, true)  }}</dd>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-sectors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-sectors.html.twig
@@ -29,7 +29,8 @@
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>
-    {% for item in list|slice(0, 5) %}
+    {# Sort by funding amount descending. #}
+    {% for item in list|sort((a, b) => b.total_funding <=> a.total_funding)|slice(0, 5) %}
     <div{{ item_attributes.addClass('uno-donor') }}>
       <dt class="uno-donors__donor">{{ item.name }}</dt>
       <dd class="uno-donors__amount"> ${{ item.total_funding|format_number_compact(null, format ?? 'long', precision ?? 1, true)  }}</dd>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-earmarked-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-earmarked-donors.html.twig
@@ -28,7 +28,8 @@
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>
-    {% for item in list %}
+    {# Sort alphabetically. #}
+    {% for item in list|taglist %}
     <div{{item_attributes.addClass('uno-donor')}}>
       <dt class="uno-donors__donor">{{ item.name }}</dt>
       <dd class="uno-donors__amount"> ${{ item.total|format_number_compact(null, format ?? 'long', precision ?? 1, true)  }}</dd>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
@@ -35,7 +35,8 @@
   </p>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--barchart').setAttribute('id', list_id) }}>
-    {% for item in list %}
+    {# Sort by total funding descending. #}
+    {% for item in list|sort((a, b) => b.total <=> a.total) %}
     <div{{item_attributes.addClass('uno-donor')}}>
       <dt class="uno-donors__donor">{{ item.name }}</dt>
       <dd class="uno-donors__amount">

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
@@ -28,7 +28,8 @@
   </header>
   {% apply spaceless %}
   <ul{{ list_attributes.addClass('uno-donors__list') }}>
-    {% for item in list %}
+    {# Sort alphabetically. #}
+    {% for item in list|taglist %}
     <li{{ item_attributes.addClass('uno-donors__list__item') }}>{{ item.name }}</li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
Refs: UNO-708, UNO-716, UNO-717

This PR combines related fixes for the donors and figures:

1. Display figure values of `0` as `0` instead of `-`
2. Fix amount not being displayed for top sectors
3. Order donor figures similarly to the current www.unocha.org

### Tests

1. Checkout the branch, run composer install, clear the cache
2. Go to the Ukraine page, check that the donors and sector show similar data as https://www.unocha.org/ukraine
3. Go to the Eritrea page, check that the "funding for OCHA Eritrea" show `0` instead of `-`