### PR TITLE
[UNO-771] Display report image for RW documents

### DIFF
--- a/docker/etc/nginx/custom/01_attachment_redirections.conf
+++ b/docker/etc/nginx/custom/01_attachment_redirections.conf
@@ -17,6 +17,18 @@ location /sites/default/files/styles/large/public/previews/ {
   try_files /dev/null @reliefweb-file;
 }
 
+## Report images.
+## @todo add a `extra-large` if this style is added to ReliefWeb (UNO-771).
+location /sites/default/files/styles/small/public/images/reports/ {
+  try_files /dev/null @reliefweb-file;
+}
+location /sites/default/files/styles/medium/public/images/reports/ {
+  try_files /dev/null @reliefweb-file;
+}
+location /sites/default/files/styles/large/public/images/reports/ {
+  try_files /dev/null @reliefweb-file;
+}
+
 ## Pass the request to ReliefWeb.
 location @reliefweb-file {
   ## Use our custom 404 handler so we can set the content disposition

--- a/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
+++ b/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
@@ -96,6 +96,9 @@ class ReliefWebDocumentController extends ControllerBase {
     if (!empty($data['attachments'])) {
       $content['attachments'] = $this->renderAttachmentList($data['attachments']);
     }
+    if (!empty($data['image'])) {
+      $content['image'] = $this->renderImage($data['image']);
+    }
     if (!empty($data['body-html'])) {
       $content['body'] = ['#markup' => $data['body-html']];
     }
@@ -140,6 +143,24 @@ class ReliefWebDocumentController extends ControllerBase {
       $ocha_product = $mapping[$data['format']] ?? 'Other';
     }
     return $ocha_product;
+  }
+
+  /**
+   * Render a report image.
+   *
+   * @param array $image
+   *   Image data.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function renderImage(array $image) {
+    return [
+      '#theme' => 'unocha_reliefweb_entity_image',
+      '#image' => $image,
+      '#caption' => TRUE,
+      '#loading' => 'eager',
+    ];
   }
 
   /**

--- a/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
+++ b/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
@@ -124,7 +124,6 @@ class ReliefWebDocuments {
         'fields' => [
           'url_alias',
           'file',
-          'image',
           'headline',
           'format',
           'date',
@@ -582,12 +581,22 @@ class ReliefWebDocuments {
       }
 
       // Image.
-      if (!empty($fields['image'])) {
-        $data['image'] = $fields['image'];
+      if (!empty($fields['image']['url'])) {
+        $image = $fields['image'];
+        // Add a URL for the medium styles as they are not in the API.
+        // @todo add a `url-extra-large` as well if this style is added to
+        // ReliefWeb (UNO-771).
+        if (isset($image['url-large'])) {
+          $image['url-medium'] = str_replace('/large/', '/medium/', $image['url-large']);
+        }
         // Change the URLs of the image to be an unocha.org URL.
         if ($white_label) {
-          $this->getApiClient()->updateApiUrls($data['image'], $unocha_url);
+          $this->getApiClient()->updateApiUrls($image, $unocha_url);
         }
+        // Fix the alternative text and copyright.
+        $image['alt'] = $image['alt'] ?? $image['caption'] ?? '';
+        $image['copyright'] = trim($image['copyright'] ?? '', " \n\r\t\v\0@");
+        $data['image'] = $image;
       }
 
       // Compute the language code from the resource's data.

--- a/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-entity-image.html.twig
+++ b/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-entity-image.html.twig
@@ -6,16 +6,17 @@
  *
  * Available variables;
  * - attributes: figure attributes
- * - style: image style
- * - image: array with uri, alt, width, height, alt and copyright
- *   and optionally the loading mode.
+ * - image: array with urls (different sizes), alt, width, height, alt and
+ *   copyright and optionally the loading mode.
  * - caption: flag to indicate whether to show the caption or not.
  * - loading: flag to indicate the default loading mode: lazy or eager.
  *
- * @todo handle responsive image styles when/if introduced.
+ * @todo add 'image['url-extra-large'] }}' image source if this image
+ * style is added in ReliefWeb (UNO-771).
  */
 
 #}
+{% if image.url %}
 <figure{{ attributes
   .addClass([
     'rw-entity-image',
@@ -23,22 +24,19 @@
     image.copyright is not empty ? 'rw-entity-image--with-copyright',
   ])
 }}>
-  {% if style is not empty %}
-    {{ render_var({
-      '#theme': 'image_style',
-      '#style_name': style,
-      '#uri': image.uri,
-      '#alt': image.alt,
-      '#attributes': {
-        'class': ['rw-entity-image__image'],
-        'loading': image.loading is not empty ? image.loading : loading,
-      },
-      '#width': image.width,
-      '#height': image.height
-    }) }}
-  {% else %}
-    <img class="rw-entity-image__image" src="{{ image.uri }}" alt="{{ image.alt }}" loading="{{ image.loading is not empty ? image.loading : loading }}">
-  {% endif %}
+
+
+  <picture class="rw-entity-image__image">
+    <source srcset="{{ image['url-small'] }}" media="(max-width: 220px)" />
+    <source srcset="{{ image['url-medium'] }}" media="(max-width: 450px)" />
+    <source srcset="{{ image['url-large'] }}" />
+    <img
+      src="{{ image['url-small'] }}"
+      alt="{{ image.alt }}"
+      loading="{{ image.loading is not empty ? image.loading : loading }}"
+      style="aspect-ratio: {{ image.width }} / {{ image.height }};"
+    />
+  </picture>
 
   {% if caption and image.alt is not empty %}
   {# We use aria-hidden="true" because we already set the image alt. This
@@ -54,3 +52,4 @@
   </footer>
   {% endif %}
 </figure>
+{% endif %}

--- a/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-river-article--report.html.twig
+++ b/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-river-article--report.html.twig
@@ -47,16 +47,6 @@
     }) }}
   </header>
 
-  {# Image (ex: headline). #}
-  {% if entity.image is not empty %}
-    {{ render_var({
-      '#theme': 'unocha_reliefweb_entity_image',
-      '#style': 'medium',
-      '#image': entity.image,
-      '#caption': false,
-    }) }}
-  {% endif %}
-
   {# Article attachment preview and/or summary. #}
   {% if entity.summary is not empty or entity.preview is not empty %}
   <div class="rw-river-article__content" lang="{{ entity.langcode }}">

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.module
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.module
@@ -144,6 +144,19 @@ function unocha_reliefweb_theme() {
         'countries' => [],
       ],
     ],
+    'unocha_reliefweb_entity_image' => [
+      'variables' => [
+        // Wrapper attributes.
+        'attributes' => NULL,
+        // Image information with urls (different sizes), width, height, alt
+        // and copyright and optionally the loading mode.
+        'image' => [],
+        // Flag to indicate whether to show the caption or not.
+        'caption' => TRUE,
+        // Flag to indicate the default loading mode: lazy or eager.
+        'loading' => 'lazy',
+      ],
+    ],
     // Theme for an article's detailed information (ex: source, format).
     'unocha_reliefweb_entity_meta' => [
       'variables' => [

--- a/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
@@ -59,6 +59,14 @@
   max-width: var(--cd-max-content-width);
 }
 
+.unocha-reliefweb-document .unocha-reliefweb-document__content .rw-entity-image {
+  max-width: var(--cd-max-content-width);
+  margin: 0;
+}
+.unocha-reliefweb-document .unocha-reliefweb-document__content .rw-entity-image img {
+  width: 100%;
+}
+
 .unocha-reliefweb-document .unocha-reliefweb-document__content p:first-child,
 .unocha-reliefweb-document .unocha-reliefweb-document__content > .unocha-reliefweb-attachment-list + p {
   margin-top: 0;

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-entity-image.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-entity-image.html.twig
@@ -1,0 +1,50 @@
+{#
+
+/**
+ * @file
+ * Template file for an image displayed in an entity article.
+ *
+ * Available variables;
+ * - attributes: figure attributes
+ * - image: array with urls (different sizes), alt, width, height, alt and
+ *   copyright and optionally the loading mode.
+ * - caption: flag to indicate whether to show the caption or not.
+ * - loading: flag to indicate the default loading mode: lazy or eager.
+ *
+ * @todo add 'image['url-extra-large'] }}' image source if this image
+ * style is added in ReliefWeb (UNO-771).
+ */
+
+#}
+{% if image.url %}
+{{ attach_library('common_design/cd-caption') }}
+<figure{{ attributes
+  .addClass([
+    'rw-entity-image',
+    caption and image.alt is not empty ? 'rw-entity-image--with-caption',
+    image.copyright is not empty ? 'rw-entity-image--with-copyright',
+  ])
+}}>
+
+  <picture class="rw-entity-image__image">
+    <source srcset="{{ image['url-small'] }}" media="(max-width: 220px)" />
+    <source srcset="{{ image['url-medium'] }}" media="(max-width: 450px)" />
+    <source srcset="{{ image['url-large'] }}" />
+    <img
+      src="{{ image['url-small'] }}"
+      alt="{{ image.alt }}"
+      loading="{{ image.loading is not empty ? image.loading : loading }}"
+      style="aspect-ratio: {{ image.width }} / {{ image.height }};"
+    />
+  </picture>
+
+  {% if image.alt or image.copyright %}
+  {# We use aria-hidden="true" because we already set the image alt. This
+     prevents the alt text to be read twice by screen readers. #}
+  <figcaption class="rw-entity-image__caption cd-caption" aria-hidden="true">
+    {{ caption ? image.alt }}
+    {{ image.copyright }}
+  </figcaption>
+  {% endif %}
+</figure>
+{% endif %}


### PR DESCRIPTION
Refs: UNO-771

This PR adds the display of the report image on the RW whitelabeled document pages.

<img width="1032" alt="Screenshot 2023-08-16 at 13 21 20" src="https://github.com/UN-OCHA/unocha-site/assets/696348/cbed3f98-058e-42fb-81db-53f90d690d82">

Screenshot source: https://unocha-local.test/publications/report/occupied-palestinian-territory/determined-stay-umm-salehs-unyielding-stand-amid-settler-aggression (replace unocha-local.test with your local domain).

The image is currently displayed like on RW, below the title. The image is a bit scaled up (700px -> 820px).

There are few `@todo ... (UNO-771)` if we decide to add a large image style on RW (ex: `extra-large` (1400px)).

### Tests

1. Checkout the branch, clear the cache, import the config.
2. Visit the URL mentioned above, the image should appear.

