### PR TITLE
feat: Pass legacy file URLs to Drupal for Redirect module.

### DIFF
--- a/docker/etc/nginx/custom/01_attachment_redirections.conf
+++ b/docker/etc/nginx/custom/01_attachment_redirections.conf
@@ -30,8 +30,12 @@ location @reliefweb-file {
   ## Make sure we can catch the 404 error to be able to use our handler.
   proxy_intercept_errors on;
 
-  ## Pass the request to ReleifWeb.
-  proxy_pass https://reliefweb.int;
+  ## Ensure the proxy host is in a variable, so nginx will not cache the IP
+  ## indefinitely and cause 502 errors if the load balancer IPs change.
+  set $reliefweb_host "reliefweb.int";
+
+  ## Pass the request to ReliefWeb.
+  proxy_pass https://$reliefweb_host;
 
   ## Override connection and buffer vars: do not attempt to buffer, just throw
   ## the data out right away and close the docstore connection when done.

--- a/docker/etc/nginx/custom/03_mapbox.conf
+++ b/docker/etc/nginx/custom/03_mapbox.conf
@@ -20,10 +20,14 @@ location /mapbox/ {
   ## Remove cookies.
   more_clear_input_headers Cookie;
 
+  ## Ensure the proxy host is in a variable, so nginx will not cache the IP
+  ## indefinitely and cause 502 errors if the IPs change.
+  set $mapbox_host "api.mapbox.com";
+
   ## Proxy the request to the mapbox API.
   proxy_ssl_server_name on;
-  proxy_set_header Host "api.mapbox.com";
-  proxy_pass https://api.mapbox.com$mapbox_request_uri;
+  proxy_set_header Host $mapbox_host;
+  proxy_pass https://$mapbox_host$mapbox_request_uri;
   proxy_http_version 1.1;
   proxy_redirect off;
   proxy_intercept_errors on;

--- a/docker/etc/nginx/custom/04_legacy_files.conf
+++ b/docker/etc/nginx/custom/04_legacy_files.conf
@@ -1,8 +1,10 @@
 # Allow legacy files (and ECOSOC files) to be available on their old URL.
+#
+# If not found, pass the request to Drupal, so redirect module may handle it if required.
 
 location /sites/unocha/files {
   location ~ ^/sites/unocha/files/(?<file_path>.*)$ {
-    try_files /sites/default/files/legacy/$file_path /sites/default/files/ecosoc/$file_path =404;
+    try_files /sites/default/files/legacy/$file_path /sites/default/files/ecosoc/$file_path @drupal;
   }
   return 404 "404 Not Found";
 }


### PR DESCRIPTION
But only if no matching file exists on disk.

And pre-empt a load balancer IP change, which can cause nginx to proxy requests to the wrong addresses.