### PR TITLE
[UNO-693] Add nginx rules to handle legacy file URLs redirections

### DIFF
--- a/docker/etc/nginx/custom/04_legacy_files.conf
+++ b/docker/etc/nginx/custom/04_legacy_files.conf
@@ -1,10 +1,67 @@
-# Allow legacy files (and ECOSOC files) to be available on their old URL.
-#
-# If not found, pass the request to Drupal, so redirect module may handle it if required.
+## Handle default site files and legacy ones.
+location /sites {
 
-location /sites/unocha/files {
+  ## Trying to access private files directly returns a 404.
+  location ^~ /sites/.*/private/ {
+    internal;
+  }
+
+  ## Deny access to files directly under `/site/` or `/site/default/` like
+  ## the services.yml files.
+  location ~ ^/sites/(?:default/)?[^/]+$ {
+    internal;
+  }
+
+  ## Location for public files.
+  location ~ ^/sites/default/files/.*$ {
+    access_log off;
+    expires 30d;
+    ## No need to bleed constant updates. Send the all shebang in one
+    ## fell swoop.
+    tcp_nodelay off;
+
+    ## Set the OS file cache.
+    open_file_cache max=3000 inactive=120s;
+    open_file_cache_valid 45s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors off;
+
+    ## Location for public derivative images to avoid hitting Drupal for invalid
+    ## image derivative paths or if the source image doesn't exist.
+    location ~ ^/sites/default/files/styles/.*$ {
+
+      ## Valid public derivative image paths.
+      ## We store the source image path without the extra `.webp` extension
+      ## present in the derivative so that we can check if the source image
+      ## exists in @drupal-generate-derivative-image.
+      ## So this handles derivatives in the form
+      ## - image.ext (ex: image.jpg, image.webp)
+      ## - image.ext.webp (ex: image.jpg.webp, image.webp.webp)
+      ## The latter is what the `imageapi_optimize_webp` generates.
+      location ~ "^/sites/default/files/styles/[^/]+/public/(?<file_path>.+?\.[^.]+)(\.webp)?$" {
+          ## Return the derivative image if it already exists or ask Drupal
+          ## to generate it otherwise.
+          try_files $uri @drupal-generate-derivative-image;
+      }
+
+      return 404;
+    }
+
+    ## Serve the file directly and fall back to drupal.
+    ## That includes the CSS/JS aggregated files in Drupal 10.1.
+    try_files $uri @drupal;
+  }
+
+  ## Invalid image styles (not in /sites/default/styles).
+  location ~ ^/sites/.*/files/styles/.*$ {
+    return 404;
+  }
+
+  ## Allow legacy files (and ECOSOC files) to be available on their old URL.
   location ~ ^/sites/unocha/files/(?<file_path>.*)$ {
     try_files /sites/default/files/legacy/$file_path /sites/default/files/ecosoc/$file_path @drupal;
   }
-  return 404 "404 Not Found";
+
+  ## Default. Try the file on disk or pass the request to Drupal.
+  try_files $uri @drupal;
 }

--- a/docker/etc/nginx/custom/04_legacy_files.conf
+++ b/docker/etc/nginx/custom/04_legacy_files.conf
@@ -6,7 +6,7 @@ location /sites {
     internal;
   }
 
-  ## Deny access to files directly under `/site/` or `/site/default/` like
+  ## Deny access to files directly under `/sites/` or `/sites/default/` like
   ## the services.yml files.
   location ~ ^/sites/(?:default/)?[^/]+$ {
     internal;


### PR DESCRIPTION
Refs: UNO-693

This adds a catch all `/sites/` location nginx rule and adds the relevant sub location rules to handle current site and legacy files including weird ones like `dms/Documents/xxx`.

It copies some parts of some rules for files from https://github.com/UN-OCHA/docker-images/blob/main/php/php-k8s-v82/etc/nginx/apps/drupal/drupal.conf so that site files (uploaded files, images, aggregated css/js and image derivatives) are handled as "usual" with the exception of the requests always being passed to Drupal regardless of the environment if the file is not find on disk (except for derivative images).

It also contain the rule for legacy and ECOSOC files.

Hopefully this is a bit easier to maintain that a modified copy of the `drupal.conf` file.

This was tested with the following:

- /sites/unocha/files/UNDAC_Field_Handbook-Rev-1.10%20%281%29.pdf --> Legacy rule, try to load legacy or ecosoc file and pass request to Drupal otherwise
- /sites/dms/Documents/OOM-humanitarianprinciples_eng_June12.pdf --> Default rule, try to load file on disk or pass request to Drupal (this example redirects to https://reliefweb.int/report/world/ocha-message-humanitarian-principles-enar via the redirect module)
- /sites/default/files/css/css_yXvfIStxEMzz-L9VsWIdnac7iJn1SS0jQaVFju_VovE.css --> Default site file rule, read file on disk or pass to Drupal (so it can generate the aggregated css)
- /sites/default/files/styles/full_width_2_1_246/public/2023-08/OCHA_NIGER_Day2_%206.jpg --> Image style rule, check if original file is on disk, return a 404 if not. Otherwise try the derivative file on disk or pass it request to Drupal for generation.
- /sites/default/files/styles/full_width_2_1_246/public/2023-08/OCHA_NIGER_Day2_%206.jpg.webp --> Image style rule, check if original file (without the .webp extension) is on disk, return a 404 if not. Otherwise try the derivative file on disk or pass it request to Drupal for generation.
- /sites/unocha/files/styles/full_width_2_1_246/public/2023-08/OCHA_NIGER_Day2_%206.jpg --> Wrong style rule (not in site/default), return a 404
- /attachments/60f4c23c-ec2a-3aea-94f7-4cdcb47d69b3/oom-humanitarianprinciples-eng-june12.pdf --> RW redirection rule for attachments
- /sites/default/files/styles/small/public/previews/60/f4/60f4c23c-ec2a-3aea-94f7-4cdcb47d69b3.png --> RW redirection rule for attachment previews
- /sites/default/files/styles/large/public/images/reports/ba/5e/ba5e2d80-a89b-4b9e-9350-1b0e5bf3756b.png --> RW redirection rule for report images
- /sites/default/test.pdf --> Deny rule, return a 404
- /sites/test.pdf --> Deny rule, return a 404
- /sites/unocha/test.pdf --> Default rule, try file on disk or pass request to Drupal