### PR TITLE
UNO-776 Fix width for river item in Resources

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
@@ -17,18 +17,6 @@
   margin-bottom: 2.5rem;
 }
 
-/* When a River paragraph is in a layout */
-.layout--twocol-sidebar .cd-layout__content .rw-river__title {
-  margin-bottom: 1rem;
-}
-
-@media screen and (min-width: 1024px) {
-  .layout--twocol-sidebar .cd-layout__sidebar--wide {
-    flex-basis: 33%;
-    margin-top: 4.25rem; /* The height of the main column's title */
-  }
-}
-
 /* Card view mode */
 @media screen and (min-width: 768px) {
   .paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river__articles {
@@ -186,3 +174,27 @@
   margin-bottom: 1rem;
 }
 
+/* When a River paragraph is in the Two Column Sidebar layout */
+.layout--twocol-sidebar .cd-layout__content .rw-river__title {
+  margin-bottom: 1rem;
+}
+
+@media screen and (min-width: 1024px) {
+  .layout--twocol-sidebar .cd-layout__sidebar--wide {
+    flex-basis: 33%;
+    margin-top: 4.25rem; /* The height of the main column's title */
+  }
+}
+
+/* Hide images on RW river items in the main and sidebar column. This is
+  specifically for Resources on Response and Region pages and might negatively
+  affect other contexts where this layout is used in the future.
+*/
+.layout--twocol-sidebar .cd-layout__content .rw-river-article--with-preview .rw-river-article__content img,
+.cd-layout__sidebar--wide .rw-river-article--with-preview .rw-river-article__content img {
+  display: none;
+}
+
+.layout--twocol-sidebar .paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-river-article .rw-river-article__header {
+  flex-basis: 100%;
+}

--- a/html/themes/custom/common_design_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/styles.css
@@ -51,19 +51,6 @@
   padding-bottom: 0.5rem;
 }
 
-/* Hide images on RW river items in the main and sidebar column. This is
-  specifically for Humanitarian resources on Response pages and might negatively
-  affect other contexts where this layout is used in the future.
-*/
-.layout--twocol-sidebar .cd-layout__content .rw-river-article--with-preview .rw-river-article__content img,
-.cd-layout__sidebar--wide .rw-river-article--with-preview .rw-river-article__content img {
-  display: none;
-}
-
-.paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-river-article.rw-river-article--with-preview .rw-river-article__header {
-  flex-basis: 100%;
-}
-
 /* Homepage styles */
 .path-frontpage .layout--twocol-66-33 .layout__region--first p.headline {
   /* Align top so it matches paragraph in next region */


### PR DESCRIPTION
move rules related to RW River from styles and into its component, group layout specific rule together, prefix rule for header flex 100% with layout class and remove `rw-river-article--with-preview` selector so it applies to all RW River items

Refs: UNO-776

This PR fixes the issue below, where the item did not span the full available width:
Eg. https://www.unocha.org/niger
![Selection_261](https://github.com/UN-OCHA/unocha-site/assets/1835923/033d24b8-0603-4826-a16e-db353dbc4f54)
