### PR TITLE
UNO-575 More style improvements and CKEditor patch

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -3,7 +3,7 @@
     "drupal/core": {
       "https://www.drupal.org/project/drupal/issues/3370828": "PATCHES/core-css-js-aggregation-3370828.patch",
       "https://www.drupal.org/project/drupal/issues/3376927": "PATCHES/core-css-js-aggregation-3376927.patch",
-      "Regression: infinite height prevention disables scrolling in Source view": "https://www.drupal.org/files/issues/2023-07-11/3372922-19.patch"
+      "Regression: infinite height prevention disables scrolling in Source view": "https://www.drupal.org/files/issues/2023-07-11/3372922-19.patch",
     },
     "drupal/csp": {
       "Simplify log format": "PATCHES/csp-log-format.patch"

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,5 +1,8 @@
 {
   "patches": {
+    "drupal/core": {
+      "Regression: infinite height prevention disables scrolling in Source view": "https://www.drupal.org/files/issues/2023-07-11/3372922-19.patch"
+    },
     "drupal/csp": {
       "Simplify log format": "PATCHES/csp-log-format.patch"
     },

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -3,7 +3,7 @@
     "drupal/core": {
       "https://www.drupal.org/project/drupal/issues/3370828": "PATCHES/core-css-js-aggregation-3370828.patch",
       "https://www.drupal.org/project/drupal/issues/3376927": "PATCHES/core-css-js-aggregation-3376927.patch",
-      "Regression: infinite height prevention disables scrolling in Source view": "https://www.drupal.org/files/issues/2023-07-11/3372922-19.patch",
+      "Regression: infinite height prevention disables scrolling in Source view": "https://www.drupal.org/files/issues/2023-07-11/3372922-19.patch"
     },
     "drupal/csp": {
       "Simplify log format": "PATCHES/csp-log-format.patch"

--- a/html/themes/custom/common_design_subtheme/components/uno-layout/uno-layout.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-layout/uno-layout.css
@@ -90,11 +90,9 @@
     display: flex;
     gap: var(--uno-card-list-gap-size);
   }
-  .layout--twocol-66-33 > .layout__region--first {
-    flex: 0 1 66%;
-  }
+  .layout--twocol-66-33 > .layout__region--first,
   .layout--twocol-66-33 > .layout__region--second {
-    flex: 1 0 33%;
+    flex: 0 1 50%;
   }
 }
 
@@ -144,6 +142,9 @@
     layout that follows on the homepage */
   .layout--twocol-66-33 > .layout__region--first {
     flex: 1 0 66%;
+  }
+  .layout--twocol-66-33 > .layout__region--second {
+    flex: 0 1 33%;
   }
 }
 

--- a/html/themes/custom/common_design_subtheme/components/uno-mega-menu/uno-mega-menu.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-mega-menu/uno-mega-menu.css
@@ -32,7 +32,7 @@
     flex-direction: column;
     width: 100%;
     max-width: var(--cd-max-width);
-    max-height: 270px;
+    max-height: 280px;
     margin: 0 auto;
     /* We could also add the cd-container to the <ul> but then we would have to
      * unset the padding on smaller screen. */

--- a/html/themes/custom/common_design_subtheme/templates/content/media-oembed-iframe.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/media-oembed-iframe.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme override to display an oEmbed resource in an iframe.
+ */
+#}
+<!DOCTYPE html>
+<html>
+  <head>
+    <css-placeholder token="{{ placeholder_token }}">
+  </head>
+  <body style="margin: 0; overflow: hidden;">
+    {{ media|raw }}
+  </body>
+</html>

--- a/html/themes/custom/common_design_subtheme/templates/content/node--media-collection--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--media-collection--full.html.twig
@@ -126,8 +126,6 @@
         </div>
         {% endif %}
 
-        {{ content|without('field_media_image', 'field_media_video', 'field_video_download', 'field_canto_collection', 'field_custom_content') }}
-
         {% if node.field_canto_collection.0.value or node.field_media_image.0.value %}
           <div class="uno-photo-gallery--two-columns">
 
@@ -145,7 +143,7 @@
           </div>
         {% endif %}
 
-      {{ content.field_custom_content }}
+        {{ content|without('field_media_image', 'field_media_video', 'field_video_download', 'field_canto_collection') }}
 
       </div>
 


### PR DESCRIPTION
UNO-575

1. CKEditor patch to add scroll when viewing source
2. Mega menu height increase to accommodate another item under Europe without creating an additional column
3. Fix video scroll by adding overflow property to body tag in iframe template override
4. Move Image gallery above Body textarea for Media Collection
5. Adjust flex display for homepage to prevent overflow