### PR TITLE
[UNO-765] Prevent error when there a no stories to show in a stories paragraph type

### DIFF
--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -97,13 +97,6 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       $stories = unocha_paragraphs_get_stories($conditions, $limit, $exclude);
     }
   }
-  // If there are no valid parent, we just show the latest stories,
-  // for example when adding a stories paragraph type to a response as the
-  // paragraph doesn't yet have a parent as it's not yet saved.
-  // @todo add disclaimer in the preview in the form?
-  else {
-    $stories = unocha_paragraphs_get_stories([], $limit);
-  }
 
   // Filter out stories that cannot be accessed by the current user.
   if (!empty($stories)) {

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--stories.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--stories.html.twig
@@ -1,1 +1,11 @@
-{% include '@common_design_subtheme/paragraphs/paragraph--stories.html.twig' %}
+{%
+  include '@common_design_subtheme/paragraphs/paragraph--stories.html.twig' with {
+    'content': content|merge({
+      'stories': content.stories ? content.stories : [
+        {
+          '#markup': 'No stories currently for this page.'|t
+        }
+      ]
+    })
+  }
+%}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--stories.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--stories.html.twig
@@ -39,6 +39,7 @@
  *
  */
 #}
+{% if content.stories %}
 {{ attach_library('common_design_subtheme/uno-stories') }}
 {{ attach_library('common_design_subtheme/rw-icons') }}
 
@@ -66,3 +67,4 @@
     {% endblock %}
   </div>
 {% endblock paragraph %}
+{% endif %}


### PR DESCRIPTION
Refs: UNO-765

This adds a check so that when there are no stories for a page (response, region, etc.) then the stories paragraph is not displayed.

However for the form, we still want to show the paragraph so this alters the template and adds a 'No stories currently for this page.' message if there are no stories.

<img width="812" alt="Screenshot 2023-08-11 at 11 04 41" src="https://github.com/UN-OCHA/unocha-site/assets/696348/27305f10-8bd7-488c-8093-4ec5aacb8d94">

### Notes

If a `stories` paragraph is added to a response for which there are no stories tagged with it **and** the response is under a region or another menu item that doesn't have stories either, then the `stories` paragraph will be empty.

Same thing when adding a `stories` paragraph to an existing region without stories tagged with this region.

That means that to be able to show stories for the `response-template` page, at least one **demo/dummy** story tagged with the `response-template` response must be created.

### Tests

1. Checkout the branch, clear the cache
2. Create a new response, add a stories paragraph, it should show the "No stories." message because there is no stories tagged with it.
3. Select a region with stories as parent in the "menu link item" in the form.
4. Save the response, it should show the stories for the region
5. Edit it, the paragraph should also show the stories for the region
6. Change the parent menu link item to a page without stories (ex: headquarters or a basic page)
7. Save, check that the stories block doesn't appear on the page
8. Edit it, check that the message "No stories" is displayed
9. Check that the behavior didn't change for existing pages with stories:
   1. Go to home page, check that the stories block is shown, edit it and confirm the stories appear there as well
   2. Repeat the above for region
   4. Repeat the above for response
