### PR TITLE
[UNO-743] Layouts

### DIFF
--- a/html/themes/custom/common_design_claro/common_design_claro.theme
+++ b/html/themes/custom/common_design_claro/common_design_claro.theme
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Template overrides, preprocess, and hooks for the Common Design claro theme.
+ */
+
+/**
+ * Implements hook_preprocess_paragraph__preview().
+ */
+function common_design_claro_preprocess_paragraph__layout__preview(array &$variables) {
+  // Add the preview suffix to the theme so that we can use different templates
+  // than the frontend ones and display all the regions to be able to fill them.
+  if (isset($variables['content']['regions']['#theme'])) {
+    $variables['content']['regions']['#theme'] .= '__preview';
+  }
+}

--- a/html/themes/custom/common_design_claro/templates/layouts/layout--fivecol--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/layouts/layout--fivecol--preview.html.twig
@@ -1,0 +1,88 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a four-column 25%-25%-25%-25% layout.
+ *
+ * Available variables:
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--fivecol',
+  ]
+%}
+{% if content %}
+  <div{{ attributes.addClass(classes) }}>
+
+    <div class="layout--row">
+      {% if content.first %}
+        <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
+          {{ content.first }}
+        </div>
+      {% endif %}
+
+      {% if content.second %}
+        <div {{ region_attributes.second.addClass('layout__region', 'layout__region--second') }}>
+          {{ content.second }}
+        </div>
+      {% endif %}
+
+      {% if content.third %}
+        <div {{ region_attributes.third.addClass('layout__region', 'layout__region--third') }}>
+          {{ content.third }}
+        </div>
+      {% endif %}
+
+      {% if content.fourth %}
+        <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
+          {{ content.fourth }}
+        </div>
+      {% endif %}
+
+      {% if content.fifth %}
+        <div {{ region_attributes.fifth.addClass('layout__region', 'layout__region--fifth') }}>
+          {{ content.fifth }}
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="layout--row">
+      {% if content.sixth %}
+        <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
+          {{ content.sixth }}
+        </div>
+      {% endif %}
+
+      {% if content.seventh %}
+        <div {{ region_attributes.seventh.addClass('layout__region', 'layout__region--seventh') }}>
+          {{ content.seventh }}
+        </div>
+      {% endif %}
+
+      {% if content.eighth %}
+        <div {{ region_attributes.eighth.addClass('layout__region', 'layout__region--eighth') }}>
+          {{ content.eighth }}
+        </div>
+      {% endif %}
+
+      {% if content.ninth %}
+        <div {{ region_attributes.ninth.addClass('layout__region', 'layout__region--ninth') }}>
+          {{ content.ninth }}
+        </div>
+      {% endif %}
+
+      {% if content.tenth %}
+        <div {{ region_attributes.tenth.addClass('layout__region', 'layout__region--tenth') }}>
+          {{ content.tenth }}
+        </div>
+      {% endif %}
+    </div>
+
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_claro/templates/layouts/layout--fourcol--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/layouts/layout--fourcol--preview.html.twig
@@ -1,0 +1,76 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a four-column 25%-25%-25%-25% layout.
+ *
+ * Available variables:
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--fourcol',
+  ]
+%}
+{% if content %}
+  <div{{ attributes.addClass(classes) }}>
+
+    <div class="layout--row">
+      {% if content.first %}
+        <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
+          {{ content.first }}
+        </div>
+      {% endif %}
+
+      {% if content.second %}
+        <div {{ region_attributes.second.addClass('layout__region', 'layout__region--second') }}>
+          {{ content.second }}
+        </div>
+      {% endif %}
+
+      {% if content.third %}
+        <div {{ region_attributes.third.addClass('layout__region', 'layout__region--third') }}>
+          {{ content.third }}
+        </div>
+      {% endif %}
+
+      {% if content.fourth %}
+        <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
+          {{ content.fourth }}
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="layout--row">
+      {% if content.fifth %}
+        <div {{ region_attributes.fifth.addClass('layout__region', 'layout__region--fifth') }}>
+          {{ content.fifth }}
+        </div>
+      {% endif %}
+
+      {% if content.sixth %}
+        <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
+          {{ content.sixth }}
+        </div>
+      {% endif %}
+
+      {% if content.seventh %}
+        <div {{ region_attributes.seventh.addClass('layout__region', 'layout__region--seventh') }}>
+          {{ content.seventh }}
+        </div>
+      {% endif %}
+
+      {% if content.eighth %}
+        <div {{ region_attributes.eighth.addClass('layout__region', 'layout__region--eighth') }}>
+          {{ content.eighth }}
+        </div>
+      {% endif %}
+    </div>
+
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_claro/templates/layouts/layout--threecol--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/layouts/layout--threecol--preview.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a three-column layout.
+ *
+ * Available variables:
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--threecol',
+  ]
+%}
+
+{% if content %}
+  <div{{ attributes.addClass(classes) }}>
+
+  <div class="layout--row">
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
+
+    {% if content.second %}
+      <div {{ region_attributes.second.addClass('layout__region', 'layout__region--second') }}>
+        {{ content.second }}
+      </div>
+    {% endif %}
+
+    {% if content.third %}
+      <div {{ region_attributes.third.addClass('layout__region', 'layout__region--third') }}>
+        {{ content.third }}
+      </div>
+    {% endif %}
+  </div>
+
+  <div class="layout--row">
+    {% if content.fourth %}
+      <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
+        {{ content.fourth }}
+      </div>
+    {% endif %}
+
+    {% if content.fifth %}
+      <div {{ region_attributes.fifth.addClass('layout__region', 'layout__region--fifth') }}>
+        {{ content.fifth }}
+      </div>
+    {% endif %}
+
+    {% if content.sixth %}
+      <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
+        {{ content.sixth }}
+      </div>
+    {% endif %}
+  </div>
+
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_claro/templates/layouts/layout--twocol--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/layouts/layout--twocol--preview.html.twig
@@ -1,0 +1,53 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a two-column layout.
+ *
+ * Available variables:
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--twocol',
+  ]
+%}
+
+{% if content %}
+  <div{{attributes.addClass(classes)}}>
+
+    <div class="layout--row">
+      {% if content.first %}
+        <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
+          {{ content.first }}
+        </div>
+      {% endif %}
+
+      {% if content.second %}
+        <div {{ region_attributes.second.addClass('layout__region', 'layout__region--second') }}>
+          {{ content.second }}
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="layout--row">
+      {% if content.third %}
+        <div {{ region_attributes.third.addClass('layout__region', 'layout__region--third') }}>
+          {{ content.third }}
+        </div>
+      {% endif %}
+
+      {% if content.fourth %}
+        <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
+          {{ content.fourth }}
+        </div>
+      {% endif %}
+    </div>
+
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_claro/templates/layouts/layout--twocol-66-33--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/layouts/layout--twocol-66-33--preview.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a two-column layout.
+ *
+ * Available variables:
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--twocol-66-33'
+  ]
+%}
+
+{% if content %}
+  <div{{attributes.addClass(classes)}}>
+
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
+
+    {% if content.second %}
+      <div {{ region_attributes.second.addClass('layout__region', 'layout__region--second') }}>
+        {{ content.second }}
+      </div>
+    {% endif %}
+
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_claro/templates/layouts/layout--twocol-sidebar--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/layouts/layout--twocol-sidebar--preview.html.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a two-column layout.
+ *
+ * Available variables:
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--twocol-sidebar',
+    'cd-layout'
+  ]
+%}
+
+{% if content %}
+  <div{{attributes.addClass(classes)}}>
+
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first', 'cd-layout__content') }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
+
+    {% if content.second %}
+      <div {{ region_attributes.second.addClass('layout__region', 'layout__region--second', 'cd-layout__sidebar', 'cd-layout__sidebar--wide') }}>
+        {{ content.second }}
+      </div>
+    {% endif %}
+
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--fivecol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--fivecol.html.twig
@@ -20,6 +20,7 @@
 {% if content %}
   <div{{ attributes.addClass(classes) }}>
 
+  {% if content.first|length > 1 or content.second|length > 1 or content.third|length > 1 or content.fourth|length > 1 or content.fifth|length > 1 %}
     <div class="layout--row">
       {% if content.first %}
         <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
@@ -51,8 +52,9 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
-  {% if logged_in %}
+  {% if content.sixth|length > 1 or content.seventh|length > 1 or content.eighth|length > 1 or content.ninth|length > 1 or content.tenth|length > 1 %}
     <div class="layout--row">
       {% if content.sixth %}
         <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
@@ -84,40 +86,6 @@
         </div>
       {% endif %}
     </div>
-  {% else %}
-    {% if content.sixth|render or content.seventh|render or content.eighth|render or content.ninth|render or content.tenth|render %}
-      <div class="layout--row">
-        {% if content.sixth %}
-          <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
-            {{ content.sixth }}
-          </div>
-        {% endif %}
-
-        {% if content.seventh %}
-          <div {{ region_attributes.seventh.addClass('layout__region', 'layout__region--seventh') }}>
-            {{ content.seventh }}
-          </div>
-        {% endif %}
-
-        {% if content.eighth %}
-          <div {{ region_attributes.eighth.addClass('layout__region', 'layout__region--eighth') }}>
-            {{ content.eighth }}
-          </div>
-        {% endif %}
-
-        {% if content.ninth %}
-          <div {{ region_attributes.ninth.addClass('layout__region', 'layout__region--ninth') }}>
-            {{ content.ninth }}
-          </div>
-        {% endif %}
-
-        {% if content.tenth %}
-          <div {{ region_attributes.tenth.addClass('layout__region', 'layout__region--tenth') }}>
-            {{ content.tenth }}
-          </div>
-        {% endif %}
-      </div>
-    {% endif %}
   {% endif %}
   </div>
 {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--fourcol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--fourcol.html.twig
@@ -20,6 +20,7 @@
 {% if content %}
   <div{{ attributes.addClass(classes) }}>
 
+  {% if content.first|length > 1 or content.second|length > 1 or content.third|length > 1 or content.fourth|length > 1 %}
     <div class="layout--row">
       {% if content.first %}
         <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
@@ -45,8 +46,9 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
-  {% if logged_in %}
+  {% if content.fifth|length > 1 or content.sixth|length > 1 or content.seventh|length > 1 or content.eighth|length > 1 %}
     <div class="layout--row">
       {% if content.fifth %}
         <div {{ region_attributes.fifth.addClass('layout__region', 'layout__region--fifth') }}>
@@ -72,34 +74,6 @@
         </div>
       {% endif %}
     </div>
-  {% else %}
-    {% if content.fifth|render or content.sixth|render or content.seventh|render or content.eighth|render %}
-      <div class="layout--row">
-        {% if content.fifth %}
-          <div {{ region_attributes.fifth.addClass('layout__region', 'layout__region--fifth') }}>
-            {{ content.fifth }}
-          </div>
-        {% endif %}
-
-        {% if content.sixth %}
-          <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
-            {{ content.sixth }}
-          </div>
-        {% endif %}
-
-        {% if content.seventh %}
-          <div {{ region_attributes.seventh.addClass('layout__region', 'layout__region--seventh') }}>
-            {{ content.seventh }}
-          </div>
-        {% endif %}
-
-        {% if content.eighth %}
-          <div {{ region_attributes.eighth.addClass('layout__region', 'layout__region--eighth') }}>
-            {{ content.eighth }}
-          </div>
-        {% endif %}
-      </div>
-    {% endif %}
   {% endif %}
 
   </div>

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--threecol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--threecol.html.twig
@@ -21,6 +21,7 @@
 {% if content %}
   <div{{ attributes.addClass(classes) }}>
 
+  {% if content.first|length > 1 or content.second|length > 1 or content.third|length > 1 %}
     <div class="layout--row">
       {% if content.first %}
         <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
@@ -40,8 +41,9 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
-  {% if logged_in %}
+  {% if content.fourth|length > 1 or content.fifth|length > 1 or content.sixth|length > 1 %}
     <div class="layout--row">
       {% if content.fourth %}
         <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
@@ -61,28 +63,6 @@
         </div>
       {% endif %}
     </div>
-  {% else %}
-    {% if content.fourth|render or content.fifth|render or content.sixth|render %}
-      <div class="layout--row">
-        {% if content.fourth %}
-          <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
-            {{ content.fourth }}
-          </div>
-        {% endif %}
-
-        {% if content.fifth %}
-          <div {{ region_attributes.fifth.addClass('layout__region', 'layout__region--fifth') }}>
-            {{ content.fifth }}
-          </div>
-        {% endif %}
-
-        {% if content.sixth %}
-          <div {{ region_attributes.sixth.addClass('layout__region', 'layout__region--sixth') }}>
-            {{ content.sixth }}
-          </div>
-        {% endif %}
-      </div>
-    {% endif %}
   {% endif %}
 
   </div>

--- a/html/themes/custom/common_design_subtheme/templates/layouts/layout--twocol.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layouts/layout--twocol.html.twig
@@ -21,6 +21,7 @@
 {% if content %}
   <div{{attributes.addClass(classes)}}>
 
+  {% if content.first|length > 1 or content.second|length > 1 %}
     <div class="layout--row">
       {% if content.first %}
         <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
@@ -34,8 +35,9 @@
         </div>
       {% endif %}
     </div>
+  {% endif %}
 
-  {% if logged_in %}
+  {% if content.third|length > 1 or content.fourth|length > 1 %}
     <div class="layout--row">
       {% if content.third %}
         <div {{ region_attributes.third.addClass('layout__region', 'layout__region--third') }}>
@@ -49,22 +51,6 @@
         </div>
       {% endif %}
     </div>
-  {% else %}
-    {% if content.third|render or content.fourth %}
-      <div class="layout--row">
-        {% if content.third %}
-          <div {{ region_attributes.third.addClass('layout__region', 'layout__region--third') }}>
-            {{ content.third }}
-          </div>
-        {% endif %}
-
-        {% if content.fourth %}
-          <div {{ region_attributes.fourth.addClass('layout__region', 'layout__region--fourth') }}>
-            {{ content.fourth }}
-          </div>
-        {% endif %}
-      </div>
-    {% endif %}
   {% endif %}
 
   </div>


### PR DESCRIPTION
Refs: UNO-743

*Please ignore the wrong reference to RW-743. It should read UNO-743. Was just doing 2 things a the same time...*

This PR does 2 things:

1. Add templates for the layouts (when used in a layout paragraph which is our use case) in the admin theme
2. Prevent rendering the content of the region twice but preserve the logic to display or not the rows based on whether the regions are empty or not.

This results in the original behavior from https://github.com/UN-OCHA/unocha-site/pull/257 for the frontend while preserving all the regions and rows in backend.

**Notes**

Empty regions only have the `#attributes` property. Non empty ones will have the `#attributes` property and at least one more for its content. So by checking the `length` we can determine if the region is empty or not. That avoids having to render the region for the test and rendering it again later.

If we want something slightly more robust we could add a hook_preprocess_layout that would add a flag for example to the regions that are empty.

### Tests

1. Checkout the branch, clear the cache
2. Check that the second row doesn't appear under the USG/ASG
3. Check that the "What we do etc." block on the homepage still displays as expected
4. Edit/create a node and add a "layout" paragraph with for example 3 columns and check that the 6 regions are visible and content can be added to them
