### PR TITLE
feat: Rewrite URLs for the old /sites/unocha/files path.

### DIFF
--- a/docker/etc/nginx/custom/04_ecosoc_files.conf
+++ b/docker/etc/nginx/custom/04_ecosoc_files.conf
@@ -1,4 +1,0 @@
-location ~ "^/sites/unocha/files/(?<file_path>.+\.[^.]+)$" {
-  try_files /sites/default/files/ecosoc/$file_path /sites/default/files/legacy/$file_path =404;
-}
-

--- a/docker/etc/nginx/custom/04_ecosoc_files.conf
+++ b/docker/etc/nginx/custom/04_ecosoc_files.conf
@@ -1,0 +1,4 @@
+location ~ "^/sites/unocha/files/(?<file_path>.+\.[^.]+)$" {
+  try_files /sites/default/files/ecosoc/$file_path /sites/default/files/legacy/$file_path =404;
+}
+

--- a/docker/etc/nginx/custom/04_legacy_files.conf
+++ b/docker/etc/nginx/custom/04_legacy_files.conf
@@ -1,0 +1,5 @@
+# Allow legacy files (and ECOSOC files) to be available on their old URL.
+
+location ~ "^/sites/unocha/files/(?<file_path>.+\.[^.]+)$" {
+  try_files /sites/default/files/legacy/$file_path /sites/default/files/ecosoc/$file_path =404;
+}


### PR DESCRIPTION
This is so that ECOSOC documents may remain available at their existing URL and ECOSOC will continue to like us. Additonally, there is a provision for a generic "legacy" subdir under files where other "migrated" documents from the Drupal 7 files may live.

Refs: OPS-9445