### PR TITLE
[UNO-744] Fix homepage metatags

### DIFF
--- a/config/metatag.metatag_defaults.front.yml
+++ b/config/metatag.metatag_defaults.front.yml
@@ -8,5 +8,10 @@ id: front
 label: 'Front page'
 tags:
   canonical_url: '[site:url]'
+  description: '[site:slogan]'
+  og_description: '[site:slogan]'
+  og_title: '[site:name]'
   shortlink: '[site:url]'
   title: '[site:name]'
+  twitter_cards_description: '[site:slogan]'
+  twitter_cards_title: '[site:name]'

--- a/config/system.site.yml
+++ b/config/system.site.yml
@@ -4,7 +4,7 @@ langcode: en
 uuid: 8b187b50-276f-4848-a7e5-f1c218f62345
 name: OCHA
 mail: unocha@test.test
-slogan: ''
+slogan: 'United Nations Office for the Coordination of Humanitarian Affairs'
 page:
   403: ''
   404: /node/279


### PR DESCRIPTION
Refs: UNO-744

Ensures the twitter and facebook titles are not 'Homepage'.