### PR TITLE
feat: Unconditionally pass unmanaged file URLs back to Drupal so redirect module can operate.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,5 +56,6 @@ COPY --from=builder /srv/www/composer.patches.json /srv/www/composer.patches.jso
 COPY --from=builder /srv/www/composer.lock /srv/www/composer.lock
 COPY --from=builder /srv/www/PATCHES /srv/www/PATCHES
 COPY --from=builder /srv/www/scripts /srv/www/scripts
+COPY --from=builder /srv/www/docker/etc/nginx/apps/drupal/drupal.conf /etc/nginx/apps/drupal/drupal.conf
 COPY --from=builder /srv/www/docker/etc/nginx/custom /etc/nginx/custom/
 COPY --from=builder /srv/www/docker/etc/nginx/sites-enabled/02_mapbox_proxy_cache.conf /etc/nginx/sites-enabled/02_mapbox_proxy_cache.conf

--- a/docker/etc/nginx/apps/drupal/drupal.conf
+++ b/docker/etc/nginx/apps/drupal/drupal.conf
@@ -1,0 +1,314 @@
+# -*- mode: nginx; mode: flyspell-prog;  ispell-local-dictionary: "american" -*-
+### Nginx configuration for Drupal. This configuration makes use of
+### drush (http:///drupal.org/project/drush) for site maintenance
+### and like tasks:
+###
+### 1. Run the cronjobs.
+### 2. Run the DB and code updates: drush up or drush upc followed by
+###    drush updb to run any DB updates required by the code upgrades
+###    that were performed.
+### 3. Disabling of xmlrpc.xml, install.php (needed only for
+###    installing the site) and update.php: all updates are now
+###    handled through drush.
+
+## The 'default' location.
+location / {
+    ## Using a nested location is the 'correct' way to use regexes.
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## Include the specific FastCGI configuration. This is for a
+        ## FCGI backend like php-cgi or php-fpm.
+        include apps/drupal/fastcgi_drupal.conf;
+        fastcgi_pass phpcgi;
+
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+    }
+
+    # Do the same for multilingual private files.
+    location ^~ /ar/system/files/ {
+      include apps/drupal/fastcgi_drupal.conf;
+      fastcgi_pass phpcgi;
+      log_not_found off;
+    }
+    location ^~ /en/system/files/ {
+      include apps/drupal/fastcgi_drupal.conf;
+      fastcgi_pass phpcgi;
+      log_not_found off;
+    }
+    location ^~ /fr/system/files/ {
+      include apps/drupal/fastcgi_drupal.conf;
+      fastcgi_pass phpcgi;
+      log_not_found off;
+    }
+    location ^~ /ru/system/files/ {
+      include apps/drupal/fastcgi_drupal.conf;
+      fastcgi_pass phpcgi;
+      log_not_found off;
+    }
+    location ^~ /es/system/files/ {
+      include apps/drupal/fastcgi_drupal.conf;
+      fastcgi_pass phpcgi;
+      log_not_found off;
+    }
+
+    ## Trying to access private files directly returns a 404.
+    location ^~ /sites/.*/private/ {
+        internal;
+    }
+
+    ## Location for public files. Avoid hitting Drupal on thye *production* env
+    ## if a file exists, but do pass it on otherwise, so stage_file_proxy can
+    ## fetch a file from production if needed.
+    location ^~ /sites/.*/files/ {
+        access_log off;
+        expires 30d;
+        ## No need to bleed constant updates. Send the all shebang in one
+        ## fell swoop.
+        tcp_nodelay off;
+
+        ## Set the OS file cache.
+        open_file_cache max=3000 inactive=120s;
+        open_file_cache_valid 45s;
+        open_file_cache_min_uses 2;
+        open_file_cache_errors off;
+
+        ## Location for aggregated css and js files under D 10.1. See:
+        ## https://www.drupal.org/node/2888767#nginx-php-fpm
+        location ^~ /sites/.*/files/(css|js)/ {
+            # Hit the original file *or* allow Drupal to aggregate.
+            try_files $uri @drupal;
+        }
+
+        ## Serve the file directly and fall back to drupal in case of UNO-693.
+        ## UNO-693: Redirects for legacy file URLs.
+        try_files $uri @drupal;
+    }
+
+    ## Location for public derivative images to avoid hitting Drupal for invalid
+    ## image derivative paths or if the source image doesn't exist.
+    location ^~ /sites/.*/files/styles/ {
+
+        ## Valid public derivative image paths.
+        ## We store the source image path without the extra `.webp` extension
+        ## present in the derivative so that we can check if the source image
+        ## exists in @drupal-generate-derivative-image.
+        ## So this handles derivatives in the form
+        ## - image.ext (ex: image.jpg, image.webp)
+        ## - image.ext.webp (ex: image.jpg.webp, image.webp.webp)
+        ## The latter is what the `imageapi_optimize_webp` generates.
+        location ~ "^/sites/default/files/styles/[^/]+/public/(?<file_path>.+?\.[^.]+)(\.webp)?$" {
+            access_log off;
+            expires 30d;
+            ## No need to bleed constant updates. Send the all shebang in one
+            ## fell swoop.
+            tcp_nodelay off;
+            ## Set the OS file cache.
+            open_file_cache max=3000 inactive=120s;
+            open_file_cache_valid 45s;
+            open_file_cache_min_uses 2;
+            open_file_cache_errors off;
+
+            ## Return the derivative image if it already exists or ask Drupal
+            ## to generate it otherwise.
+            try_files $uri @drupal-generate-derivative-image;
+        }
+
+        ## Simply return a 404 for unrecognized derivative image paths.
+        return 404;
+    }
+
+    ## All static files will be served directly.
+    location ~* ^.+\.(?:cur|htc|ico|html|otf|ttf|eot|svg)$ {
+
+        access_log off;
+        expires 30d;
+        ## No need to bleed constant updates. Send the all shebang in one
+        ## fell swoop.
+        tcp_nodelay off;
+        ## Set the OS file cache.
+        open_file_cache max=3000 inactive=120s;
+        open_file_cache_valid 45s;
+        open_file_cache_min_uses 2;
+        open_file_cache_errors off;
+    }
+
+    ## PDFs and MS office files handling.
+    location ~* ^.+\.(?:docx?|pdf|pptx?|xlsx?)$ {
+        expires 30d;
+        ## No need to bleed constant updates. Send the all shebang in one
+        ## fell swoop.
+        tcp_nodelay off;
+    }
+
+    ## Replicate the Apache <FilesMatch> directive of Drupal standard
+    ## .htaccess. Disable access to any code files. Return a 404 to curtail
+    ## information disclosure. Hide also the text files.
+    ## And amend the list with Drupal 8/9/10 yaml files.
+    location ~* ^(?:.+\.(?:htaccess|make|txt|engine|inc|info|install|module|profile|po|pot|sh|.*sql|test|theme|twig|tpl(?:\.php)?|xtmpl|yaml|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?|code-style\.pl|/Entries.*|/Repository|/Root|/Tag|/Template|)$ {
+        return 404;
+    }
+
+    ## Extend the list with Drupal 8/9/10 composer files and the rest of the new shipped .htaccess list :-)
+    location ~* (composer\.(json|lock)|web\.config)|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+        return 404;
+    }
+
+    ## First we try the URI and relay to the /index.php?q=$uri&$args if not found.
+    try_files $uri @drupal;
+}
+
+########### Security measures ##########
+
+## Uncomment the line below if you want to enable basic auth for
+## access to all /admin URIs. Note that this provides much better
+## protection if use HTTPS. Since it can easily be eavesdropped if you
+## use HTTP.
+#include apps/drupal/admin_basic_auth.conf;
+
+## Restrict access to the strictly necessary PHP files. Reducing the
+## scope for exploits. Handling of PHP code and the Drupal event loop.
+location @drupal {
+    ## Include the FastCGI config.
+    include apps/drupal/fastcgi_drupal.conf;
+    fastcgi_pass phpcgi;
+
+    ## If proxying to apache comment the two lines above and
+    ## uncomment the two lines below.
+    #proxy_pass http://phpapache/index.php?q=$uri;
+    #proxy_set_header Connection '';
+
+    ## Filefield Upload progress
+    ## http://drupal.org/project/filefield_nginx_progress support
+    ## through the NginxUploadProgress modules.
+    # track_uploads uploads 60s;
+}
+
+location @drupal-no-args {
+    ## Include the specific FastCGI configuration. This is for a
+    ## FCGI backend like php-cgi or php-fpm.
+    include apps/drupal/fastcgi_no_args_drupal.conf;
+    fastcgi_pass phpcgi;
+
+    ## If proxying to apache comment the two lines above and
+    ## uncomment the two lines below.
+    #proxy_pass http://phpapache/index.php?q=$uri;
+    #proxy_set_header Connection '';
+}
+
+## Internal location to ask Drupal to generate a derivative image if the
+## source ## image is present. Add a bit of logic so that it does not break
+## stage_file_proxy on non-prod environments.
+location @drupal-generate-derivative-image {
+
+  set_by_lua $environment 'return os.getenv("ENVIRONMENT")';
+
+  # If this is not the production environement, pass the request to Drupal.
+  if ($environment != "prod") {
+    return 406;
+  }
+  # If the source image doesn't exist, return a 404.
+  if (!-f "$document_root/sites/default/files/$file_path") {
+    return 404;
+  }
+
+  # Otherwise, pass the request to Drupal to generate the derivative.
+  try_files /dev/null @drupal;
+}
+
+## Internal location check if we're a production site and potentially
+## pass a request to stage_file_proxy if not.
+location @drupal-stage-file-proxy {
+  set_by_lua $environment 'return os.getenv("ENVIRONMENT")';
+
+  # If this is the prod environment, the original $uri would have worked.
+  if ($environment = "prod") {
+    return 404;
+  }
+
+  # Not prod, pass the request to Drupal.
+  try_files /dev/null @drupal;
+}
+
+## Disallow access to .bzr, .git, .hg, .svn, .cvs directories: return
+## 404 as not to disclose information.
+location ^~ /.bzr {
+    return 404;
+}
+
+location ^~ /.git {
+    return 404;
+}
+
+location ^~ /.hg {
+    return 404;
+}
+
+location ^~ /.svn {
+    return 404;
+}
+
+location ^~ /.cvs {
+    return 404;
+}
+
+## Disallow access to patches directory.
+location ^~ /patches {
+    return 404;
+}
+
+## Disallow access to drush backup directory.
+location ^~ /backup {
+    return 404;
+}
+
+## Disable access logs for robots.txt.
+location = /robots.txt {
+    access_log off;
+    ## Add support for the robotstxt module
+    ## http://drupal.org/project/robotstxt.
+    try_files $uri @drupal-no-args;
+}
+
+## RSS feed support.
+location = /rss.xml {
+    try_files $uri @drupal-no-args;
+}
+
+## XML Sitemap support.
+location = /sitemap.xml {
+    try_files $uri @drupal;
+}
+
+## Support for favicon. Return an 1x1 transparent GIF if it doesn't
+## exist.
+location = /favicon.ico {
+    expires 30d;
+    try_files /favicon.ico @empty;
+}
+
+## Return an in memory 1x1 transparent GIF.
+location @empty {
+    expires 30d;
+    empty_gif;
+}
+
+## Any other attempt to access PHP files returns a 404.
+location ~* ^.+\.php$ {
+    return 404;
+}
+
+## Avoid a Drupal error when requesting index.phpfoobar.
+location ~ "^/index\.php.+" {
+    return 404;
+}
+
+if ( $args ~* "/autocomplete/" ) {
+  return 406;
+  ### error_page 406 = @drupal; ### error_page directive is not allowed within pseudo-location
+}
+
+error_page 406 = @drupal;


### PR DESCRIPTION
The actual fix in the overridden drupal.conf file is to use **@drupal** and not **@drupal-stage-file-proxy** as final location. That means the request is always passed to Drupal and not only on the non-production environment.

Refs: UNO-693