### PR TITLE
[UNO-746] Restore user menu when logged in

### DIFF
--- a/config/block.block.languageswitcher.yml
+++ b/config/block.block.languageswitcher.yml
@@ -9,7 +9,7 @@ dependencies:
 id: languageswitcher
 theme: common_design_subtheme
 region: header_top
-weight: -6
+weight: -8
 provider: null
 plugin: 'language_block:language_interface'
 settings:

--- a/config/block.block.topmenu.yml
+++ b/config/block.block.topmenu.yml
@@ -11,7 +11,7 @@ dependencies:
 id: topmenu
 theme: common_design_subtheme
 region: header_top
-weight: 0
+weight: -10
 provider: null
 plugin: 'system_menu_block:top-menu'
 settings:

--- a/config/block.block.useraccountmenu.yml
+++ b/config/block.block.useraccountmenu.yml
@@ -1,6 +1,6 @@
 uuid: 27c7be05-3927-4379-b034-2762d177d8a7
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - system.menu.account
@@ -11,7 +11,7 @@ dependencies:
 id: useraccountmenu
 theme: common_design_subtheme
 region: header_top
-weight: -4
+weight: -9
 provider: null
 plugin: 'system_menu_block:account'
 settings:

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -68,8 +68,8 @@ module:
   path_alias: 0
   redirect: 0
   responsive_image: 0
-  serialization: 0
   samlauth: 0
+  serialization: 0
   social_api: 0
   social_auth: 0
   social_auth_hid: 0

--- a/html/themes/custom/common_design_subtheme/components/cd/cd.css
+++ b/html/themes/custom/common_design_subtheme/components/cd/cd.css
@@ -249,7 +249,8 @@ a.cd-footer-social__link svg {
   text-align: start;
 }
 
-.cd-user-menu a {
+/* Change the menu item style for the Media Centre (top menu) only */
+.cd-global-header__actions > nav:first-child .cd-user-menu a {
   text-transform: uppercase;
   font-weight: bold;
   padding-inline: 20px;
@@ -259,8 +260,3 @@ a.cd-footer-social__link svg {
 .cd-user-menu a:focus {
   color: white;
 }
-
-/* .cd-user-menu li:only-child a {
-  font-weight: bold;
-  padding-inline-end: 0;
-} */

--- a/html/themes/custom/common_design_subtheme/templates/blocks/block--system-menu-block--account.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/blocks/block--system-menu-block--account.html.twig
@@ -1,0 +1,3 @@
+{% if logged_in %}
+  {% include '@common_design/block/block--system-menu-block--account.html.twig' %}
+{% endif %}


### PR DESCRIPTION
Refs: UNO-746

This shows the user menu when logged in (assuming here that we still don't want to show the "log in" link).

Note: the styling feels odd because of the css rules applied to the top header for the media centre:

<img width="386" alt="Screenshot 2023-07-26 at 13 11 06" src="https://github.com/UN-OCHA/unocha-site/assets/696348/d2ea05df-1ec2-4b40-bc85-46e525ea9207">

### Notes:

URL aliases were created on preview (`/admin/config/search/path`):

- `/user/login` is an alias of `/saml/login`
- `/user/logout` is an alias of `/saml/logout`

When `saml` is not configured this is the equivalent of the normal login/logout.

### Tests

1. Checkout the branch, clear the cache import the config
2. Log in, check that the user menu appears
3. In another browser/winder, as anonymous, check that the user menu is not there
4. Click the log out link and confirm you are logged out.