### PR TITLE
[UNO-712] Stories - number of items

### DIFF
--- a/config/views.view.stories.yml
+++ b/config/views.view.stories.yml
@@ -76,7 +76,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 10
+          items_per_page: 12
           total_pages: null
           id: 0
           tags:


### PR DESCRIPTION
Refs: UNO-712

Change view config to show 12 items on the stories page to avoid blank before pager.