### PR TITLE
[UNO-753] Remove leftover attributes from paragraphs that impact backend

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--call-to-action.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--call-to-action.html.twig
@@ -28,11 +28,7 @@
 {% set destination = paragraph.field_destination.0.url %}
 {% set link_text = paragraph.field_destination.0.title %}
 {% block paragraph %}
-  <div{{ attributes
-    .addClass(classes)
-    .setAttribute('data-type', paragraph.bundle)
-    .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
-  }}>
+  <div{{ attributes.addClass(classes) }}>
     {% block content %}
     {{ content|without('field_destination')}}
       {% if paragraph.field_destination.0.url %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--card-list--featured-highlight.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--card-list--featured-highlight.html.twig
@@ -22,11 +22,7 @@
   ]
 %}
 {% block paragraph %}
-  <article{{ attributes
-    .addClass(classes)
-    .setAttribute('data-type', paragraph.bundle)
-    .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
-  }}>
+  <div{{ attributes.addClass(classes) }}>
     {% block content %}
       {% set destination = paragraph.field_destination.0.url %}
       <div{{ content_attributes.addClass('node__content').addClass('uno-card__content') }}>

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--card-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--card-list.html.twig
@@ -20,11 +20,7 @@
   ]
 %}
 {% block paragraph %}
-  <div{{ attributes
-    .addClass(classes)
-    .setAttribute('data-type', paragraph.bundle)
-    .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
-  }}>
+  <div{{ attributes.addClass(classes) }}>
     {% block content %}
       {{ content }}
     {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--card.html.twig
@@ -23,11 +23,7 @@
 %}
 
 {% block paragraph %}
-  <div{{ attributes
-    .addClass(classes)
-    .setAttribute('data-type', paragraph.bundle)
-    .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
-  }}>
+  <div{{ attributes.addClass(classes) }}>
     {% block content %}
       {% set destination = paragraph.field_card_link.0.url %}
       <div class="uno-card__content">

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--node.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--node.html.twig
@@ -51,11 +51,7 @@
 {{ attach_library('common_design_subtheme/uno-card-list')}}
 
 {% block paragraph %}
-  <div{{ attributes
-    .addClass(classes)
-    .setAttribute('data-type', paragraph.bundle)
-    .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
-  }}>
+  <div{{ attributes.addClass(classes) }}>
     {% block content %}
       {{ content }}
     {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--subscribe.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--subscribe.html.twig
@@ -23,11 +23,7 @@
 %}
 
 {% block paragraph %}
-  <div{{ attributes
-    .addClass(classes)
-    .setAttribute('data-type', paragraph.bundle)
-    .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
-  }}>
+  <div{{ attributes.addClass(classes) }}>
     {% block content %}
 
     {{ content|without('field_url')}}


### PR DESCRIPTION
Refs: UNO-753

This PR removes the `data-type` and `id` attributes in some paragraph templates copied from the response-site during the initial setup of the subtheme.

The `id` attribute interferes with the logic of the paragraph layout preventing it from adding the buttons to edit the paragraph.

I compared several pages with those paragraphs with prod and there is no impact. There doesn't seem to be any code in the subtheme necessitating those attributes so I think it's safe to remove them.