### PR TITLE
[UNO-693] Drush command to create/update redirects

### DIFF
--- a/html/modules/custom/unocha_migrate/README.md
+++ b/html/modules/custom/unocha_migrate/README.md
@@ -3,4 +3,7 @@ UNOCHA - Migrate module
 
 This module handles initial migration/creation of content like the country terms.
 
-It provides the `unocha-migrate:update-country-terms` drush command to update or create taxonomy terms from the ReliefWeb API.
+It provides the following drush commands:
+
+- `unocha-migrate:update-country-terms`: update or create taxonomy terms from the ReliefWeb API.
+- `unocha-migrate:create-redirects`: create redirects (for example from a CSV file).

--- a/html/modules/custom/unocha_migrate/drush.services.yml
+++ b/html/modules/custom/unocha_migrate/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   unocha_migrate.commands:
     class: \Drupal\unocha_migrate\Commands\MigrateCommands
-    arguments: ['@entity_type.manager', '@reliefweb_api.client']
+    arguments: ['@config.factory', '@entity_type.manager', '@path_alias.manager', '@redirect.repository', '@reliefweb_api.client']
     tags:
       - { name: drush.command }

--- a/html/modules/custom/unocha_migrate/src/Commands/MigrateCommands.php
+++ b/html/modules/custom/unocha_migrate/src/Commands/MigrateCommands.php
@@ -2,7 +2,11 @@
 
 namespace Drupal\unocha_migrate\Commands;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\redirect\Entity\Redirect;
+use Drupal\redirect\RedirectRepository;
 use Drupal\unocha_reliefweb\Services\ReliefWebApiClient;
 use Drush\Commands\DrushCommands;
 
@@ -12,11 +16,25 @@ use Drush\Commands\DrushCommands;
 class MigrateCommands extends DrushCommands {
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * Entity Type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
+
+  /**
+   * The redirect repository.
+   *
+   * @var \Drupal\redirect\RedirectRepository
+   */
+  protected $redirectRepository;
 
   /**
    * ReliefWeb API Client.
@@ -26,13 +44,26 @@ class MigrateCommands extends DrushCommands {
   protected $reliefwebApiClient;
 
   /**
+   * The path alias manager.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  protected $pathAliasManager;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(
+    ConfigFactoryInterface $config_factory,
     EntityTypeManagerInterface $entity_type_manager,
+    AliasManagerInterface $path_alias_manager,
+    RedirectRepository $redirect_repository,
     ReliefWebApiClient $reliefweb_api_client
   ) {
+    $this->configFactory = $config_factory;
     $this->entityTypeManager = $entity_type_manager;
+    $this->pathAliasManager = $path_alias_manager;
+    $this->redirectRepository = $redirect_repository;
     $this->reliefwebApiClient = $reliefweb_api_client;
   }
 
@@ -139,6 +170,173 @@ class MigrateCommands extends DrushCommands {
     }
 
     $this->logger()->info('Updated/created ' . $updated . ' countries');
+  }
+
+  /**
+   * Create redirects for CSV file.
+   *
+   * If neither `file` not `source/target` is provided then it tries to read
+   * from stdin.
+   *
+   * @param array $options
+   *   Options for the command.
+   *
+   * @command unocha-migrate:create-redirects
+   *
+   * @option file Path to a CSV file containing pairs of source -> target redirect URLs.
+   * @option source Source URL of redirect. It must be used in conjunction with the target option.
+   * @option target Source URL of redirect. It must be used in conjunction with the source option.
+   * @option language Language for the redirect. Default to English.
+   *
+   * @default $options []
+   *
+   * @usage unocha-migrate:create-redirects --file=/tmp/test.csv
+   *   Create redirects from the test.csv file.
+   * @usage unocha-migrate:create-redirects --source=/truc --target=/bidule
+   *   Create a redirect from /truc to /bidule.
+   * @usage unocha-migrate:create-redirects < ./test.csv
+   *   Create redirects from CSV data was passed to stdin.
+   *
+   * @validate-module-enabled unocha_migrate
+   */
+  public function createRedirects($options = [
+    'file' => NULL,
+    'source' => NULL,
+    'target' => NULL,
+    'language' => 'en',
+  ]) {
+    $file = $options['file'] ?? NULL;
+    $source = $options['source'] ?? NULL;
+    $target = $options['target'] ?? NULL;
+    $language = $options['language'] ?? 'en';
+
+    if (empty($source) && empty($target)) {
+      // Ensure the auto detect line endings in on so that it can work with
+      // windows or unix files. This needs to happen before opening a file.
+      $auto_detect_line_endings = ini_get('auto_detect_line_endings') ?? FALSE;
+      ini_set('auto_detect_line_endings', TRUE);
+
+      // Read from a CSV file.
+      if (!empty($file)) {
+        if (!file_exists($file)) {
+          $this->logger()->error("The file '$file' doesn't exist");
+          return FALSE;
+        }
+        $handle = fopen($file, 'r');
+      }
+      // Otherwise try to read from the standard input.
+      else {
+        $file = 'stdin';
+        $handle = \STDIN;
+        // Make sure we do not block on the standard input which happens when
+        // it's empty.
+        stream_set_blocking($handle, FALSE);
+      }
+
+      if ($handle === FALSE) {
+        $this->logger()->error("Unable to open the file '$file'");
+        return FALSE;
+      }
+      try {
+        $count = 0;
+        $valid = 0;
+        while (($data = fgetcsv($handle)) !== FALSE) {
+          $count++;
+          if (count($data) >= 2 && $this->createRedirect($data[0], $data[1], $language)) {
+            $valid++;
+          }
+        }
+      }
+      catch (\Exception $exception) {
+        $this->logger()->error($exception->getMessage());
+      }
+      fclose($handle);
+
+      // Reset the line endings detection.
+      ini_set('auto_detect_line_endings', $auto_detect_line_endings);
+
+      if ($count === 0) {
+        $this->logger()->warning('No data found');
+      }
+      else {
+        $this->logger()->info("Processed $valid/$count valid redirects.");
+      }
+    }
+    elseif (empty($source)) {
+      $this->logger()->error('Missing source URL');
+      return FALSE;
+    }
+    elseif (empty($target)) {
+      $this->logger()->error('Missing target URL');
+      return FALSE;
+    }
+    else {
+      if ($this->createRedirect($source, $target, $language)) {
+        $this->logger()->info("Processed '$source' redirect.");
+      }
+      else {
+        $this->logger()->warning("Invalid source '$source' or target '$target'");
+      }
+    }
+  }
+
+  /**
+   * Create a redirect for the source and target.
+   *
+   * @param string $source
+   *   Source URL or path.
+   * @param string $target
+   *   Target URL or path.
+   * @param string $language
+   *   Language code.
+   *
+   * @return bool
+   *   TRUE if the redirect was created or already existed.
+   */
+  public function createRedirect($source, $target, $language = 'en') {
+    $source_path = parse_url(preg_replace('#^(https?://[^/]+)?/+#', 'https://wwww.unocha.org/', $source), \PHP_URL_PATH);
+    $target_path = parse_url(preg_replace('#^(https?://[^/]+)?/+#', 'https://wwww.unocha.org/', $target), \PHP_URL_PATH);
+
+    if (empty($source_path)) {
+      $this->logger()->warning("Invalid source: '$source'");
+      return FALSE;
+    }
+    if (empty($target_path)) {
+      $this->logger()->warning("Invalid target: '$target'");
+      return FALSE;
+    }
+
+    // Prevent double encoding.
+    $source_path = rawurldecode($source_path);
+    $target_path = rawurldecode($target_path);
+
+    try {
+      $target_path = $this->pathAliasManager->getPathByAlias($target_path, $language) ??
+        $this->redirectRepository->findMatchingRedirect($target_path, [], $language)?->getRedirect() ??
+        $target_path;
+
+      $redirect = $this->redirectRepository->findMatchingRedirect($source_path, [], $language) ??
+        Redirect::create();
+
+      $redirect->setSource($source_path);
+      $redirect->setRedirect($target_path);
+      $redirect->setLanguage($language);
+      $redirect->setStatusCode($this->configFactory->get('redirect.settings')->get('default_status_code'));
+      $result = $redirect->save();
+
+      if ($result === SAVED_NEW) {
+        $this->logger()->info("Created redirect from '$source' to '$target'");
+      }
+      else {
+        $this->logger()->info("Updated redirect from '$source' to '$target'");
+      }
+    }
+    catch (\Exception $exception) {
+      $this->logger()->warning("Unable to create redirect for '$source': $exception->getMessage()");
+      return FALSE;
+    }
+
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
Refs: UNO-693

This adds a drush command to create or update redirects from CSV data (or single one with the `--source` and `--target` options).

The CSV data must be 2 columns:  source URL (legacy) and target URL (new URL). The URL can be relative ones in the from `/path` or full URLs (the domain doesn't matter).

