### PR TITLE
chore: remove unused variable

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -17,6 +17,5 @@ jobs:
         patch_branch: 'develop'
         patch_packages: 'drupal/*'
         patch_maintainers: ${{ secrets.DRUPAL_MAINTAINERS }}
-        php_version: '8.2'
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel_name: ${{ vars.SLACK_CHANNEL }}


### PR DESCRIPTION
Refs: updates

Updates produce a warning: `Unexpected input(s) 'php_version', valid inputs are ['github_access_token', 'patch_branch', 'patch_packages', 'patch_author', 'patch_maintainers', 'slack_bot_token', 'slack_channel_name', 'flowdock_token']`. The version is no longer needed.

https://github.com/UN-OCHA/unocha-site/actions/runs/5819534642