### PR TITLE
[UNO-775] Allow editors to view and edit any unpublished content or media

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -12,6 +12,7 @@ module:
   config_split: 0
   config_translation: 0
   contact: 0
+  content_moderation: 0
   contextual: 0
   csp: 0
   ctools: 0
@@ -99,6 +100,7 @@ module:
   username_enumeration_prevention: 0
   verf: 0
   viewsreference: 0
+  workflows: 0
   xmlsitemap_engines: 0
   pathauto: 1
   xmlsitemap: 1

--- a/config/language/ar/views.view.moderated_content.yml
+++ b/config/language/ar/views.view.moderated_content.yml
@@ -1,0 +1,50 @@
+label: 'محتوى خاضع للإشراف'
+display:
+  default:
+    display_title: الافتراضي
+    display_options:
+      title: 'محتوى خاضع للإشراف'
+      fields:
+        title:
+          label: العنوان
+          separator: ', '
+        type:
+          label: 'نوع المحتوى'
+          separator: ', '
+        name:
+          label: المؤلف
+          separator: ', '
+        moderation_state:
+          separator: ', '
+        changed:
+          label: التحديث
+          separator: ', '
+        operations:
+          label: عمليات
+      pager:
+        options:
+          tags:
+            next: 'التالي ›'
+            previous: '‹ السابق'
+          expose:
+            items_per_page_options_all_label: '- الكل -'
+            offset_label: الإزاحة
+      exposed_form:
+        options:
+          submit_button: انتقاء
+          reset_button_label: 'إعادة الضبط'
+          exposed_sorts_label: 'الترتيب حسب'
+          sort_asc_label: تصاعدي
+          sort_desc_label: تنازلي
+      filters:
+        title:
+          expose:
+            label: العنوان
+        type:
+          expose:
+            label: 'نوع المحتوى'
+        langcode:
+          expose:
+            label: اللغة
+  moderated_content:
+    display_title: 'محتوى خاضع للإشراف'

--- a/config/language/es/views.view.moderated_content.yml
+++ b/config/language/es/views.view.moderated_content.yml
@@ -1,0 +1,61 @@
+label: 'Contenido moderado'
+description: 'Encuentra y modera contenido.'
+display:
+  default:
+    display_title: 'Por defecto'
+    display_options:
+      title: 'Contenido moderado'
+      fields:
+        title:
+          label: Título
+          separator: ', '
+        type:
+          label: 'Tipo de contenido'
+          separator: ', '
+        name:
+          label: Autor
+          separator: ', '
+        moderation_state:
+          label: 'Estado de moderación'
+          separator: ', '
+        changed:
+          label: Actualizado
+          separator: ', '
+        operations:
+          label: Operaciones
+      pager:
+        options:
+          tags:
+            next: 'Siguiente >'
+            previous: '‹ Anterior'
+            first: '« Primero'
+            last: 'Último »'
+          expose:
+            items_per_page_label: 'Elementos por página'
+            items_per_page_options_all_label: '- Todo -'
+            offset_label: Desplazamiento
+      exposed_form:
+        options:
+          submit_button: Filtro
+          reset_button_label: Restablecer
+          exposed_sorts_label: 'Ordenar por'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      empty:
+        area_text_custom:
+          content: 'No hay contenido moderado disponible. Solo las versiones pendientes de contenido, como los borradores, se enumeran aquí.'
+      filters:
+        title:
+          expose:
+            label: Título
+        type:
+          expose:
+            label: 'Tipo de contenido'
+        moderation_state:
+          expose:
+            label: 'Estado de moderación'
+        langcode:
+          expose:
+            label: Idioma
+  moderated_content:
+    display_title: 'Contenido moderado'

--- a/config/language/fr/views.view.moderated_content.yml
+++ b/config/language/fr/views.view.moderated_content.yml
@@ -1,0 +1,61 @@
+label: 'Contenu modéré'
+description: 'Trouver et modérer du contenu.'
+display:
+  default:
+    display_title: 'Par défaut'
+    display_options:
+      title: 'Contenu modéré'
+      fields:
+        title:
+          label: Titre
+          separator: ', '
+        type:
+          label: 'Type de contenu'
+          separator: ', '
+        name:
+          label: Auteur
+          separator: ', '
+        moderation_state:
+          label: 'État de modération'
+          separator: ', '
+        changed:
+          label: 'Mis à jour'
+          separator: ', '
+        operations:
+          label: Actions
+      pager:
+        options:
+          tags:
+            next: 'Suivant ›'
+            previous: '‹ Précédent'
+            first: '« Premier'
+            last: 'Dernier »'
+          expose:
+            items_per_page_label: 'Éléments par page'
+            items_per_page_options_all_label: '- Tout -'
+            offset_label: Décalage
+      exposed_form:
+        options:
+          submit_button: Filtrer
+          reset_button_label: Réinitialiser
+          exposed_sorts_label: 'Trier par'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      empty:
+        area_text_custom:
+          content: "Aucun contenu modéré disponible. Seules les versions de contenu en attente, telles que 'Brouillon', sont listées ici."
+      filters:
+        title:
+          expose:
+            label: Titre
+        type:
+          expose:
+            label: 'Type de contenu'
+        moderation_state:
+          expose:
+            label: 'État de modération'
+        langcode:
+          expose:
+            label: Langue
+  moderated_content:
+    display_title: 'Contenu modéré'

--- a/config/language/ru/views.view.moderated_content.yml
+++ b/config/language/ru/views.view.moderated_content.yml
@@ -1,0 +1,61 @@
+label: 'Модерируемые материалы'
+description: 'Найти и модерировать контент.'
+display:
+  default:
+    display_title: 'По умолчанию'
+    display_options:
+      title: 'Модерируемые материалы'
+      fields:
+        title:
+          label: Заголовок
+          separator: ', '
+        type:
+          label: 'Тип материала'
+          separator: ', '
+        name:
+          label: Автор
+          separator: ', '
+        moderation_state:
+          label: 'Состояние модерации'
+          separator: ', '
+        changed:
+          label: Обновлено
+          separator: ', '
+        operations:
+          label: Операции
+      pager:
+        options:
+          tags:
+            next: 'Следующий ›'
+            previous: '‹ Предыдущий'
+            first: '« Первая'
+            last: 'Последняя »'
+          expose:
+            items_per_page_label: 'Элементов на страницу'
+            items_per_page_options_all_label: '- Все -'
+            offset_label: Пропустить
+      exposed_form:
+        options:
+          submit_button: Фильтр
+          reset_button_label: Сбросить
+          exposed_sorts_label: 'Сортировать по'
+          sort_asc_label: 'По возрастанию'
+          sort_desc_label: 'По убыванию'
+      empty:
+        area_text_custom:
+          content: 'Нет доступных модерируемых материалов. Здесь перечислены только ожидающие версии материалов, такие как черновики.'
+      filters:
+        title:
+          expose:
+            label: Заголовок
+        type:
+          expose:
+            label: 'Тип материала'
+        moderation_state:
+          expose:
+            label: 'Состояние модерации'
+        langcode:
+          expose:
+            label: Язык
+  moderated_content:
+    display_title: 'Модерируемые материалы'

--- a/config/language/zh-hans/views.view.moderated_content.yml
+++ b/config/language/zh-hans/views.view.moderated_content.yml
@@ -1,0 +1,58 @@
+label: 等待审核的内容
+description: 查找并审核内容。
+display:
+  default:
+    display_title: 默认
+    display_options:
+      title: 等待审核的内容
+      fields:
+        title:
+          label: 标题
+          separator: ', '
+        type:
+          label: 内容类型
+          separator: ', '
+        name:
+          label: 作者
+          separator: ', '
+        moderation_state:
+          label: 审批状态
+          separator: ', '
+        changed:
+          label: 已更新
+          separator: ', '
+        operations:
+          label: 操作
+      pager:
+        options:
+          tags:
+            next: '下一个 ›'
+            previous: '‹ 上一个'
+            first: '« 首页'
+            last: '末页 »'
+          expose:
+            items_per_page_label: 每页条目数
+            items_per_page_options_all_label: '- 全部 -'
+            offset_label: 偏移量
+      exposed_form:
+        options:
+          submit_button: 过滤
+          reset_button_label: 重置
+          exposed_sorts_label: 排序依据
+          sort_asc_label: 升序
+          sort_desc_label: 降序
+      filters:
+        title:
+          expose:
+            label: 标题
+        type:
+          expose:
+            label: 内容类型
+        moderation_state:
+          expose:
+            label: 审批状态
+        langcode:
+          expose:
+            label: 语言
+  moderated_content:
+    display_title: 等待审核的内容

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -22,8 +22,8 @@ dependencies:
     - taxonomy.vocabulary.story_type
     - taxonomy.vocabulary.theme
   module:
+    - content_moderation
     - content_translation
-    - file
     - filter
     - media
     - menu_link_content
@@ -45,7 +45,6 @@ permissions:
   - 'access administration pages'
   - 'access canto api'
   - 'access content overview'
-  - 'access files overview'
   - 'access media overview'
   - 'access taxonomy overview'
   - 'access toolbar'
@@ -156,10 +155,12 @@ permissions:
   - 'use text format text_editor_simple'
   - 'view all media revisions'
   - 'view all revisions'
+  - 'view any unpublished content'
   - 'view basic revisions'
   - 'view event revisions'
   - 'view events menu in menu list'
   - 'view latest menu in menu list'
+  - 'view latest version'
   - 'view leader revisions'
   - 'view main menu in menu list'
   - 'view media_collection revisions'

--- a/config/views.view.media.yml
+++ b/config/views.view.media.yml
@@ -720,6 +720,45 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
+        status_extra:
+          id: status_extra
+          table: media_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          plugin_id: media_status
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         langcode:
           id: langcode
           table: media_field_data
@@ -847,6 +886,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags: {  }
   media_page_list:
@@ -874,5 +914,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags: {  }

--- a/config/views.view.moderated_content.yml
+++ b/config/views.view.moderated_content.yml
@@ -1,19 +1,22 @@
-uuid: d64717a9-db2d-49e3-9cd7-a83f31dd62cd
+uuid: c837fc37-e28b-4b69-887c-7962a5d341cc
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - node
     - user
+  enforced:
+    module:
+      - content_moderation
 _core:
-  default_config_hash: vBKWYGGDoAX-tFd1JErB8tZLSxx3lJ0foouVsgpcbB4
-id: content
-label: Content
-module: node
-description: 'Find and manage content.'
-tag: default
-base_table: node_field_data
-base_field: nid
+  default_config_hash: 7olvKOaJNf15B-Bj4eD1wJyaz4BR7CNA9cEjWBssa2Y
+id: moderated_content
+label: 'Moderated content'
+module: views
+description: 'Find and moderate content.'
+tag: ''
+base_table: node_field_revision
+base_field: vid
 display:
   default:
     id: default
@@ -21,123 +24,11 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Content
+      title: 'Moderated content'
       fields:
-        node_bulk_form:
-          id: node_bulk_form
-          table: node
-          field: node_bulk_form
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: node_bulk_form
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          action_title: Action
-          include_exclude: include
-          selected_actions:
-            - node_make_sticky_action
-            - node_make_unsticky_action
-            - node_promote_action
-            - node_publish_action
-            - node_unpromote_action
-            - node_unpublish_action
-        view_node:
-          id: view_node
-          table: node
-          field: view_node
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: entity_link
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          text: view
-          output_url_as_text: true
-          absolute: false
         title:
           id: title
-          table: node_field_data
+          table: node_field_revision
           field: title
           relationship: none
           group_type: group
@@ -148,8 +39,8 @@ display:
           label: Title
           exclude: false
           alter:
-            alter_text: true
-            text: "{{ title }}\r\n<div><small><em>{{ view_node }}<em></small></div>"
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -165,8 +56,8 @@ display:
             target: ''
             nl2br: false
             max_length: 0
-            word_boundary: true
-            ellipsis: true
+            word_boundary: false
+            ellipsis: false
             more_link: false
             more_link_text: ''
             more_link_path: ''
@@ -204,7 +95,7 @@ display:
           id: type
           table: node_field_data
           field: type
-          relationship: none
+          relationship: nid
           group_type: group
           admin_label: ''
           entity_type: node
@@ -270,6 +161,8 @@ display:
           table: users_field_data
           field: name
           relationship: uid
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
           plugin_id: field
@@ -277,39 +170,127 @@ display:
           exclude: false
           alter:
             alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
           element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          click_sort_column: value
           type: user_name
-        status:
-          id: status
-          table: node_field_data
-          field: status
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        moderation_state:
+          id: moderation_state
+          table: node_field_revision
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
-          entity_field: status
           plugin_id: field
-          label: Status
+          label: 'Moderation state'
           exclude: false
           alter:
             alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
           element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          type: boolean
-          settings:
-            format: custom
-            format_custom_false: Unpublished
-            format_custom_true: Published
+          click_sort_column: value
+          type: content_moderation_state
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         changed:
           id: changed
-          table: node_field_data
+          table: node_field_revision
           field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: changed
           plugin_id: field
@@ -317,19 +298,51 @@ display:
           exclude: false
           alter:
             alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
           element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          click_sort_column: value
           type: timestamp
           settings:
             date_format: short
             custom_date_format: ''
             timezone: ''
             tooltip:
-              date_format: ''
+              date_format: long
               custom_date_format: ''
             time_diff:
               enabled: false
@@ -337,13 +350,24 @@ display:
               past_format: '@interval ago'
               granularity: 2
               refresh: 60
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         operations:
           id: operations
-          table: node
+          table: node_revision
           field: operations
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
           plugin_id: entity_operations
           label: Operations
           exclude: false
@@ -390,12 +414,24 @@ display:
       pager:
         type: full
         options:
+          offset: 0
           items_per_page: 50
+          total_pages: null
+          id: 0
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
             first: '« First'
             last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       exposed_form:
         type: basic
         options:
@@ -409,23 +445,67 @@ display:
       access:
         type: perm
         options:
-          perm: 'access content overview'
+          perm: 'view any unpublished content'
       cache:
         type: tag
+        options: {  }
       empty:
         area_text_custom:
           id: area_text_custom
           table: views
           field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
           plugin_id: text_custom
           empty: true
-          content: 'No content available.'
+          content: 'No moderated content available. Only pending versions of content, such as drafts, are listed here.'
+          tokenize: false
       sorts: {  }
       arguments: {  }
       filters:
+        latest_translation_affected_revision:
+          id: latest_translation_affected_revision
+          table: node_revision
+          field: latest_translation_affected_revision
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: latest_translation_affected_revision
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         title:
           id: title
-          table: node_field_data
+          table: node_field_revision
           field: title
           relationship: none
           group_type: group
@@ -469,7 +549,7 @@ display:
           id: type
           table: node_field_data
           field: type
-          relationship: none
+          relationship: nid
           group_type: group
           admin_label: ''
           entity_type: node
@@ -508,57 +588,53 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        status:
-          id: status
-          table: node_field_data
-          field: status
+        moderation_state:
+          id: moderation_state
+          table: node_field_revision
+          field: moderation_state
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: status
-          plugin_id: boolean
-          operator: '='
-          value: '1'
+          plugin_id: moderation_state_filter
+          operator: in
+          value:
+            editorial-draft: editorial-draft
+            editorial-archived: editorial-archived
           group: 1
           exposed: true
           expose:
-            operator_id: ''
-            label: Status
+            operator_id: moderation_state_op
+            label: 'Moderation state'
             description: ''
             use_operator: false
-            operator: status_op
+            operator: moderation_state_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: status
+            identifier: moderation_state
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-          is_grouped: true
+              anonymous: '0'
+              administrator: '0'
+            reduce: true
+          is_grouped: false
           group_info:
-            label: 'Published status'
+            label: ''
             description: ''
-            identifier: status
+            identifier: ''
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items:
-              1:
-                title: Published
-                operator: '='
-                value: '1'
-              2:
-                title: Unpublished
-                operator: '='
-                value: '0'
+            group_items: {  }
         langcode:
           id: langcode
-          table: node_field_data
+          table: node_field_revision
           field: langcode
           relationship: none
           group_type: group
@@ -599,18 +675,47 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        status_extra:
-          id: status_extra
-          table: node_field_data
-          field: status_extra
+        moderation_state_1:
+          id: moderation_state_1
+          table: node_field_revision
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
-          plugin_id: node_status
-          operator: '='
-          value: false
+          plugin_id: moderation_state_filter
+          operator: 'not in'
+          value:
+            editorial-published: editorial-published
           group: 1
+          exposed: false
           expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -622,23 +727,13 @@ display:
           row_class: ''
           default_row_class: true
           columns:
-            node_bulk_form: node_bulk_form
             title: title
             type: type
             name: name
-            status: status
+            moderation_state: moderation_state
             changed: changed
-            edit_node: edit_node
-            delete_node: delete_node
-            dropbutton: dropbutton
-            timestamp: title
           default: changed
           info:
-            node_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
             title:
               sortable: true
               default_sort_order: asc
@@ -659,8 +754,8 @@ display:
               align: ''
               separator: ''
               empty_column: false
-              responsive: priority-low
-            status:
+              responsive: ''
+            moderation_state:
               sortable: true
               default_sort_order: asc
               align: ''
@@ -670,34 +765,6 @@ display:
             changed:
               sortable: true
               default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            edit_node:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            delete_node:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            dropbutton:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            timestamp:
-              sortable: false
-              default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
@@ -712,56 +779,65 @@ display:
         type: fields
       query:
         type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
+        nid:
+          id: nid
+          table: node_field_revision
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: 'Get the actual content from a content revision.'
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          required: false
         uid:
           id: uid
-          table: node_field_data
+          table: node_field_revision
           field: uid
-          admin_label: author
+          relationship: none
+          group_type: group
+          admin_label: User
+          entity_type: node
+          entity_field: uid
           plugin_id: standard
-          required: true
-      show_admin_links: false
+          required: false
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  page_1:
-    id: page_1
-    display_title: Page
+  moderated_content:
+    id: moderated_content
+    display_title: 'Moderated content'
     display_plugin: page
     position: 1
     display_options:
+      enabled: false
+      display_description: ''
       display_extenders: {  }
-      path: admin/content/node
-      menu:
-        type: 'default tab'
-        title: Content
-        description: ''
-        weight: -10
-        menu_name: admin
-        context: ''
-      tab_options:
-        type: normal
-        title: Content
-        description: 'Find and manage content'
-        weight: -10
-        menu_name: admin
+      path: admin/content/moderated
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/html/modules/custom/unocha_menus/unocha_menus.module
+++ b/html/modules/custom/unocha_menus/unocha_menus.module
@@ -5,6 +5,7 @@
  * Module file for unocha_menus.
  */
 
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
@@ -185,5 +186,17 @@ function unocha_menus_form_node_form_submit($form, FormStateInterface $form_stat
       }
       unocha_menus_node_save($node, $values);
     }
+  }
+}
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ *
+ * Hide the Moderated Content tab under /admin/content because it's uncessary
+ * as we don't use complex workflows.
+ */
+function unocha_menus_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface &$cacheability) {
+  if ($route_name == 'system.admin_content') {
+    unset($data['tabs'][1]['content_moderation.content']);
   }
 }


### PR DESCRIPTION
Refs: UNO-775

This PR allows editors to view and edit any unpublished content or media by enabling the content_moderation module as described in https://www.drupal.org/docs/7/managing-users/viewing-unpublished-content#s-drupal-9

Note: the `Moderated content` view is disabled because, we only use the basic workflow with published/unpublished.

## Tests

1. Checkout the branch, clear the cache, import the config
2. Log in as an editor, create some dummy node, save it as unpublished (uncheck "published" above the save button)
3. Check that it's not accessible to anonymous users or authenticated users without the `Editor` role
4. Log in as a different editor, check that the content from (2) appears in `/admin/content` and can be edited
5. Edit it, change the title for example and save it as published
6. Check that it's now accessible to anonymous users
7. Login as the editor from (2), check that you can edit the node and that the revisions reflect what happened above