### PR TITLE
[UNO-741] Photo galleries

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-media/uno-media.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-media/uno-media.css
@@ -42,11 +42,16 @@
     flex-basis: auto;
     flex-grow: 0;
     flex-shrink: 0;
-    width: 33%;
+    width: 33.33%;
   }
 
   .uno-photo-gallery--two-columns .uno-photo-gallery__photo:first-child {
-    width: 66%;
+    width: 100%;
+  }
+
+  .uno-photo-gallery--two-columns .uno-photo-gallery__photos[data-count="2"] .uno-photo-gallery__photo:first-child,
+  .uno-photo-gallery--two-columns .uno-photo-gallery__photos[data-count="5"] .uno-photo-gallery__photo:first-child {
+    width: 66.66%;
   }
 }
 

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-media-image--media-collection.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-media-image--media-collection.html.twig
@@ -1,4 +1,4 @@
-<div class="uno-photo-gallery__photos">
+<div class="uno-photo-gallery__photos" data-count="{{ items|length }}">
 {%- for item in items -%}
   <div class="uno-photo-gallery__photo">
   {{ item.content }}


### PR DESCRIPTION
Refs: UNO-741

This PR adds a "data-count" attribute to the media photo galleries and uses it to adjust the size of the images:

<img width="1212" alt="Screenshot 2023-07-24 at 8 45 27" src="https://github.com/UN-OCHA/unocha-site/assets/696348/fab16b79-1b73-491a-ba8e-464bab9e93d3">
<img width="1196" alt="Screenshot 2023-07-24 at 8 45 17" src="https://github.com/UN-OCHA/unocha-site/assets/696348/edeb2990-d98c-4e0a-b3a8-12f374c4b11c">
<img width="1240" alt="Screenshot 2023-07-24 at 8 45 06" src="https://github.com/UN-OCHA/unocha-site/assets/696348/74cdabb3-df27-4907-9a86-3330256b8936">
<img width="1206" alt="Screenshot 2023-07-24 at 8 44 53" src="https://github.com/UN-OCHA/unocha-site/assets/696348/2a1f45ee-0914-4d98-8f17-252d96577b6b">
<img width="1248" alt="Screenshot 2023-07-24 at 8 44 43" src="https://github.com/UN-OCHA/unocha-site/assets/696348/0f40d4fe-438b-4ee1-a796-4b1c8e720b02">
