### PR TITLE
[UNO-760] Fix breadcrumb for RW white labeled documents.

### DIFF
--- a/config/menu_breadcrumb.settings.yml
+++ b/config/menu_breadcrumb.settings.yml
@@ -12,7 +12,7 @@ add_home: true
 front_title: 0
 exclude_empty_url: false
 exclude_disabled_menu_items: false
-derived_active_trail: false
+derived_active_trail: true
 menu_breadcrumb_menus:
   main:
     enabled: 1
@@ -44,11 +44,6 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
-  help:
-    enabled: 1
-    weight: 0
-    taxattach: 0
-    langhandle: 0
   latest:
     enabled: 1
     weight: 0
@@ -64,7 +59,17 @@ menu_breadcrumb_menus:
     weight: 0
     taxattach: 0
     langhandle: 0
+  take-action:
+    enabled: 0
+    weight: 0
+    taxattach: 0
+    langhandle: 0
   tools:
+    enabled: 0
+    weight: 0
+    taxattach: 0
+    langhandle: 0
+  top-menu:
     enabled: 0
     weight: 0
     taxattach: 0

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -35,6 +35,7 @@ dependencies:
     - taxonomy
     - toolbar
     - unocha_canto
+    - unocha_reliefweb
 id: editor
 label: Editor
 weight: 3
@@ -50,6 +51,7 @@ permissions:
   - 'administer menu'
   - 'administer nodes'
   - 'administer redirects'
+  - 'administer reliefweb breadcrumbs'
   - 'administer taxonomy'
   - 'create basic content'
   - 'create content translations'

--- a/html/modules/custom/unocha_reliefweb/src/Form/BreadcrumbSettingsForm.php
+++ b/html/modules/custom/unocha_reliefweb/src/Form/BreadcrumbSettingsForm.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\unocha_reliefweb\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for the ReliefWeb breadcrumbs.
+ */
+class BreadcrumbSettingsForm extends FormBase {
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   */
+  public function __construct(StateInterface $state) {
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('state')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $default_path = $this->state->get('unocha_reliefweb.breadcrumb.default_path', '');
+
+    $form['default_path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Default path'),
+      '#description' => $this->t('Indicate the default parent path for the white labeled ReliefWeb documents. Ex: /publications.'),
+      '#default_value' => $default_path,
+    ];
+
+    $paths = $this->state->get('unocha_reliefweb.breadcrumb.ocha_product_paths', []);
+    $default = [];
+    foreach ($paths as $key => $info) {
+      $default[$key] = $info['ocha_product'] . ':' . $info['path'];
+    }
+
+    $form['ocha_product_paths'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('OCHA product path mapping'),
+      '#description' => $this->t('Indicate <em>one per line</em> the parent path of the white labeled ReliefWeb documents with a particular OCHA product, in the form: ocha_product:/path. Ex: Press Release:/latest/press-releases.'),
+      '#default_value' => implode("\n", $default),
+    ];
+
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save settings'),
+      '#button_type' => 'primary',
+    ];
+    // By default, render the form using system-config-form.html.twig.
+    $form['#theme'] = 'system_config_form';
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    if (preg_match_all('#^\s*(?<ocha_product>[^:]+)\s*:\s*(?<path>\S+)\s*$#m', $form_state->getValue('ocha_product_paths') ?? '', $matches, \PREG_SET_ORDER) !== FALSE) {
+      $paths = [];
+      foreach ($matches as $match) {
+        if (!empty($match['ocha_product']) && !empty($match['path'])) {
+          $paths[mb_strtolower($match['ocha_product'])] = [
+            'ocha_product' => $match['ocha_product'],
+            'path' => '/' . trim($match['path'], '/'),
+          ];
+        }
+      }
+      $this->state->set('unocha_reliefweb.breadcrumb.ocha_product_paths', $paths);
+    }
+
+    $default_path = '/' . trim($form_state->getValue('default_path') ?? '', '/');
+    $this->state->set('unocha_reliefweb.breadcrumb.default_path', $default_path);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'unocha_reliefweb_breadcrumb_settings';
+  }
+
+}

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.links.menu.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.links.menu.yml
@@ -1,0 +1,5 @@
+unocha_reliefweb.breadcrumb.settings:
+  title: ReliefWeb Breadcrumb
+  description: 'Configure ReliefWeb Breadcrumb settings'
+  route_name: unocha_reliefweb.breadcrumb.settings
+  parent: system.admin_config_ui

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.permissions.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.permissions.yml
@@ -1,0 +1,3 @@
+administer reliefweb breadcrumbs:
+  title: 'Administer reliefweb breadcrumbs'
+  description: 'Administer reliefweb breadcrumb settings.'

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.routing.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.routing.yml
@@ -5,3 +5,11 @@ unocha_reliefweb.publications.document:
     _title_callback: '\Drupal\unocha_reliefweb\Controller\ReliefWebDocumentController::getPageTitle'
   requirements:
     _permission: 'access content'
+
+unocha_reliefweb.breadcrumb.settings:
+  path: '/admin/config/user-interface/reliefweb-breadcrumb'
+  defaults:
+    _title: 'ReliefWeb Breadcrumb'
+    _form: '\Drupal\unocha_reliefweb\Form\BreadcrumbSettingsForm'
+  requirements:
+    _permission: 'administer reliefweb breadcrumbs'

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.services.yml
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.services.yml
@@ -16,6 +16,6 @@ services:
     arguments: ['@config.factory', '@reliefweb_api.client', '@reliefweb_api.converter', '@logger.factory', '@request_stack', '@string_translation']
   reliefweb.breadcrumb:
     class: Drupal\unocha_reliefweb\Services\ReliefWebBreadcrumbBuilder
-    arguments: ['@request_stack', '@controller_resolver', '@language_manager']
+    arguments: ['@request_stack', '@controller_resolver', '@language_manager', '@state', '@breadcrumb', '@router']
     tags:
       - { name: breadcrumb_builder, priority: 701 }


### PR DESCRIPTION
Refs: UNO-760

This PR refactor the logic for the breadcrumb for the RW white labeled documents to use the breadcrumb of the parent path as base instead of having the breadcrumb fully hardcoded.

There is now an admin page `/admin/config/user-interface/reliefweb-breadcrumb` accessible via the configuration menu > ReliefWeb breadcrumb to adjust the paths. Editors have the permission to access this page.

## Deployment

After deploying:

1. Go to `/admin/config/user-interface/reliefweb-breadcrumb`
2. Set the default path to `/publications`.
3. Set the OCHA product paths to:

```
Press Release:/latest/press-releases
Statement/Speech:/latest/speeches-and-statements
```

### Tests

1. Checkout the branch, clear the cache, import the config
2. Follow the after deployment instructions
3. Go to Latest > News and Stories > Press releases, click on a document, check that the breadcrumb is `Home > Latest > News and Stories > Press releases`.
4. Go to Latest > News and Stories > Statements and Speeches, click on a document, check that the breadcrumb is `Home > Latest > News and Stories > Statements and Speeches`.
5. Go to Latest > Publications, click on a document, check that the breadcrumb is `Home > Latest > Publications`.