### PR TITLE
UNO-575 Render layout row only if there is content

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-layout/uno-layout.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-layout/uno-layout.css
@@ -17,15 +17,15 @@
 .layout--fivecol .layout--row {
   display: flex;
   flex-flow: row wrap;
-  gap: 0 var(--uno-card-list-gap-size);
+  gap: var(--uno-card-list-gap-size);
 }
 
 .layout--twocol .layout--row {
-  gap: 0 var(--uno-card-list-gap-size--twocol);
+  gap: var(--uno-card-list-gap-size--twocol);
 }
 
 .layout--fivecol .layout--row {
-  gap: 0 var(--uno-card-list-gap-size--reduced);
+  gap: var(--uno-card-list-gap-size--reduced);
 }
 
 .layout--threecol .layout--row > .layout__region,
@@ -68,22 +68,6 @@
 }
 
 @media screen and (min-width: 768px) {
-  .layout--twocol .layout--row,
-  .layout--twocol-siderbar,
-  .layout--threecol .layout--row,
-  .layout--fourcol .layout--row,
-  .layout--fivecol .layout--row {
-    gap: var(--uno-card-list-gap-size);
-  }
-
-  .layout--twocol .layout--row {
-    gap: var(--uno-card-list-gap-size--twocol);
-  }
-
-  .layout--fivecol .layout--row {
-    gap: var(--uno-card-list-gap-size--reduced);
-  }
-
   .layout--twocol .layout--row > .layout__region {
     --uno-card-list-num-cols: 2;
   }

--- a/html/themes/custom/common_design_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/styles.css
@@ -583,7 +583,7 @@ footer.cd-author {
   affect other contexts where this layout is used in the future.
 */
 
-.cd-layout__content .rw-river-article--with-preview .rw-river-article__content img,
+.layout--twocol-sidebar .cd-layout__content .rw-river-article--with-preview .rw-river-article__content img,
 .cd-layout__sidebar--wide .rw-river-article--with-preview .rw-river-article__content img {
   display: none;
 }

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--fivecol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--fivecol.html.twig
@@ -52,6 +52,7 @@
       {% endif %}
     </div>
 
+  {% if content.sixth|render or content.seventh|render or content.eighth|render or content.ninth|render or content.tenth|render %}
     <div class="layout--row">
       {% if content.sixth %}
         <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
@@ -83,6 +84,7 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
   </div>
 {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--fourcol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--fourcol.html.twig
@@ -46,6 +46,7 @@
       {% endif %}
     </div>
 
+  {% if content.fifth|render or content.sixth|render or content.seventh|render or content.eighth|render %}
     <div class="layout--row">
       {% if content.fifth %}
         <div {{ region_attributes.fifth.addClass('layout__region', 'layout__region--fifth') }}>
@@ -71,6 +72,7 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
   </div>
 {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--threecol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--threecol.html.twig
@@ -41,6 +41,7 @@
       {% endif %}
     </div>
 
+  {% if content.fourth|render or content.fifth|render or content.sixth|render %}
     <div class="layout--row">
       {% if content.fourth %}
         <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
@@ -60,6 +61,7 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
   </div>
 {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--twocol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--twocol.html.twig
@@ -35,6 +35,7 @@
       {% endif %}
     </div>
 
+  {% if content.third|render or content.fourth %}
     <div class="layout--row">
       {% if content.third %}
         <div {{ region_attributes.third.addClass('layout__region', 'layout__region--third') }}>
@@ -48,6 +49,7 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
   </div>
 {% endif %}


### PR DESCRIPTION
UNO-743 The render filter is being applied to the layout row, not the layout regions. This means we can still use a layout and leave the first region empty and it takes up space.

This also fixes an issue I introduced earlier which hid the RW images in places where we want them to show (Publications page)