### PR TITLE
[UNO-727] Fix ids of main navigation menu

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/navigation/menu--main.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/navigation/menu--main.html.twig
@@ -50,7 +50,7 @@
       ]
     %}
 
-    {% set parent_id = attributes.id ?? (component ~ menu_level) %}
+    {% set parent_id = attributes.id ?? component  %}
 
     {# In case of a mega menu, wrap the list of menu items to ease styling. #}
     {% if mega_menu and menu_level == 1 %}
@@ -82,7 +82,7 @@
               'data-cd-toggable': item.title,
               'data-cd-icon': 'arrow-down',
               'data-cd-component': component,
-              'id': (component ~ '-' ~ menu_level_cosmetic ~ '-' ~ loop.index)|clean_id,
+              'id': id ~ '-wrapper',
             })
           %}
           <div{{ dropdown_attributes.addClass('uno-mega-menu__dropdown') }}>
@@ -97,9 +97,9 @@
              will be replaced with a button to show the child menu.
            - If the menu item has children, an id attribute / value is added. #}
         {% if url is not empty %}
-        <a class="cd-nav__btn {{ component ~ '__btn' }} menu-item__label" href="{{ url }}" id="{{ id }}"><span>{{ title }}</span></a>
+        <a class="cd-nav__btn {{ component ~ '__btn' }} menu-item__label" href="{{ url }}" id="{{ id ~ '-link' }}"><span>{{ title }}</span></a>
         {% else %}
-        <span class="menu-item__label" id="{{ id }}">{{ title }}</span>
+        <span class="menu-item__label" id="{{ id ~ '-link' }}">{{ title }}</span>
         {% endif %}
 
         {% if item.is_expanded and item.below %}
@@ -111,13 +111,15 @@
                 'data-cd-toggable': item.title,
                 'data-cd-icon': 'arrow-down',
                 'data-cd-component': component,
-                'data-cd-replace': id,
-                'id': (component ~ '-' ~ menu_level_cosmetic ~ '-' ~ loop.index)|clean_id,
+                'data-cd-replace': id ~ '-link',
+                'id': id ~ '-menu',
               })
             %}
           {# Reset the attributes otherwise. #}
           {% else %}
-            {% set attributes = create_attribute() %}
+            {% set attributes = create_attribute({
+              'id': id ~ '-menu',
+            }) %}
           {% endif %}
 
           {# Limit the nested levels. #}


### PR DESCRIPTION
Refs: UNO-727

This fixes the IDs of the main navigation menu to ensure uniqueness.

### Tests

1. Checkout the branch, clear the cache
2. Run `Object.entries(Array.from(document.querySelectorAll('[id]')).map(v => v.id).reduce((acc, v) => { acc[v] = (acc[v] || 0) + 1; return acc }, {})).filter(([key, value]) => value > 1).map(([ key, value]) => key);` in the browser console to get the list of duplicate IDs.
3. Confirm that there are none starting with `cd-nav` (main navigation).