### PR TITLE
[UNO-768] Fix issue with news and stories

### DIFF
--- a/config/core.entity_form_display.paragraph.news_and_stories.default.yml
+++ b/config/core.entity_form_display.paragraph.news_and_stories.default.yml
@@ -13,14 +13,15 @@ bundle: news_and_stories
 mode: default
 content:
   field_news_and_stories_list:
-    type: viewsreference_autocomplete
+    type: viewsreference_select
     weight: 0
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/views.view.stories.yml
+++ b/config/views.view.stories.yml
@@ -239,7 +239,7 @@ display:
             operator: field_country_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: country
+            identifier: countries
             required: false
             remember: false
             multiple: false
@@ -263,9 +263,9 @@ display:
             group_items: {  }
           verf_target_bundles:
             country: country
+            contacts: '0'
             event_type: '0'
-            regional_offices: '0'
-            response_type: '0'
+            office_type: '0'
             story_type: '0'
             theme: '0'
           show_unpublished: 0
@@ -289,7 +289,7 @@ display:
             operator: field_responses_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: response
+            identifier: responses
             required: false
             remember: false
             multiple: false
@@ -341,7 +341,7 @@ display:
             operator: field_regions_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: region
+            identifier: regions
             required: false
             remember: false
             multiple: false
@@ -534,7 +534,7 @@ display:
             operator: field_country_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: country
+            identifier: countries
             required: false
             remember: false
             multiple: false
@@ -558,9 +558,9 @@ display:
             group_items: {  }
           verf_target_bundles:
             country: country
+            contacts: '0'
             event_type: '0'
-            regional_offices: '0'
-            response_type: '0'
+            office_type: '0'
             story_type: '0'
             theme: '0'
           show_unpublished: 0
@@ -584,7 +584,7 @@ display:
             operator: field_responses_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: response
+            identifier: responses
             required: false
             remember: false
             multiple: false
@@ -636,7 +636,7 @@ display:
             operator: field_regions_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: region
+            identifier: regions
             required: false
             remember: false
             multiple: false
@@ -829,7 +829,7 @@ display:
             operator: field_country_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: country
+            identifier: countries
             required: false
             remember: false
             multiple: false
@@ -853,9 +853,9 @@ display:
             group_items: {  }
           verf_target_bundles:
             country: country
+            contacts: '0'
             event_type: '0'
-            regional_offices: '0'
-            response_type: '0'
+            office_type: '0'
             story_type: '0'
             theme: '0'
           show_unpublished: 0
@@ -879,7 +879,7 @@ display:
             operator: field_responses_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: response
+            identifier: responses
             required: false
             remember: false
             multiple: false
@@ -931,7 +931,7 @@ display:
             operator: field_regions_target_id_verf_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: region
+            identifier: regions
             required: false
             remember: false
             multiple: false

--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -39,7 +39,7 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       ], $limit);
 
       // Filter the News and Stories page by the response.
-      $view_all_query['response'] = $parent->id();
+      $view_all_query['responses'] = $parent->id();
 
       // If we don't have enough stories for the response, complete with
       // stories from the region.
@@ -52,7 +52,7 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
 
           // Also add the region as filter to have consistent results in the
           // News and Stories landing page.
-          $view_all_query['region'] = $region->id();
+          $view_all_query['regions'] = $region->id();
         }
       }
     }
@@ -63,7 +63,7 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       ], $limit);
 
       // Filter the News and Stories page by the region.
-      $view_all_query['region'] = $parent->id();
+      $view_all_query['regions'] = $parent->id();
     }
     else {
       // Exclude the current story so we can show related ones only.
@@ -72,9 +72,9 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       // Add conditions on the referenced entities.
       $conditions = [];
       $fields = [
-        'field_responses' => 'response',
-        'field_regions' => 'region',
-        'field_country' => 'country',
+        'field_responses' => 'responses',
+        'field_regions' => 'regions',
+        'field_country' => 'countries',
       ];
       foreach ($fields as $field => $filter) {
         if ($parent->hasField($field)) {


### PR DESCRIPTION
Refs: UNO-768

This PR changes the name of the exposed filters for the News and Stories view to "countries", "responses" and "regions" instead of "country", "response" and "region".

It happened that the "region" query parameter has a special meaning for the layout paragraphs to determine where to place the paragraph when adding a new one.

The exposed "region" filter from the news and stories was conflicting when adding such a paragraph type and was set to an empty string which was not a valid option.

## Tests

1. Checkout the branch, clear the cache and import the config
2. Add a "news and stories" paragraph to some content, it should show the default latest list (or whatever display was selected)
3. Save, there should be no error message anymore
4. Visit a region, check that the "view all" for the "stories" paragraph leads to the properly filtered news and stories page using the new "regions" query parameter instead of "region"
5. Repeat (4) for a response, this time the query parameter should be "countries"