### PR TITLE
[UNO-580] Sitemap

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -84,6 +84,7 @@ module:
   unocha_migrate: 0
   unocha_paragraphs: 0
   unocha_reliefweb: 0
+  unocha_sitemap: 0
   unocha_utility: 0
   update: 0
   user: 0

--- a/config/xmlsitemap.settings.node.basic.yml
+++ b/config/xmlsitemap.settings.node.basic.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 86400

--- a/config/xmlsitemap.settings.node.event.yml
+++ b/config/xmlsitemap.settings.node.event.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 86400

--- a/config/xmlsitemap.settings.node.leader.yml
+++ b/config/xmlsitemap.settings.node.leader.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 31449600

--- a/config/xmlsitemap.settings.node.media_collection.yml
+++ b/config/xmlsitemap.settings.node.media_collection.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 604800

--- a/config/xmlsitemap.settings.node.region.yml
+++ b/config/xmlsitemap.settings.node.region.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 86400

--- a/config/xmlsitemap.settings.node.resource.yml
+++ b/config/xmlsitemap.settings.node.resource.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 2419200

--- a/config/xmlsitemap.settings.node.response.yml
+++ b/config/xmlsitemap.settings.node.response.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 86400

--- a/config/xmlsitemap.settings.node.story.yml
+++ b/config/xmlsitemap.settings.node.story.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 604800

--- a/config/xmlsitemap.settings.yml
+++ b/config/xmlsitemap.settings.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: 58nI4vVTGv677fB42ySkQN9iTenfZvvW-xJlXODHdV4
-minimum_lifetime: 0
+minimum_lifetime: 86400
 xsl: 1
 prefetch_aliases: 1
 chunk_size: auto
@@ -11,6 +11,6 @@ frontpage_changefreq: 86400
 lastmod_format: 'Y-m-d\TH:i\Z'
 gz: false
 clean_url: 0
-disable_cron_regeneration: false
+disable_cron_regeneration: true
 i18n_selection_mode: simple
 metatag_exclude_noindex: true

--- a/config/xmlsitemap.xmlsitemap.g3XYqcXbSKPVBDODwnT6pq7oqhCFkPryj4vVqrl_Kfc.yml
+++ b/config/xmlsitemap.xmlsitemap.g3XYqcXbSKPVBDODwnT6pq7oqhCFkPryj4vVqrl_Kfc.yml
@@ -1,0 +1,8 @@
+uuid: c34efe7f-95c0-4f31-be75-735263179d04
+langcode: en
+status: true
+dependencies: {  }
+id: g3XYqcXbSKPVBDODwnT6pq7oqhCFkPryj4vVqrl_Kfc
+label: Sitemap
+context:
+  language: en

--- a/html/modules/custom/unocha_sitemap/README.md
+++ b/html/modules/custom/unocha_sitemap/README.md
@@ -1,0 +1,4 @@
+UNOCHA - Sitemap module
+=======================
+
+This module handles the addition of the whitelabeled RW links to the sitemap.

--- a/html/modules/custom/unocha_sitemap/unocha_sitemap.info.yml
+++ b/html/modules/custom/unocha_sitemap/unocha_sitemap.info.yml
@@ -1,0 +1,8 @@
+type: module
+name: UNOCHA Sitemap
+description: 'Handles the sitemap.'
+package: unocha
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:unocha_reliefweb
+  - xmlsitemap:xmlsitemap

--- a/html/modules/custom/unocha_sitemap/unocha_sitemap.install
+++ b/html/modules/custom/unocha_sitemap/unocha_sitemap.install
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Install file for the unocha_sitemap module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function unocha_sitemap_install($is_syncing) {
+  $schema = \Drupal::database()?->schema();
+  if (isset($schema) && $schema->tableExists('xmlsitemap')) {
+    if (\Drupal::moduleHandler()->loadInclude('xmlsitemap', 'install') !== FALSE) {
+      $xmlsitemap_schema = xmlsitemap_schema()['xmlsitemap'] ?? [];
+
+      if (isset($xmlsitemap_schema['fields']['loc'])) {
+        // Drop the indexes using the loc field.
+        $indexes = $xmlsitemap_schema['indexes'] ?? [];
+        foreach ($indexes as $name => $fields) {
+          if (!in_array('loc', $fields)) {
+            unset($indexes[$name]);
+          }
+          else {
+            $schema->dropIndex('xmlsitemap', $name);
+          }
+        }
+
+        // Increase the length of the loc field.
+        $xmlsitemap_schema['fields']['loc']['length'] = 2024;
+
+        // Update the loc field with the new spec.
+        $schema->changeField('xmlsitemap', 'loc', 'loc', $xmlsitemap_schema['fields']['loc']);
+
+        // Recreate the indexes using the loc field.
+        foreach ($indexes as $name => $fields) {
+          $schema->addIndex('xmlsitemap', $name, $fields, $xmlsitemap_schema);
+        }
+      }
+    }
+  }
+}

--- a/html/modules/custom/unocha_sitemap/unocha_sitemap.install
+++ b/html/modules/custom/unocha_sitemap/unocha_sitemap.install
@@ -27,7 +27,7 @@ function unocha_sitemap_install($is_syncing) {
         }
 
         // Increase the length of the loc field.
-        $xmlsitemap_schema['fields']['loc']['length'] = 2024;
+        $xmlsitemap_schema['fields']['loc']['length'] = 2048;
 
         // Update the loc field with the new spec.
         $schema->changeField('xmlsitemap', 'loc', 'loc', $xmlsitemap_schema['fields']['loc']);

--- a/html/modules/custom/unocha_sitemap/unocha_sitemap.module
+++ b/html/modules/custom/unocha_sitemap/unocha_sitemap.module
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * @file
+ * Module file for the unocha_sitemap module.
+ */
+
+use Drupal\unocha_reliefweb\Helpers\UrlHelper;
+
+/**
+ * Provide information on the type of links this module provides.
+ *
+ * @see hook_entity_info()
+ * @see hook_entity_info_alter()
+ */
+function unocha_sitemap_xmlsitemap_link_info() {
+  return [
+    'reliefweb_documents' => [
+      'label' => t('Whitelabelled ReliefWeb documents'),
+      'xmlsitemap' => [
+        // Callback to create sitemap links.
+        'process callback' => 'unocha_sitemap_process_reliefweb_links',
+        // Callback to rebuild sitemap links.
+        'rebuild callback' => 'unocha_sitemap_rebuild_reliefweb_links',
+      ],
+    ],
+  ];
+}
+
+/**
+ * Callback to rebuild the sitemap links for the ReliefWeb documents.
+ *
+ * @param string $link_type_id
+ *   The type of sitemap links.
+ * @param mixed $context
+ *   Batch context.
+ */
+function unocha_sitemap_rebuild_reliefweb_links($link_type_id, &$context) {
+  if (!isset($context['sandbox']['info'])) {
+    $context['sandbox']['info'] = xmlsitemap_get_link_info($link_type_id);
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['last_id'] = 0;
+  }
+
+  $info = $context['sandbox']['info'];
+  $last_id = $context['sandbox']['last_id'] ?? 0;
+
+  $payload = [
+    'fields' => [
+      'include' => [
+        'id',
+        'url_alias',
+        'date',
+      ],
+    ],
+    'filter' => [
+      'conditions' => [
+        [
+          'field' => 'source.shortname.exact',
+          'value' => 'OCHA',
+        ],
+        [
+          'field' => 'id',
+          'value' => [
+            'from' => $last_id + 1,
+          ],
+        ],
+      ],
+      'operator' => 'AND',
+    ],
+    'sort' => ['id:asc'],
+    'limit' => 1000,
+  ];
+
+  $data = \Drupal::service('reliefweb_api.client')->request('reports', $payload, TRUE, 10);
+
+  if (!isset($context['sandbox']['max'])) {
+    $context['sandbox']['max'] = $data['totalCount'] ?? 0;
+
+    // If there are no items to process, skip everything else.
+    if (!$context['sandbox']['max']) {
+      $context['finished'] = 1;
+      return;
+    }
+  }
+
+  // Process the links.
+  if (!empty($data['data'][0]['id'])) {
+    $info['xmlsitemap']['process callback']($link_type_id, $data['data']);
+
+    $context['sandbox']['last_id'] = end($data['data'])['id'];
+    $context['sandbox']['progress'] += count($data['data']);
+    $context['message'] = t('Processed %link_type_id @last_id (@progress of @count).', [
+      '%link_type_id' => $link_type_id,
+      '@last_id' => $context['sandbox']['last_id'],
+      '@progress' => $context['sandbox']['progress'],
+      '@count' => $context['sandbox']['max'],
+    ]);
+
+    if ($context['sandbox']['progress'] >= $context['sandbox']['max']) {
+      $context['finished'] = 1;
+    }
+    else {
+      $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+    }
+  }
+  else {
+    $context['finished'] = 1;
+  }
+}
+
+/**
+ * Callback to generate sitemap links for ReliefWeb documents.
+ *
+ * @param string $link_type_id
+ *   The type of sitemap links.
+ * @param array $items
+ *   List of items returned by the ReliefWeb API.
+ */
+function unocha_sitemap_process_reliefweb_links($link_type_id, array $items) {
+  /** @var \Drupal\xmlsitemap\XmlSitemapLinkStorageInterface $link_storage */
+  $link_storage = \Drupal::service('xmlsitemap.link_storage');
+
+  foreach ($items as $item) {
+    if (isset($item['fields'])) {
+      $link = unocha_sitemap_xmlsitemap_create_link($link_type_id, $item['fields']);
+      if (!empty($link)) {
+        $link_storage->save($link);
+      }
+    }
+  }
+}
+
+/**
+ * Create a sitemap link from the ReliefWeb data for a resource.
+ *
+ * @param string $link_type_id
+ *   The type of sitemap links.
+ * @param array $data
+ *   Fields of a resource item from the ReliefWeb API.
+ */
+function unocha_sitemap_xmlsitemap_create_link($link_type_id, array $data) {
+  if (!isset($data['url_alias'])) {
+    return [];
+  }
+
+  $url = UrlHelper::getUnochaUrlFromReliefWebUrl($data['url_alias']);
+  $loc = '/' . ltrim(preg_replace('#^https?://[^/]+#', '', $url), '/');
+
+  $link = [
+    'type' => $link_type_id,
+    'id' => (string) $data['id'],
+    'subtype' => '',
+    'loc' => $loc,
+  ];
+
+  $timestamps['now'] = time();
+  if (isset($data['date']['changed'])) {
+    $timestamps['changed'] = strtotime($data['date']['changed']);
+  }
+  if (isset($data['date']['created'])) {
+    $timestamps['created'] = strtotime($data['date']['created']);
+  }
+
+  $link['changefreq'] = unocha_sitemap_get_change_frequency($timestamps);
+  $link['lastmod'] = $timestamps['changed'] ?? $timestamps['created'] ?? 0;
+
+  return $link;
+}
+
+/**
+ * Calculate the change frequency based on a list of timestamps.
+ *
+ * @param array $timestamps
+ *   List of timestamps (for each change to an entity for example).
+ *
+ * @return string
+ *   The name of the change frequency.
+ */
+function unocha_sitemap_get_change_frequency(array $timestamps) {
+  static $frequencies;
+  if (!isset($frequencies)) {
+    $frequencies = [
+      'always'  => 60,
+      'hourly'  => 60 * 60,
+      'daily'   => 24 * 60 * 60,
+      'weekly'  => 7 * 24 * 60 * 60,
+      'monthly' => 30 * 24 * 60 * 60,
+      'yearly'  => 365 * 24 * 60 * 60,
+    ];
+  }
+
+  if (count($timestamps) > 1) {
+    sort($timestamps);
+    $count = count($timestamps) - 1;
+    $diff = 0;
+
+    for ($i = 0; $i < $count; $i++) {
+      $diff += $timestamps[$i + 1] - $timestamps[$i];
+    }
+
+    $interval = round($diff / $count);
+
+    foreach ($frequencies as $value) {
+      if ($interval <= $value) {
+        return $value;
+      }
+    }
+  }
+
+  // Never.
+  return 0;
+}


### PR DESCRIPTION
Refs: UNO-580

This PR configures the `xmlsitemap` module and add a hook implementation to also create links for the white labeled RW documents.

### Deployment

The `xmlsitemap` module doesn't store the  base url it uses for the links in `config` and doesn't use the site base URL... (see: https://www.drupal.org/project/xmlsitemap/issues/2832471). 

So after deployment, one needs to go to `/admin/config/search/xmlsitemap/settings` and under `advanced settings`, set the  "default base URL" to something appropriate for the site (ex: https://www.unocha.org for prod before launch).

### Tests

1. Checkout the  branch, clear the cache, import the config
2. Run `drush sql-query "SHOW CREATE TABLE xmlsitemap"` and check that the `loc` field is a `varchar(2048)`
3. Set up the base URL as per the above "deployment" instructions
4. Run `drush xmlsitemap:rebuild`
5. Go to `/sitemap.xml` and check that there are 2 pages.