### PR TITLE
[UNO-622] Paragraph display in form

### DIFF
--- a/config/core.entity_form_display.node.basic.default.yml
+++ b/config/core.entity_form_display.node.basic.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.basic.field_custom_content
     - node.type.basic
   module:
+    - allowed_formats
     - layout_paragraphs
     - media_library
     - path
@@ -23,11 +24,14 @@ content:
     weight: 3
     region: content
     settings:
-      rows: 24
+      rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
   created:
     type: datetime_timestamp
     weight: 7

--- a/html/themes/custom/common_design_claro/css/styles.css
+++ b/html/themes/custom/common_design_claro/css/styles.css
@@ -92,13 +92,13 @@
 }
 
 blockquote {
-  border-inline-start: 3px solid grey;
   padding: 0.25rem 1rem;
+  border-inline-start: 3px solid grey;
 }
 
 p.title {
-  font-size: 24px;
   text-align: center;
+  font-size: 24px;
 }
 
 /* Disable elements.css quote icon */
@@ -106,3 +106,163 @@ blockquote::before {
   /* content: open-quote; */
   content: none;
 }
+
+/**
+ * Style adjustments for the preview of the paragraphs.
+ */
+
+form .paragraph--view-mode--preview {
+  /* Adjust typography from @claro/css/base/variables.css to be smaller. */
+  --font-size-xl: 1.4rem; /* ~36px */
+  --font-size-h1: 1.3rem; /* ~32px */
+  --font-size-h2: 1.2rem; /* ~29px */
+  --font-size-h3: 1.1rem; /* ~26px */
+  --font-size-h4: 1rem; /* ~23px */
+  --font-size-h5: 0.9rem; /* ~20px */
+  --font-size-h6: 0.8rem; /* 18px */
+  --font-size-s: 0.7rem; /* ~14px */
+  --font-size-xs: 0.6rem; /* ~13px */
+  --font-size-xxs: 0.5rem; /* ~11px */
+
+  /* Adjust the gap for the grid type paragraph view modes. */
+  --uno-card-list-gap-size: 1rem;
+}
+
+/* Map. */
+form .paragraph--view-mode--preview.unocha-response-map[data-map-enabled] .unocha-response-map__article[data-active] {
+  padding: 0;
+}
+
+/* Stories. */
+form .paragraph--view-mode--preview.paragraph--type--news-and-stories .viewsreference--view-title {
+  font-size: var(--font-size-h2);
+  font-weight: bold;;
+}
+form .paragraph--view-mode--preview.paragraph--type--news-and-stories .view-header {
+  margin-bottom: 1rem;
+}
+form .paragraph--view-mode--preview.paragraph--type--news-and-stories .view-filters {
+  display: none;
+}
+form .paragraph--view-mode--preview.paragraph--type--news-and-stories .view-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--uno-card-list-gap-size);
+}
+form .paragraph--view-mode--preview article.node--type-story.node--view-mode-card {
+  display: flex;
+  flex: 1 0 calc(33.33% - var(--uno-card-list-gap-size));
+  flex-direction: column;
+}
+form .paragraph--view-mode--preview article.node--type-story.node--view-mode-card h2 {
+  font-size: var(--font-size-h3);
+}
+form .paragraph--view-mode--preview article.node--type-story.node--view-mode-card .node__content {
+  order: -1;
+  margin-right: 1rem;
+}
+form .paragraph--view-mode--preview article.node--type-story.node--view-mode-card .field--name-field-story-type {
+  font-size: var(--font-size-h5);
+}
+form .paragraph--view-mode--preview.paragraph--type--news-and-stories .uno-stories__content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--uno-card-list-gap-size);
+}
+form .paragraph--view-mode--preview.paragraph--type--content-list .uno-stories__header {
+  margin-bottom: 1rem;
+}
+form .paragraph--view-mode--preview.paragraph--type--content-list article.node--type-story.node--sticky.node--view-mode-card .node__content {
+  min-width: 220px;
+}
+
+/* Events. */
+form .paragraph--view-mode--preview.paragraph--type--events .viewsreference--view-title {
+  margin-bottom: 1rem;
+  font-size: var(--font-size-h2);
+  font-weight: bold;
+}
+form .paragraph--view-mode--preview.paragraph--type--events .view-header h2 {
+  display: none;
+}
+form .paragraph--view-mode--preview.paragraph--type--events .view-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--uno-card-list-gap-size);
+}
+form .paragraph--view-mode--preview article.node--type-event.node--view-mode-card {
+  display: flex;
+  flex: 1 0 calc(33.33% - var(--uno-card-list-gap-size));
+  flex-direction: column;
+}
+form .paragraph--view-mode--preview article.node--type-event.node--view-mode-card h2 {
+  font-size: var(--font-size-h3);
+}
+form .paragraph--view-mode--preview article.node--type-event.node--view-mode-card .node__content {
+  order: -1;
+  margin-right: 1rem;
+}
+form .paragraph--view-mode--preview article.node--type-event.node--view-mode-card .field--name-field-event-date,
+form .paragraph--view-mode--preview article.node--type-event.node--view-mode-card .field--name-field-event-location {
+  display: none;
+  font-size: var(--font-size-h5);
+}
+
+/* Nodes. */
+form .paragraph--view-mode--preview.paragraph--type--node article.node h2 {
+  font-size: var(--font-size-h3);
+}
+form .paragraph--view-mode--preview.paragraph--type--node article.node .node__content {
+  display: none;
+}
+
+/* ReliefWeb rivers. */
+form .paragraph--view-mode--preview.paragraph--type--reliefweb-river .rw-river-article__content,
+form .paragraph--view-mode--preview.paragraph--type--reliefweb-river .rw-river-article__footer {
+  display: none;
+}
+form .paragraph--view-mode--preview.paragraph--type--reliefweb-document .rw-river-article__content {
+  display: flex;
+  flex-direction: column-reverse;
+  justify-content: flex-end;
+}
+form .paragraph--view-mode--preview .rw-river-article .rw-river-article__content .rw-river-article__title {
+  font-size: var(--font-size-h3);
+}
+form .paragraph--view-mode--preview .rw-river-article .rw-river-article__content img[src*="styles/thumbnail/"] {
+  max-width: 100px;
+  max-height: 140px;
+  margin: 0 0 1rem 0;
+}
+
+/* Subscribe. */
+form .paragraph--view-mode--preview.paragraph--type--subscribe .mc-field-group {
+  align-items: center;
+}
+form .paragraph--view-mode--preview.paragraph--type--subscribe .email {
+  height: 3rem;
+  border: 1px solid black;
+}
+
+/* Media centre. */
+form .paragraph--view-mode--preview.paragraph--type--media-centre .viewsreference--view-title {
+  display: none;
+}
+form .paragraph--view-mode--preview.paragraph--type--media-centre .uno-media-centre__header {
+  margin-bottom: 1rem;
+}
+form .paragraph--view-mode--preview.paragraph--type--media-centre article.node--type-media-collection .node__content > .field--name-field-media-image > .field__item:nth-child(n+2) {
+  display: none;
+}
+form .paragraph--view-mode--preview.paragraph--type--media-centre article.node--type-media-collection {
+  display: flex;
+  flex-direction: column;
+}
+form .paragraph--view-mode--preview.paragraph--type--media-centre article.node--type-media-collection h2 {
+  font-size: var(--font-size-h3);
+}
+form .paragraph--view-mode--preview.paragraph--type--media-centre article.node--type-media-collection .node__content {
+  order: -1;
+  margin-right: 1rem;
+}
+

--- a/html/themes/custom/common_design_claro/css/styles.css
+++ b/html/themes/custom/common_design_claro/css/styles.css
@@ -101,6 +101,12 @@ p.title {
   font-size: 24px;
 }
 
+p.headline {
+  font-size: 2rem;
+  font-weight: bold;
+  line-height: 1.2;
+}
+
 /* Disable elements.css quote icon */
 blockquote::before {
   /* content: open-quote; */

--- a/html/themes/custom/common_design_claro/templates/content/node--basic--default.html.twig
+++ b/html/themes/custom/common_design_claro/templates/content/node--basic--default.html.twig
@@ -1,0 +1,4 @@
+{% include '@common_design_claro/content/node.html.twig' with {
+  'display_submitted': false,
+  'content': content|without('field_basic_image'),
+} %}

--- a/html/themes/custom/common_design_claro/templates/content/node.html.twig
+++ b/html/themes/custom/common_design_claro/templates/content/node.html.twig
@@ -1,0 +1,3 @@
+{% include '@claro/classy/content/node.html.twig' with {
+  'display_submitted': false
+} %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--call-to-action.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--call-to-action.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--call-to-action.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--card-list--featured-highlight.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--card-list--featured-highlight.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--card-list--featured-highlight.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--card-list.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--card-list.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--card-list.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--card.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--card.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--card.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--cbpf.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--cbpf.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--cbpf.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--content-list.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--content-list.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--content-list.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--datawrapper.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--datawrapper.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--datawrapper.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--donors.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--donors.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--donors.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--events.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--events.html.twig
@@ -1,0 +1,13 @@
+{% extends '@common_design_subtheme/paragraphs/paragraph--events.html.twig' %}
+
+{% block content %}
+  {% if content.field_events['#items'] %}
+    {{ content }}
+  {% elseif paragraph.field_events.entity and paragraph.field_events.display_id %}
+    {% set display = paragraph.field_events.entity.getDisplay(paragraph.field_events.display_id) %}
+    {% if display %}
+      <div class="viewsreference--view-title">{{ display.display_title }}</div>
+      <div class="views-element-container">{% trans %}No events currently. This section will only be displayed when there are events.{% endtrans %}</div>
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--figures--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--figures--preview.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--figures--preview.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--figures.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--figures.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--events.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--layout.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--layout.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--layout.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--media-centre.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--media-centre.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--media-centre.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--node.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--node.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--node.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--regions.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--regions.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--regions.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-document.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-document.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--reliefweb-document.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-river-curated.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-river-curated.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--river-curated.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-river.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-river.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--reliefweb-river.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--resources.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--resources.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--resources.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--response-map.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--response-map.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--response-map.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--responses.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--responses.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--responses.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--rss-feed.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--rss-feed.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--rss-feed.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--section--tabs.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--section--tabs.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--section--tabs.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--stories.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--stories.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--stories.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--subscribe.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--subscribe.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--subscribe.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--text-and-image.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--text-and-image.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph--text-and-image.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/paragraphs/paragraph.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/unocha-reliefweb-river-article--report--preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/unocha-reliefweb-river-article--report--preview.html.twig
@@ -33,7 +33,6 @@
 
   {# Article attachment preview and/or summary. #}
   <div class="rw-river-article__content" lang="{{ entity.langcode }}">
-    <div class="cd-preview--label">{{ 'This is a preview'|t }}</div>
     {# Header with country slug and title. #}
     <header
       class="rw-river-article__header">

--- a/html/themes/custom/common_design_claro/templates/views/views-view-unformatted.html.twig
+++ b/html/themes/custom/common_design_claro/templates/views/views-view-unformatted.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/views/views-view-unformatted.html.twig' %}

--- a/html/themes/custom/common_design_claro/templates/views/views-view.html.twig
+++ b/html/themes/custom/common_design_claro/templates/views/views-view.html.twig
@@ -1,0 +1,1 @@
+{% include '@common_design_subtheme/views/views-view.html.twig' %}


### PR DESCRIPTION
Refs: UNO-622

This PR creates templates in the claro subtheme to link to the CD ones and add some css rules to have a relatively streamlined display of the paragraphs in the forms.

### Tests.

1. Checkout the branch, clear the cache and import the config
2. Edit different type of content (notably homepage, a region, a response, leader page, events, publications and media centre) and check that the paragraphs displayed in the form look reasonably clear in conveying what is going to be displayed and without too much clutter. (Ex: grids should be grids, map should be a map, RW rivers should show list of links etc.)