### PR TITLE
[UNO-739] Use one decimal point for the figures

### DIFF
--- a/config/core.entity_view_display.paragraph.figures.figures_compact_long.yml
+++ b/config/core.entity_view_display.paragraph.figures.figures_compact_long.yml
@@ -31,7 +31,7 @@ content:
     label: hidden
     settings:
       format: long
-      precision: 2
+      precision: 1
       percentage: 'yes'
       currency_symbol: 'yes'
     third_party_settings: {  }
@@ -49,7 +49,7 @@ content:
     label: hidden
     settings:
       format: long
-      precision: 2
+      precision: 1
       percentage: 'yes'
       currency_symbol: 'yes'
     third_party_settings: {  }

--- a/config/core.entity_view_display.paragraph.figures.figures_compact_short.yml
+++ b/config/core.entity_view_display.paragraph.figures.figures_compact_short.yml
@@ -49,7 +49,7 @@ content:
     label: hidden
     settings:
       format: short
-      precision: 2
+      precision: 1
       percentage: 'yes'
       currency_symbol: 'yes'
     third_party_settings: {  }

--- a/html/modules/custom/unocha_utility/src/Helpers/NumberFormatter.php
+++ b/html/modules/custom/unocha_utility/src/Helpers/NumberFormatter.php
@@ -326,10 +326,6 @@ class NumberFormatter {
       if ($number < 1e6) {
         $n = $n / 1000;
         $p = $p + 1;
-        $precision = 2;
-      }
-      else {
-        $precision = 1;
       }
     }
 


### PR DESCRIPTION
Refs: UNO-739

This changes the precision for all the figures on the site to have only 1 decimal point.

### Tests

1. Checkout the branch, clear the cache, import the condig
2. Visit pages with figures like `/our-funding`
3. Check that the figures are rounded to 1 decimal point