### PR TITLE
[UNO-766] Allow editors to view other unpublished content

### DIFF
--- a/config/views.view.content.yml
+++ b/config/views.view.content.yml
@@ -599,18 +599,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        status_extra:
-          id: status_extra
-          table: node_field_data
-          field: status_extra
-          entity_type: node
-          plugin_id: node_status
-          operator: '='
-          value: false
-          group: 1
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
       filter_groups:
         operator: AND
         groups:
@@ -729,7 +717,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -761,7 +748,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/config/views.view.media.yml
+++ b/config/views.view.media.yml
@@ -720,45 +720,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-        status_extra:
-          id: status_extra
-          table: media_field_data
-          field: status_extra
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          plugin_id: media_status
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
         langcode:
           id: langcode
           table: media_field_data
@@ -886,7 +847,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags: {  }
   media_page_list:
@@ -914,6 +874,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags: {  }


### PR DESCRIPTION
Refs: UNO-766

This removes the filter for the `/admin/content` view that limits to published content if not an admin so that editors can see all the content published or unpublished and whether they are the author or not.

Same thing for `/admin/content/media`.

Note: editors already have the permission to view other unpublished content or media but the /admin/content views didn't respect that.

See https://www.drupal.org/project/drupal/issues/2971902 for similar issue.

## Tests.

1. Checkout the branch, clear the cache, import the config
2. Log in as an editor, create some page
3. Log in as a **different** editor in another browser or private tab and check that you see the page from (1) and can access it.