### PR TITLE
chore: remove patch that's been merged

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -28,9 +28,6 @@
     },
     "drupal/username_enumeration_prevention": {
       "Avoid leaking the path via Drupal.settings json": "PATCHES/username_enumeration_prevention-user-login-block-form-3312288.patch"
-    },
-    "drupal/xmlsitemap": {
-      "https://www.drupal.org/project/xmlsitemap/issues/3323148": "PATCHES/xmlsitemap-d10-compatibility-admin-page.patch"
     }
   }
 }


### PR DESCRIPTION
Refs: updates
https://www.drupal.org/project/xmlsitemap/releases/8.x-1.5

Update failing: https://github.com/UN-OCHA/unocha-site/actions/runs/5817773842/job/15772959457 - should be re-run after this is merged.