### PR TITLE
UNO-575 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -13766,16 +13766,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v9.0.0",
+            "version": "v9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "1be9b7af953766fa86694ab750f2c1a8f794489e"
+                "reference": "084f9403f23e43e44661a269181734d6ea425094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/1be9b7af953766fa86694ab750f2c1a8f794489e",
-                "reference": "1be9b7af953766fa86694ab750f2c1a8f794489e",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/084f9403f23e43e44661a269181734d6ea425094",
+                "reference": "084f9403f23e43e44661a269181734d6ea425094",
                 "shasum": ""
             },
             "require": {
@@ -13790,9 +13790,9 @@
             "description": "OCHA Common Design base theme for Drupal 9+",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v9.0.0"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v9.0.1"
             },
-            "time": "2023-07-03T12:43:11+00:00"
+            "time": "2023-07-10T07:28:12+00:00"
         },
         {
             "name": "unocha/ocha_key_figures",

--- a/config/node.type.event.yml
+++ b/config/node.type.event.yml
@@ -6,8 +6,9 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus: {  }
-    parent: ''
+    available_menus:
+      - main
+    parent: 'main:menu_link_content:99552f38-0538-419c-9730-f04e708279ae'
 name: Event
 type: event
 description: 'Event with date, time, location, additional information and associated Response, Regions, and/or Country optional.'

--- a/html/themes/custom/common_design_subtheme/components/cd-hero/cd-hero.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-hero/cd-hero.css
@@ -20,8 +20,16 @@
   margin-top: -2rem;
 }
 
+.cd-page-layout-container main [data-drupal-messages] + .cd-hero {
+  margin-top: 0;
+}
+
 @media screen and (min-width: 1024px) {
   .cd-page-layout-container main .cd-hero {
     margin-top: -3rem;
+  }
+
+  .cd-page-layout-container main [data-drupal-messages] + .cd-hero {
+    margin-top: 0;
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/cd-social-links/cd-social-links.html.twig
+++ b/html/themes/custom/common_design_subtheme/components/cd-social-links/cd-social-links.html.twig
@@ -18,7 +18,7 @@
           </a>
         </li>
         <li class="cd-social-links__item">
-          <a class="cd-social-links__link cd-social-links__link--twitter" target="_blank" href="https://twitter.com/intent/tweet?text={{ shareMessage }}%0A%0A{{ shareUrl|url_encode }}">
+          <a class="cd-social-links__link cd-social-links__link--twitter" target="_blank" href="https://twitter.com/intent/tweet?text={{ shareMessage|url_encode }}%0A%0A{{ shareUrl|url_encode }}">
             <span class="visually-hidden">{{ 'Share on Twitter'|t }}</span>
             <svg class="cd-icon cd-icon--social-links--twitter" aria-hidden="true" focusable="false" width="16" height="16">
               <use xlink:href="#cd-icon--social-links--twitter"></use>
@@ -26,7 +26,7 @@
           </a>
         </li>
         <li class="cd-social-links__item">
-          <a class="cd-social-links__link cd-social-links__link--linkedin" target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&summary={{ shareMessage }}&title={{ label|render|striptags|trim }}&url={{ shareUrl|url_encode }}">
+          <a class="cd-social-links__link cd-social-links__link--linkedin" target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&summary={{ shareMessage|url_encode }}&title={{ label|render|striptags|trim }}&url={{ shareUrl|url_encode }}">
             <span class="visually-hidden">{{ 'Share on LinkedIn'|t }}</span>
             <svg class="cd-icon cd-icon--social-links--linkedin" aria-hidden="true" focusable="false" width="16" height="16">
               <use xlink:href="#cd-icon--social-links--linkedin"></use>
@@ -34,7 +34,7 @@
           </a>
         </li>
         <li class="cd-social-links__item">
-          <a class="cd-social-links__link cd-social-links__link--email" href="mailto:?subject=UNOCHA&amp;body={{ shareMessage }}&title={{ label|render|striptags|trim }}&url={{ shareUrl|url_encode }}">
+          <a class="cd-social-links__link cd-social-links__link--email" href="mailto:?subject=UNOCHA&amp;body={{ shareMessage|url_encode }}&title={{ label|render|striptags|trim }}&url={{ shareUrl|url_encode }}">
             <span class="visually-hidden">{{ 'Share by Email'|t }}</span>
             <svg class="cd-icon cd-icon--social-links--email" aria-hidden="true" focusable="false" width="16" height="16">
               <use xlink:href="#cd-icon--social-links--email"></use>

--- a/html/themes/custom/common_design_subtheme/components/cd/cd.css
+++ b/html/themes/custom/common_design_subtheme/components/cd/cd.css
@@ -58,8 +58,27 @@ a:focus {
 }
 
 @media screen and (min-width: 1024px) {
+  /* Dontate button */
   .cd-nav > .menu > .menu-item:last-child a {
     padding: 0 20px;
+  }
+
+  /* Second last menu item dropdown aligns right since Donate button is not wide
+    enough to prevent 2nd last item overflowing the right edge */
+  [dir=ltr] .cd-nav > .menu > .menu-item:nth-last-child(2) > ul.menu {
+    right: 0;
+  }
+
+  [dir=rtl] .cd-nav > .menu > .menu-item:nth-last-child(2) > ul.menu {
+    left: 0;
+  }
+
+  /* If the menu items wrap, make sure they sit above the hero image */
+  #main-content {
+    z-index: 1;
+  }
+  .cd-header {
+    z-index: 2;
   }
 }
 

--- a/html/themes/custom/common_design_subtheme/components/cd/cd.css
+++ b/html/themes/custom/common_design_subtheme/components/cd/cd.css
@@ -13,6 +13,11 @@ a:focus {
   color: var(--brand-primary);
 }
 
+.field--type-text-with-summary a,
+.field--name-field-text a {
+  text-decoration: underline;
+}
+
 .cd-global-header {
   background: var(--brand-primary--dark);
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-article.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-article.css
@@ -48,12 +48,21 @@
   color: var(--brand-default-text-color);
 }
 .rw-river-article .rw-river-article__content {
-  display: flex;
-  flex: 1 0 auto;
+  /* display: flex; */
+  /* flex: 1 0 auto; */
   /* align-items: center; */
   /* padding-top: 16px; */
   color: var(--cd-reliefweb-brand-grey--mid);
 }
+
+@media screen and (min-width: 768px) {
+  .rw-river-article .rw-river-article__header {
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
+  }
+}
+
 /* Article with a thumbnail preview (typically Map and Infographic). */
 .rw-river-article .rw-river-article__content img {
   float: left;

--- a/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
@@ -69,15 +69,17 @@
 }
 
 /* Card view mode */
-.paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river__articles {
-  display: flex;
-  flex-flow: row wrap;
-  gap: var(--rw-card-list-gap-size);
-}
+@media screen and (min-width: 768px) {
+  .paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river__articles {
+    display: flex;
+    flex-flow: row wrap;
+    gap: var(--rw-card-list-gap-size);
+  }
 
-.paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river__articles article {
-  /* stylelint-disable-next-line max-line-length */
-  flex: 0 1 calc((100% / var(--rw-card-list-num-cols)) - var(--rw-card-list-gap-size) + var(--rw-card-list-gap-size) / var(--rw-card-list-num-cols));
+  .paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river__articles article {
+    /* stylelint-disable-next-line max-line-length */
+    flex: 0 1 calc((100% / var(--rw-card-list-num-cols)) - var(--rw-card-list-gap-size) + var(--rw-card-list-gap-size) / var(--rw-card-list-num-cols));
+  }
 }
 
 @media screen and (min-width: 768px) {
@@ -89,8 +91,10 @@
 /* cd-flow reset for 2nd item on rw-river items because
   we are displaying as cards now
 */
-.paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river__articles.cd-flow article:nth-child(2) {
-  margin-top: 0;
+@media screen and (min-width: 768px) {
+  .paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river__articles.cd-flow article:nth-child(2) {
+    margin-top: 0;
+  }
 }
 
 /* rw-article reset for last item on rw-river items because

--- a/html/themes/custom/common_design_subtheme/css/brand.css
+++ b/html/themes/custom/common_design_subtheme/css/brand.css
@@ -17,7 +17,7 @@
   --brand-highlight-contrast: #000;
   --brand-grey: #f5f5f5;
   --brand-grey--border: #ccc;
-  --brand-grey--text: #00000080;
+  --brand-grey--text: #767676;
   --brand-logo-width: 186px;
   --brand-default-text-color: #444;
 

--- a/html/themes/custom/common_design_subtheme/templates/content/node--leader--teaser.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--leader--teaser.html.twig
@@ -86,10 +86,12 @@
 
 <article{{ attributes.addClass(classes) }}>
 
-  {{ content.field_leader_portrait }}
+  <a href="{{ url }}">{{ content.field_leader_portrait }}</a>
 
   {{ title_prefix }}
-  <h2{{ title_attributes.addClass('uno-leader__name') }}>{{ label }}</h2>
+  <h2{{ title_attributes.addClass('uno-leader__name') }}>
+    <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+  </h2>
   {{ title_suffix }}
 
   {{ content|without('field_leader_portrait') }}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--leader--title.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--leader--title.html.twig
@@ -87,10 +87,12 @@
 
 <article{{ attributes.addClass(classes) }}>
 
-  {{ content.field_leader_portrait }}
+  <a href="{{ url }}">{{ content.field_leader_portrait }}</a>
 
   {{ title_prefix }}
-  <h3{{ title_attributes.addClass('uno-leader__name') }}>{{ label }}</a></h3>
+  <h3{{ title_attributes.addClass('uno-leader__name') }}>
+    <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+  </h3>
   {{ title_suffix }}
 
   {{ content|without('field_leader_portrait') }}


### PR DESCRIPTION
UNO-711 RW thumbnails in Resources river, and better display on mobile
UNO-714 Main menu last item
UNO-715 Hero and Drupal message display
UNO-575 Underlined links in body text, make Leader CT teaser and title viewmode templates title and image link to full page
UNO-638 url_encode filter for Share message for social share, new grey that passes contrast check
UNO-725 Enable Main Menu in Events content type for breadcrumbs