### PR TITLE
[UNO-763] Display of attachments for RW documents

### DIFF
--- a/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
+++ b/html/modules/custom/unocha_reliefweb/src/Controller/ReliefWebDocumentController.php
@@ -6,6 +6,8 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Http\Exception\CacheableNotFoundHttpException;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\unocha_reliefweb\Helpers\UrlHelper;
 use Drupal\unocha_reliefweb\Services\ReliefWebDocuments;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -92,9 +94,28 @@ class ReliefWebDocumentController extends ControllerBase {
       return [];
     }
 
+    $type = isset($data['format']) ? strtolower($data['format']) : 'report';
+
     $content = [];
     if (!empty($data['attachments'])) {
-      $content['attachments'] = $this->renderAttachmentList($data['attachments']);
+      $content['attachments'] = $this->renderAttachmentList($data['attachments'], $type);
+
+      if ($type === 'interactive' && !empty($content['attachments'])) {
+        $content['attachments']['#title'] = $this->t('Screenshot(s) of the interactive content as of @date', [
+          '@date' => $data['published']->format('j m Y'),
+        ]);
+        if (!empty($data['origin'])) {
+          $content['attachments']['#footer'] = Link::fromTextAndUrl(
+            $this->t('View the interactive content page'),
+            Url::fromUri($data['origin'], [
+              'attributes' => [
+                'target' => '_blank',
+                'rel' => 'noopener',
+              ],
+            ])
+          )->toRenderable();
+        }
+      }
     }
     if (!empty($data['image'])) {
       $content['image'] = $this->renderImage($data['image']);
@@ -168,34 +189,66 @@ class ReliefWebDocumentController extends ControllerBase {
    *
    * @param array $attachments
    *   List of attachments.
+   * @param string $type
+   *   One of `map`, `infographic`, `interactive` or `report`.
    *
    * @return array
    *   Render array.
    */
-  protected function renderAttachmentList(array $attachments) {
+  protected function renderAttachmentList(array $attachments, $type) {
     if (empty($attachments)) {
       return [];
     }
 
+    if ($type === 'map') {
+      $label = $this->t('Download Map');
+      $size = 'large';
+    }
+    elseif ($type === 'infographic') {
+      $label = $this->t('Download Infographic');
+      $size = 'large';
+    }
+    elseif ($type === 'interactive') {
+      $size = 'large';
+    }
+    else {
+      $type = 'report';
+      $label = $this->t('download Attachment');
+      $size = 'small';
+    }
+
     $list = [];
-    foreach ($attachments as $attachment) {
+    foreach ($attachments as $index => $attachment) {
       $extension = $this->extractFileExtension($attachment['filename']);
-      $list[] = [
-        'url' => $attachment['url'],
-        'name' => $attachment['filename'],
-        'preview' => $this->renderAttachmentPreview($attachment),
-        'label' => $this->t('Download Attachment'),
-        'description' => '(' . implode(' | ', array_filter([
-          mb_strtoupper($extension),
-          format_size($attachment['filesize']),
-          $attachment['description'] ?? '',
-        ])) . ')',
-      ];
+
+      if ($type === 'interactive') {
+        $description = $this->t('Screenshot @index', [
+          '@index' => $index + 1,
+        ]);
+        $list[] = [
+          'preview' => $this->renderAttachmentPreview($attachment, $size, $description),
+          'description' => $description,
+        ];
+      }
+      else {
+        $list[] = [
+          'url' => $attachment['url'],
+          'name' => $attachment['filename'],
+          'preview' => $this->renderAttachmentPreview($attachment, $size),
+          'label' => $label,
+          'description' => '(' . implode(' | ', array_filter([
+            mb_strtoupper($extension),
+            format_size($attachment['filesize']),
+            $attachment['description'] ?? '',
+          ])) . ')',
+        ];
+      }
     }
 
     return [
-      '#theme' => 'unocha_reliefweb_attachment_list',
+      '#theme' => 'unocha_reliefweb_attachment_list__' . $type,
       '#list' => $list,
+      '#type' => $type,
     ];
   }
 
@@ -204,21 +257,23 @@ class ReliefWebDocumentController extends ControllerBase {
    *
    * @param array $attachment
    *   The attachment data.
+   * @param string $size
+   *   Size of the image to use: small or large.
+   * @param string $alt
+   *   Alternative text for the preview.
    *
    * @return array
    *   Render array.
    */
-  public function renderAttachmentPreview(array $attachment) {
+  public function renderAttachmentPreview(array $attachment, $size = 'small', $alt = '') {
     if (empty($attachment['preview'])) {
       return [];
     }
 
-    // @todo review when deciding on how to deal with image styles for
-    // images coming from ReliefWeb.
     return [
       '#theme' => 'image',
-      '#uri' => $attachment['preview']['url-small'] . '?' . $attachment['preview']['version'],
-      '#alt' => $this->t('Preview of @filename', [
+      '#uri' => $attachment['preview']['url-' . $size] . '?' . $attachment['preview']['version'],
+      '#alt' => $alt ?: $this->t('Preview of @filename', [
         '@filename' => $attachment['filename'],
       ]),
       '#attributes' => [

--- a/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
+++ b/html/modules/custom/unocha_reliefweb/src/Services/ReliefWebDocuments.php
@@ -529,6 +529,7 @@ class ReliefWebDocuments {
         'format' => $format,
         'tags' => $tags,
         'body-html' => $fields['body-html'] ?? '',
+        'origin' => $fields['origin'] ?? '',
       ];
 
       // Url to the article.

--- a/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-attachment-list.html.twig
+++ b/html/modules/custom/unocha_reliefweb/templates/unocha-reliefweb-attachment-list.html.twig
@@ -9,6 +9,7 @@
  * - title: section title
  * - title_attributes: attributes for the title
  * - level: heading level for the title
+ * - type: type of attachments
  * - list: list of attachments with a preview, label, description and url
  * - list_attributes: attributes for the list
  * - lazy_load_first_preview: also lazy load the first attachment preview
@@ -16,31 +17,47 @@
 
 #}
 {% if list is not empty %}
-<section{{ attributes.addClass('unocha-reliefweb-attachment-list') }}>
-  <h{{ level }}{{ title_attributes.addClass('visually-hidden') }}>{{ title }}</h{{ level }}>
+<section{{ attributes.addClass('unocha-reliefweb-attachment-list', 'unocha-reliefweb-attachment-list--' ~ type) }}>
+  <h{{ level }}{{ title_attributes.addClass('unocha-reliefweb-attachment-list__title', type != 'interactive' ? 'visually-hidden') }}>{{ title }}</h{{ level }}>
   <ul{{ list_attributes }}>
     {% for item in list %}
-    <li>
-      <a href="{{ item.url }}">
-        {% if item.preview is not empty and loop.index == 1 and not lazy_load_first_preview %}
-          {%
-            set item = item|merge({
-              'preview': item.preview|merge({
-                '#attributes': (item.preview['#attributes'] ?? {})|merge({
-                  'loading': 'eager'
-                })
-              })
+    {# Load the first preview as eager unless specified otherwise, for better UX. #}
+    {% if item.preview is not empty and loop.index == 1 and not lazy_load_first_preview %}
+      {%
+        set item = item|merge({
+          'preview': item.preview|merge({
+            '#attributes': (item.preview['#attributes'] ?? {})|merge({
+              'loading': 'eager'
             })
-          %}
-        {% endif %}
+          })
+        })
+      %}
+    {% endif %}
+    <li>
+      {% if item. url %}
+      <a href="{{ item.url }}">
+      {% endif %}
 
         {{ item.preview }}
+        {% if item.label %}
         <strong class="unocha-reliefweb-attachment-list__label">{{ item.label }}</strong>
+        {% endif %}
+        {% if item.description %}
         <span class="unocha-reliefweb-attachment-list__description">{{ item.description }}</span>
+        {% endif %}
+
+      {% if item.url %}
       </a>
+      {% endif %}
     </li>
     {% endfor %}
   </ul>
+
+  {% if footer %}
+  <footer{{ footer_attributes.addClass('unocha-reliefweb-attachment-list__footer') }}>
+    {{ footer }}
+  </footer>
+  {% endif %}
 </section>
 {% endif %}
 

--- a/html/modules/custom/unocha_reliefweb/unocha_reliefweb.module
+++ b/html/modules/custom/unocha_reliefweb/unocha_reliefweb.module
@@ -40,6 +40,8 @@ function unocha_reliefweb_theme() {
         'title' => t('Attachments'),
         // Section title attributes.
         'title_attributes' => NULL,
+        // Type of attachments.
+        'type' => NULL,
         // List of files. Each item has the following properties:
         // - url: link to the file
         // - name: file name
@@ -54,7 +56,7 @@ function unocha_reliefweb_theme() {
         'footer_attributes' => NULL,
         // Flag to indicate if the first attachment's preview should be lazy
         // loaded or not.
-        'lazy_load_first_preview' => TRUE,
+        'lazy_load_first_preview' => FALSE,
       ],
     ],
     // Theme for a list of articles.

--- a/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
@@ -9,9 +9,12 @@
 
 /* Attachments. */
 .unocha-reliefweb-attachment-list {
+  max-width: var(--cd-max-content-width);
+  margin: 0 0 24px 0;
+}
+.unocha-reliefweb-attachment-list--report {
   max-width: 220px;
   margin: 0 auto 24px auto;
-  padding-top: 0;
 }
 .unocha-reliefweb-attachment-list ul {
   margin: 0;
@@ -45,11 +48,32 @@
   font-size: 14px;
 }
 
+.unocha-reliefweb-attachment-list__footer {
+  margin-top: 24px;
+}
+.unocha-reliefweb-attachment-list__footer a[target="_blank"][rel~="noopener"]:after {
+  display: inline-block;
+  overflow: hidden;
+  width: 12px;
+  height: 12px;
+  margin: -2px 0 0 6px;
+  content: "";
+  vertical-align: middle;
+  background: var(--rw-icons--common--external-link--12--dark-blue);
+}
+
 @media screen and (min-width: 480px) {
-  .unocha-reliefweb-attachment-list {
+  .unocha-reliefweb-attachment-list--report {
     float: right;
     margin-left: 24px;
   }
+}
+
+/* Attachments for interactive content. */
+.unocha-reliefweb-attachment-list--interactive .unocha-reliefweb-attachment-list__title {
+  margin: 0 0 24px 0;
+  font-size: var(--cd-font-size--base);
+  font-weight: normal;
 }
 
 /* Reading width. */


### PR DESCRIPTION
Refs: UNO-763

**Note:** This is against the branch from https://github.com/UN-OCHA/unocha-site/pull/313.

This PR adds logic to display the attachment similarly to RW:

- Map/Infographic --> full width with either Download Map or Download Infographic as attachment label
- Interactive --> full width with "Screenshot ... as of ..." title for the list of attachment and a link to interactive content page as footer

**Normal attachment**

- RW: https://reliefweb.int/report/syrian-arab-republic/syria-humanitarian-fund-annual-report-2022
- UNO: https://unocha-local.test/publications/report/syrian-arab-republic/syria-humanitarian-fund-annual-report-2022

<img width="1039" alt="Screenshot 2023-08-16 at 15 45 58" src="https://github.com/UN-OCHA/unocha-site/assets/696348/90e03e36-5c76-4a17-8f3d-1bfa28c7af01">

**Infographic**

- RW: https://reliefweb.int/report/afghanistan/afghanistan-humanitarian-operational-presence-3w-western-region-april-june-2023
- UNO: https://unocha-local.test/publications/report/afghanistan/afghanistan-humanitarian-operational-presence-3w-western-region-april-june-2023

<img width="611" alt="Screenshot 2023-08-16 at 15 38 07" src="https://github.com/UN-OCHA/unocha-site/assets/696348/a01b6d11-a80b-49ec-b989-eb52992a9abb">

**Map**

- RW: https://reliefweb.ints/map/sudan/sudan-operational-presence-3w-post-15-april-15-jul-2023
- UNO: https://unocha-local.test/publications/map/sudan/sudan-operational-presence-3w-post-15-april-15-jul-2023

<img width="1047" alt="Screenshot 2023-08-16 at 15 38 45" src="https://github.com/UN-OCHA/unocha-site/assets/696348/29271b95-6c8b-4f78-8b37-a543cc6d92c8">

**Interactive**

- RW: https:/reliefweb.int/report/mali/mali-cartographie-des-incidents-dacces-humanitaire-la-date-du-7-juillet-2023
- UNO: https://unocha-local.test/publications/report/mali/mali-cartographie-des-incidents-dacces-humanitaire-la-date-du-7-juillet-2023

<img width="1011" alt="Screenshot 2023-08-16 at 15 39 09" src="https://github.com/UN-OCHA/unocha-site/assets/696348/2977c505-997f-40a2-aad5-5da02346bcf0">

## Tests

1. Checkout the branch, clear the cache, import the config
2. Visit the links mentioned above (change the domain) and confirm it looks like the screenshots. Compare with the RW urls as well.
