### PR TITLE
UNO-724 Image and Image-and-Text image style should not crop

### DIFF
--- a/config/core.entity_view_display.media.image.original_resized.yml
+++ b/config/core.entity_view_display.media.image.original_resized.yml
@@ -1,0 +1,57 @@
+uuid: be5eb117-8804-4108-9096-9cf461d413ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.original_resized
+    - field.field.media.image.field_canto_asset_id
+    - field.field.media.image.field_image_caption
+    - field.field.media.image.field_image_copyright
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.original_resized
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.image.original_resized
+targetEntityType: media
+bundle: image
+mode: original_resized
+content:
+  field_image_caption:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_image_copyright:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_media_image:
+    type: responsive_image
+    label: visually_hidden
+    settings:
+      responsive_image_style: original_resized
+      image_link: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_canto_asset_id: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.paragraph.image.default.yml
+++ b/config/core.entity_view_display.paragraph.image.default.yml
@@ -14,7 +14,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: story
+      view_mode: original_resized
       link: false
     third_party_settings: {  }
     weight: 0

--- a/config/core.entity_view_display.paragraph.text_and_image.default.yml
+++ b/config/core.entity_view_display.paragraph.text_and_image.default.yml
@@ -19,7 +19,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: story
+      view_mode: original_resized
       link: false
     third_party_settings: {  }
     weight: 2

--- a/config/core.entity_view_display.paragraph.text_and_image.image_align_left.yml
+++ b/config/core.entity_view_display.paragraph.text_and_image.image_align_left.yml
@@ -25,7 +25,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: story
+      view_mode: original_resized
       link: false
     third_party_settings: {  }
     weight: 1

--- a/config/core.entity_view_display.paragraph.text_and_image.image_align_right.yml
+++ b/config/core.entity_view_display.paragraph.text_and_image.image_align_right.yml
@@ -25,7 +25,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: story
+      view_mode: original_resized
       link: false
     third_party_settings: {  }
     weight: 2

--- a/config/core.entity_view_mode.media.original_resized.yml
+++ b/config/core.entity_view_mode.media.original_resized.yml
@@ -1,0 +1,10 @@
+uuid: b38520e7-be86-4eac-a26c-8c98f088a25d
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.original_resized
+label: 'Original resized'
+targetEntityType: media
+cache: true

--- a/config/responsive_image.styles.original_resized.yml
+++ b/config/responsive_image.styles.original_resized.yml
@@ -1,0 +1,79 @@
+uuid: 4690d393-54c8-41e1-8ae1-af11de9930aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.full_width_100
+    - image.style.full_width_133
+    - image.style.full_width_180
+    - image.style.full_width_200
+    - image.style.full_width_50
+    - image.style.full_width_66
+    - image.style.full_width_90
+  theme:
+    - common_design_subtheme
+id: original_resized
+label: 'Original resized'
+image_style_mappings:
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_100
+    breakpoint_id: common_design_subtheme.xxl
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_100
+    breakpoint_id: common_design_subtheme.xl
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_100
+    breakpoint_id: common_design_subtheme.lg
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_200
+    breakpoint_id: common_design_subtheme.xxl
+    multiplier: 2x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_200
+    breakpoint_id: common_design_subtheme.xl
+    multiplier: 2x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_200
+    breakpoint_id: common_design_subtheme.lg
+    multiplier: 2x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_90
+    breakpoint_id: common_design_subtheme.md
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_180
+    breakpoint_id: common_design_subtheme.md
+    multiplier: 2x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_66
+    breakpoint_id: common_design_subtheme.sm
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_50
+    breakpoint_id: common_design_subtheme.xs
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_133
+    breakpoint_id: common_design_subtheme.sm
+    multiplier: 2x
+  -
+    image_mapping_type: image_style
+    image_mapping: full_width_100
+    breakpoint_id: common_design_subtheme.xs
+    multiplier: 2x
+breakpoint_group: common_design_subtheme
+fallback_image_style: full_width_50


### PR DESCRIPTION
chore: media view mode for original resize, set responsive image styles to use full image style and update image and image and text paragraph type

Please see UNO-724 for more.

To test (optional):
1. Import config, drush image:flush
2. Visit `/news/afghan-women-aid-workers-risk-own-lives-keep-people-alive` and check that the images in the content area are no longer cropped
3. On any page, add a Text and Image paragraph and upload a diagram or another image with a non 3:2 aspect ratio. Make sure the whole image appears and there is no cropping.

Refs: UNO-724