### PR TITLE
fix: Replace the legacy/ecosoc rule with one that works.

### DIFF
--- a/docker/etc/nginx/custom/04_legacy_files.conf
+++ b/docker/etc/nginx/custom/04_legacy_files.conf
@@ -1,5 +1,8 @@
 # Allow legacy files (and ECOSOC files) to be available on their old URL.
 
-location ~ "^/sites/unocha/files/(?<file_path>.+\.[^.]+)$" {
-  try_files /sites/default/files/legacy/$file_path /sites/default/files/ecosoc/$file_path =404;
+location /sites/unocha/files {
+  location ~ ^/sites/unocha/files/(?<file_path>.*)$ {
+    try_files /sites/default/files/legacy/$file_path /sites/default/files/ecosoc/$file_path =404;
+  }
+  return 404 "404 Not Found";
 }


### PR DESCRIPTION
Probably this one does work because location match precedence. The end result is the same, so whatevs.

Refs: OPS-9445