### PR TITLE
[UNO-740] Media centre - archive page

### DIFF
--- a/config/core.entity_form_display.paragraph.media_centre.default.yml
+++ b/config/core.entity_form_display.paragraph.media_centre.default.yml
@@ -9,11 +9,18 @@ dependencies:
     - paragraphs.paragraphs_type.media_centre
   module:
     - text
+    - viewsreference
 id: paragraph.media_centre.default
 targetEntityType: paragraph
 bundle: media_centre
 mode: default
 content:
+  field_media_centre_list:
+    type: viewsreference_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_text:
     type: text_textarea
     weight: 1
@@ -32,16 +39,15 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 3
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
-  field_media_centre_list: true

--- a/config/views.view.media_centre.yml
+++ b/config/views.view.media_centre.yml
@@ -193,12 +193,53 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  media_centre:
-    id: media_centre
-    display_title: Block
+  block_archive:
+    id: block_archive
+    display_title: Archive
     display_plugin: block
     position: 1
     display_options:
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 12
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      defaults:
+        pager: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  media_centre:
+    id: media_centre
+    display_title: Latest
+    display_plugin: block
+    position: 1
+    display_options:
+      display_description: ''
       display_extenders: {  }
     cache_metadata:
       max-age: -1

--- a/config/views.view.media_centre.yml
+++ b/config/views.view.media_centre.yml
@@ -75,7 +75,7 @@ display:
         type: some
         options:
           offset: 0
-          items_per_page: 5
+          items_per_page: 6
       exposed_form:
         type: basic
         options:

--- a/html/themes/custom/common_design_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/styles.css
@@ -378,7 +378,8 @@
 .view-display-id-past_events .view-header,
 .view-display-id-response_stories .view-header,
 .view-display-id-stories .view-header,
-.uno-stories .uno-stories__header {
+.uno-stories .uno-stories__header,
+.uno-media-centre .uno-media-centre__header {
   display: flex;
   align-items: baseline;
 }
@@ -393,16 +394,19 @@
 }
 
 .uno-stories .uno-stories__view_all,
+.uno-media-centre .uno-media-centre__view_all,
 .view-header .views-display-link {
   flex: 1 0 auto;
 }
 .uno-stories .uno-stories__view_all a,
+.uno-media-centre .uno-media-centre__view_all a,
 .view-header .views-display-link {
   position: relative;
   padding-inline-start: 1rem;
 }
 
 .uno-stories .uno-stories__view_all a::after,
+.uno-media-centre .uno-media-centre__view_all a::after,
 .view-header .views-display-link::after {
   display: inline-block;
   overflow: hidden;
@@ -414,6 +418,8 @@
 }
 .uno-stories .uno-stories__view_all a:hover::after,
 .uno-stories .uno-stories__view_all a:focus::after,
+.uno-media-centre .uno-media-centre__view_all a:hover::after,
+.uno-media-centre .uno-media-centre__view_all a:focus::after,
 .view-header .views-display-link:hover::after,
 .view-header .views-display-link:focus::after {
   display: inline-block;

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--media-centre.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--media-centre.html.twig
@@ -1,0 +1,68 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/uno-card-list') }}
+{{ attach_library('common_design_subtheme/rw-icons') }}
+
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'uno-media-centre',
+    'paragraph--type--content-list'
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      <header class="uno-media-centre__header">
+        {{- content.field_title -}}
+        {% if path('<current>') != '/media-centre/archive' %}
+        <span class="uno-media-centre__view_all"><a href="/media-centre/archive">{% trans %}View all{% endtrans %}</a></span>
+        {% endif %}
+      </header>
+      <div class="uno-media-centre__content">
+        {{ content|without('field_title') }}
+      </div>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Refs: UNO-740

This PR changes the limit of the media collection items in the media centre block to 6 (from 5).

It also adds a new "archive" block that shows a paginated list of media collection items (12) like the "stories" view (no filters though).

Similar to the stories page, this block can be used on a basic page ("Media centre - Archive") with `/media-centre/archive` as path alias.

To go with that there is a template override for the `media-centre` paragraph type that displays a "view all" link to that archive page when not already on that page.

The "view all" link is styles the same

### Deployment/setup

1. Normal deployment (cache clearing, config import)
2. Create a basic page with something like "Media centre - Archive" as title
3. Add a "media centre" paragraph type, select the "Archive" display
4. Add a url alias, uncheck the "Generate automatic URL alias" and entre "/media-centre/archive"

### Tests

See above setup section.