### PR TITLE
UNO-780 Replace hard-coded Title and Description with Paragraph fields for editability

### DIFF
--- a/config/core.entity_form_display.paragraph.donors.default.yml
+++ b/config/core.entity_form_display.paragraph.donors.default.yml
@@ -6,11 +6,14 @@ dependencies:
     - field.field.paragraph.donors.field_country_donors
     - field.field.paragraph.donors.field_figures_footnote
     - field.field.paragraph.donors.field_presence_donors
+    - field.field.paragraph.donors.field_text
+    - field.field.paragraph.donors.field_title
     - field.field.paragraph.donors.field_url
     - paragraphs.paragraphs_type.donors
   module:
     - link
     - ocha_key_figures
+    - text
 id: paragraph.donors.default
 targetEntityType: paragraph
 bundle: donors
@@ -18,14 +21,14 @@ mode: default
 content:
   field_country_donors:
     type: key_figure
-    weight: 0
+    weight: 2
     region: content
     settings:
       allow_manual: 'no'
     third_party_settings: {  }
   field_figures_footnote:
     type: string_textarea
-    weight: 3
+    weight: 5
     region: content
     settings:
       rows: 5
@@ -33,14 +36,30 @@ content:
     third_party_settings: {  }
   field_presence_donors:
     type: key_figure_presence
-    weight: 1
+    weight: 3
     region: content
     settings:
       allow_manual: 'no'
     third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_url:
     type: link_default
-    weight: 2
+    weight: 4
     region: content
     settings:
       placeholder_url: ''
@@ -48,13 +67,13 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 5
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_view_display.paragraph.donors.default.yml
+++ b/config/core.entity_view_display.paragraph.donors.default.yml
@@ -6,10 +6,13 @@ dependencies:
     - field.field.paragraph.donors.field_country_donors
     - field.field.paragraph.donors.field_figures_footnote
     - field.field.paragraph.donors.field_presence_donors
+    - field.field.paragraph.donors.field_text
+    - field.field.paragraph.donors.field_title
     - field.field.paragraph.donors.field_url
     - paragraphs.paragraphs_type.donors
   module:
     - link
+    - text
     - unocha_donors
 id: paragraph.donors.default
 targetEntityType: paragraph
@@ -25,14 +28,14 @@ content:
       currency_symbol: 'yes'
       percentage: 'yes'
     third_party_settings: {  }
-    weight: 0
+    weight: 2
     region: content
   field_figures_footnote:
     type: basic_string
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 4
     region: content
   field_presence_donors:
     type: unocha_donors
@@ -43,7 +46,22 @@ content:
       currency_symbol: 'yes'
       percentage: 'yes'
     third_party_settings: {  }
+    weight: 3
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
     weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
     region: content
   field_url:
     type: link
@@ -55,6 +73,6 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 3
+    weight: 5
     region: content
 hidden: {  }

--- a/config/core.entity_view_display.paragraph.donors.preview.yml
+++ b/config/core.entity_view_display.paragraph.donors.preview.yml
@@ -14,6 +14,7 @@ dependencies:
   module:
     - layout_builder
     - link
+    - text
     - unocha_donors
 third_party_settings:
   layout_builder:
@@ -33,14 +34,14 @@ content:
       currency_symbol: 'yes'
       percentage: 'yes'
     third_party_settings: {  }
-    weight: 0
+    weight: 2
     region: content
   field_figures_footnote:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 4
     region: content
   field_presence_donors:
     type: unocha_donors
@@ -51,7 +52,22 @@ content:
       currency_symbol: 'yes'
       percentage: 'yes'
     third_party_settings: {  }
+    weight: 3
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
     weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
     region: content
   field_url:
     type: link
@@ -63,8 +79,6 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 3
+    weight: 5
     region: content
-hidden:
-  field_text: true
-  field_title: true
+hidden: {  }

--- a/config/core.entity_view_display.paragraph.donors.preview.yml
+++ b/config/core.entity_view_display.paragraph.donors.preview.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.paragraph.donors.field_country_donors
     - field.field.paragraph.donors.field_figures_footnote
     - field.field.paragraph.donors.field_presence_donors
+    - field.field.paragraph.donors.field_text
+    - field.field.paragraph.donors.field_title
     - field.field.paragraph.donors.field_url
     - paragraphs.paragraphs_type.donors
   module:
@@ -63,4 +65,6 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
-hidden: {  }
+hidden:
+  field_text: true
+  field_title: true

--- a/config/field.field.paragraph.donors.field_text.yml
+++ b/config/field.field.paragraph.donors.field_text.yml
@@ -17,7 +17,7 @@ field_name: field_text
 entity_type: paragraph
 bundle: donors
 label: Text
-description: ''
+description: 'Use the "@year" placeholder in the text to have it replaced by the current year (ex: "Some text @year and some other text.") when displayed.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/field.field.paragraph.donors.field_text.yml
+++ b/config/field.field.paragraph.donors.field_text.yml
@@ -1,0 +1,27 @@
+uuid: c956a0e3-26e3-4e90-a6a8-d7b88551aaa0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.donors
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - ckeditor
+id: paragraph.donors.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: donors
+label: Text
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/field.field.paragraph.donors.field_title.yml
+++ b/config/field.field.paragraph.donors.field_title.yml
@@ -12,7 +12,7 @@ bundle: donors
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/field.field.paragraph.donors.field_title.yml
+++ b/config/field.field.paragraph.donors.field_title.yml
@@ -10,7 +10,7 @@ field_name: field_title
 entity_type: paragraph
 bundle: donors
 label: Title
-description: ''
+description: 'Use the "@year" placeholder in the title to have it replaced by the current year (ex: "Funding in @year") when displayed.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/field.field.paragraph.donors.field_title.yml
+++ b/config/field.field.paragraph.donors.field_title.yml
@@ -1,0 +1,19 @@
+uuid: fe1f05aa-76ee-4925-989d-934d288cd387
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.donors
+id: paragraph.donors.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: donors
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/html/modules/custom/unocha_donors/src/Plugin/Field/FieldFormatter/Donors.php
+++ b/html/modules/custom/unocha_donors/src/Plugin/Field/FieldFormatter/Donors.php
@@ -86,12 +86,14 @@ class Donors extends KeyFigureBase {
           '#theme' => 'unocha_donors_list__' . $type . '__' . $view_mode,
           '#id' => Html::getUniqueId($type . '-' . $items->getEntity()->id() . '-' . $delta),
           '#type' => $type,
-          '#title' => $item->getFigureLabel() ?: $this->t('Top donors'),
+          // The title is handled in the template.
+          '#title' => '',
           '#year' => $data['year'] ?? NULL,
           '#list' => $donors,
           '#format' => $format,
           '#precision' => $precision,
           '#currency_symbol' => $currency_symbol,
+          '#item' => $item,
           '#cache' => [
             'max-age' => $this->ochaKeyFiguresApiClient->getMaxAge(),
             'tags' => $this->ochaKeyFiguresApiClient->getCacheTags([

--- a/html/modules/custom/unocha_donors/templates/unocha-donors-list.html.twig
+++ b/html/modules/custom/unocha_donors/templates/unocha-donors-list.html.twig
@@ -11,18 +11,25 @@
  * - level: heading level for the title
  * - title: list's title
  * - title_attributes: title attributes
+ * - description: list's description
+ * - description_attributes: description attributes
  * - year: the year of the data
  * - list: list of donors/sectors with name and optional pledged/paid amounts
  * - list_attributes: attributes for the list
  * - item_attributes: attributes for the list items
  * - format: number format
  * - precision: number format precision
+ * - item: KeyFigure or KeyFigurePresence item
  */
 
 #}
 {% if list is not empty %}
+{% set title = title ?: (item.getFigureLabel() ? '@label (@provider)'|t({'@label': item.getFigureLabel(), '@provider': item.getFigureProvider()|upper}) : 'Top donors'|t) %}
 <section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class).setAttribute('id', id) }}>
   <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+  {% if description %}
+    <div{{ description_attributes.addClass('uno-donors__description') }}>{{ description }}</div>
+  {% endif %}
   <ul{{ list_attributes.addClass('uno-donors__list') }}>
     {% for item in list %}
     <li{{ item_attributes.addClass('uno-donors__list__item') }}>{{ item.name }}</li>

--- a/html/modules/custom/unocha_donors/unocha_donors.module
+++ b/html/modules/custom/unocha_donors/unocha_donors.module
@@ -25,6 +25,10 @@ function unocha_donors_theme() {
         'title' => NULL,
         // Title attributes.
         'title_attributes' => NULL,
+        // Description.
+        'description' => NULL,
+        // Description attributes.
+        'description_attributes' => NULL,
         // The year of the data.
         'year' => NULL,
         // List of donors/sectors with name and optional pledged/paid amounts.
@@ -37,6 +41,8 @@ function unocha_donors_theme() {
         'format' => NULL,
         // Number format precision.
         'precision' => NULL,
+        // KeyFigure or KeyFigurePresence item.
+        'item' => NULL,
       ],
     ],
   ];

--- a/html/themes/custom/common_design_claro/css/styles.css
+++ b/html/themes/custom/common_design_claro/css/styles.css
@@ -54,7 +54,7 @@
 }
 
 /* Matches .cd-block-title */
-.field--name-field-title {
+.field--name-field-title:not(.form-wrapper) {
   margin: 0 0 1rem 0;
   margin-top: 0;
   margin-bottom: 1rem;
@@ -112,6 +112,11 @@ p.headline {
 blockquote::before {
   /* content: open-quote; */
   content: none;
+}
+
+/* Prevent excessive spacing between text widget and description. */
+.field--widget-text-textarea .filter-wrapper {
+  float: right;
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/uno-donors/uno-donors.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-donors/uno-donors.css
@@ -266,3 +266,17 @@ ul.uno-donors__list--with-figures .uno-donors__amount {
 .uno-donors--oct-top-donors .uno-donors__donor {
   padding: 0;
 }
+
+.node--view-mode-full .paragraph .field--name-field-text,
+p.uno-donors__description {
+  margin: 1rem 0;
+}
+
+@media (min-width: 768px) {
+  /* When content.field_text has content, remove the padding for consistent
+    vertical rhythm.
+  */
+  .field--name-field-text + .field--name-field-country-donors .uno-donors {
+    padding-top: 0;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--cbpf-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--cbpf-top-donors.html.twig
@@ -11,21 +11,27 @@
  * - level: heading level for the title
  * - title: list's title
  * - title_attributes: title attributes
+ * - description: list's description
+ * - description_attributes: description attributes
  * - year: the year of the data
  * - list: list of donors/sectors with name and optional pledged/paid amounts
  * - list_attributes: attributes for the list
  * - item_attributes: attributes for the list items
  * - format: number format
  * - precision: number format precision
+ * - item: KeyFigure or KeyFigurePresence item
  */
 
 #}
 {% if list is not empty %}
 {{ attach_library('common_design_subtheme/uno-donors') }}
-{% set title = 'Top 5 donors'|t %}
+{% set title = title ?: 'Top 5 donors'|t %}
 <section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class).setAttribute('id', id) }}>
   <header class="uno-donors__header">
     <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+    {% if description %}
+      <div{{ description_attributes.addClass('uno-donors__description') }}>{{ description }}</div>
+    {% endif %}
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-donors.html.twig
@@ -11,21 +11,27 @@
  * - level: heading level for the title
  * - title: list's title
  * - title_attributes: title attributes
+ * - description: list's description
+ * - description_attributes: description attributes
  * - year: the year of the data
  * - list: list of donors/sectors with name and optional pledged/paid amounts
  * - list_attributes: attributes for the list
  * - item_attributes: attributes for the list items
  * - format: number format
  * - precision: number format precision
+ * - item: KeyFigure or KeyFigurePresence item
  */
 
 #}
 {% if list is not empty %}
 {{ attach_library('common_design_subtheme/uno-donors') }}
-{% set title = 'Top 5 donors'|t %}
+{% set title = title ?: 'Top 5 donors'|t %}
 <section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class).setAttribute('id', id) }}>
   <header class="uno-donors__header">
     <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+    {% if description %}
+      <div{{ description_attributes.addClass('uno-donors__description') }}>{{ description }}</div>
+    {% endif %}
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-sectors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--fts-top-sectors.html.twig
@@ -11,21 +11,27 @@
  * - level: heading level for the title
  * - title: list's title
  * - title_attributes: title attributes
+ * - description: list's description
+ * - description_attributes: description attributes
  * - year: the year of the data
  * - list: list of donors/sectors with name and optional pledged/paid amounts
  * - list_attributes: attributes for the list
  * - item_attributes: attributes for the list items
  * - format: number format
  * - precision: number format precision
+ * - item: KeyFigure or KeyFigurePresence item
  */
 
 #}
 {% if list is not empty %}
 {{ attach_library('common_design_subtheme/uno-donors') }}
-{% set title = 'Top 5 funded sectors'|t %}
+{% set title = title ?: 'Top 5 funded sectors'|t %}
 <section{{attributes.addClass('uno-donors','uno-donors--'~type|clean_class).setAttribute('id',id)}}>
   <header class="uno-donors__header">
     <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+    {% if description %}
+      <div{{ description_attributes.addClass('uno-donors__description') }}>{{ description }}</div>
+    {% endif %}
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-earmarked-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-earmarked-donors.html.twig
@@ -11,21 +11,27 @@
  * - level: heading level for the title
  * - title: list's title
  * - title_attributes: title attributes
+ * - description: list's description
+ * - description_attributes: description attributes
  * - year: the year of the data
  * - list: list of donors/sectors with name and optional pledged/paid amounts
  * - list_attributes: attributes for the list
  * - item_attributes: attributes for the list items
  * - format: number format
  * - precision: number format precision
+ * - item: KeyFigure or KeyFigurePresence item
  */
 
 #}
 {% if list is not empty %}
 {{ attach_library('common_design_subtheme/uno-donors') }}
-{% set title = 'Earmarked contributions'|t %}
+{% set title = title ?: 'Earmarked contributions'|t %}
 <section{{attributes.addClass('uno-donors','uno-donors--'~type|clean_class).setAttribute('id',id)}}>
   <header class="uno-donors__header">
     <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+    {% if description %}
+      <div{{ description_attributes.addClass('uno-donors__description') }}>{{ description }}</div>
+    {% endif %}
   </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--with-figures') }}>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
@@ -22,7 +22,7 @@
 #}
 {% if list is not empty %}
 {{ attach_library('common_design_subtheme/uno-donors') }}
-{% set title = year ? 'OCHA donors in @year'|t({'@year': year}) : 'OCHA donors'|t %}
+{% set title = year ? 'Funding for OCHA in @year'|t({'@year': year}) : 'Funding for OCHA'|t %}
 {% set title_id = id ~ '-title' %}
 {% set list_id = id ~ '-list' %}
 <section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class, 'uno-donors--collapsible').setAttribute('id', id) }}>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
@@ -29,8 +29,8 @@
   <h{{ level }}{{ title_attributes.addClass('uno-donors__title', 'cd-block-title', 'visually-hidden').setAttribute('id', title_id) }}>{{ title }}</h{{ level }}>
   {# <p class="uno-donors__description">{% trans %}The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA's donors, please click the button below.{% endtrans %}</p> #}
   <p class="uno-donors__legend">
-    <span class="uno-donors__legend__unearmarked">{{ 'Unearmaked %'|t }}</span>
-    <span class="uno-donors__legend__earmarked">{{ 'Earmaked %'|t }}</span>
+    <span class="uno-donors__legend__unearmarked">{{ 'Unearmarked %'|t }}</span>
+    <span class="uno-donors__legend__earmarked">{{ 'Earmarked %'|t }}</span>
   </p>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--barchart').setAttribute('id', list_id) }}>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
@@ -12,26 +12,33 @@
  * - title: list's title
  * - title_attributes: title attributes
  * - year: the year of the data
+ * - description: list's description
+ * - description_attributes: description attributes
  * - list: list of donors/sectors with name and optional pledged/paid amounts
  * - list_attributes: attributes for the list
  * - item_attributes: attributes for the list items
  * - format: number format
  * - precision: number format precision
+ * - item: KeyFigure or KeyFigurePresence item
  */
 
 #}
 {% if list is not empty %}
 {{ attach_library('common_design_subtheme/uno-donors') }}
-{% set title = year ? 'Funding for OCHA in @year'|t({'@year': year}) : 'Funding for OCHA'|t %}
+{% set title = title ?: 'Funding of OCHA in @year'|t({'@year': year ?? date('Y')}) %}
 {% set title_id = id ~ '-title' %}
 {% set list_id = id ~ '-list' %}
 <section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class, 'uno-donors--collapsible').setAttribute('id', id) }}>
-  <h{{ level }}{{ title_attributes.addClass('uno-donors__title', 'cd-block-title', 'visually-hidden').setAttribute('id', title_id) }}>{{ title }}</h{{ level }}>
-  {# <p class="uno-donors__description">{% trans %}The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA's donors, please click the button below.{% endtrans %}</p> #}
-  <p class="uno-donors__legend">
-    <span class="uno-donors__legend__unearmarked">{{ 'Unearmarked %'|t }}</span>
-    <span class="uno-donors__legend__earmarked">{{ 'Earmarked %'|t }}</span>
-  </p>
+  <header class="uno-donors__header">
+    <h{{ level }}{{ title_attributes.addClass('uno-donors__title', 'cd-block-title').setAttribute('id', title_id) }}>{{ title }}</h{{ level }}>
+    {% if description %}
+      <div{{ description_attributes.addClass('uno-donors__description') }}>{{ description }}</div>
+    {% endif %}
+    <p class="uno-donors__legend">
+      <span class="uno-donors__legend__unearmarked">{{ 'Unearmarked %'|t }}</span>
+      <span class="uno-donors__legend__earmarked">{{ 'Earmarked %'|t }}</span>
+    </p>
+  </header>
   {% apply spaceless %}
   <dl{{ list_attributes.addClass('uno-donors__list', 'uno-donors__list--barchart').setAttribute('id', list_id) }}>
     {# Sort by total funding descending. #}

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
@@ -26,8 +26,8 @@
 {% set title_id = id ~ '-title' %}
 {% set list_id = id ~ '-list' %}
 <section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class, 'uno-donors--collapsible').setAttribute('id', id) }}>
-  <h{{ level }}{{ title_attributes.addClass('uno-donors__title', 'cd-block-title').setAttribute('id', title_id) }}>{{ title }}</h{{ level }}>
-  <p class="uno-donors__description">{% trans %}The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA's donors, please click the button below.{% endtrans %}</p>
+  <h{{ level }}{{ title_attributes.addClass('uno-donors__title', 'cd-block-title', 'visually-hidden').setAttribute('id', title_id) }}>{{ title }}</h{{ level }}>
+  {# <p class="uno-donors__description">{% trans %}The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA's donors, please click the button below.{% endtrans %}</p> #}
   <p class="uno-donors__legend">
     <span class="uno-donors__legend__unearmarked">{{ 'Unearmaked %'|t }}</span>
     <span class="uno-donors__legend__earmarked">{{ 'Earmaked %'|t }}</span>

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig
@@ -12,20 +12,26 @@
  * - title: list's title
  * - title_attributes: title attributes
  * - year: the year of the data
+ * - description: list's description
+ * - description_attributes: description attributes
  * - list: list of donors/sectors with name and optional pledged/paid amounts
  * - list_attributes: attributes for the list
  * - item_attributes: attributes for the list items
  * - format: number format
  * - precision: number format precision
+ * - item: KeyFigure or KeyFigurePresence item
  */
 
 #}
 {% if list is not empty %}
 {{ attach_library('common_design_subtheme/uno-donors') }}
-{% set title = 'Unearmarked contributions'|t %}
+{% set title = title ? 'Unearmarked contributions'|t %}
 <section{{attributes.addClass('uno-donors','uno-donors--'~type|clean_class).setAttribute('id',id)}}>
   <header class="uno-donors__header">
     <h{{ level }}{{ title_attributes.addClass('uno-donors__title') }}>{{ title }}</h{{ level }}>
+    {% if description %}
+      <div{{ description_attributes.addClass('uno-donors__description') }}>{{ description }}</div>
+    {% endif %}
   </header>
   {% apply spaceless %}
   <ul{{ list_attributes.addClass('uno-donors__list') }}>

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--donors.html.twig
@@ -46,28 +46,29 @@
     not paragraph.isPublished() ? 'paragraph--unpublished'
   ]
 %}
+{% set donors = content.field_country_donors.0 ?? content.field_presence_donors.0 %}
+{% if donors %}
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
-    {% set donor_type = content.field_country_donors.0['#type'] ?? content.field_presence_donors.0['#type'] %}
-    {% set title = 'Funding for OCHA'|t %}
-    {% set text = 'The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA\'s donors, please click the button below.'|t %}
-    {% set text_formatted %}<p class="uno-donors__description">{{ text }}</p>{% endset %}
     {% block content %}
+      {#
+        We render the title and description to be able to replace the `@year`
+        with the year variable because they may be renderable arrays. We then
+        wrap the result in a '#markup' to avoid double escaping when printed.
+      #}
+      {% set year = donors['#year'] ?: date('Y') %}
+      {% set title = (content.field_title.0 ?: donors['#title'])|render|replace({'@year': year}) %}
+      {% set description = (content.field_text.0 ?: donors['#description'])|render|replace({'@year': year}) %}
+      {{
+        donors|merge({
+          '#title': title ? {'#markup': title},
+          '#description': description ? {'#markup': description}
+        })
+      }}
 
-      {% if donor_type == 'oct_top_donors' %}
-        <h2{{ title_attributes.addClass('uno-donors__title', 'cd-block-title') }}>
-          {{ content.field_title[0]['#context']['value'] ? content.field_title[0]['#context']['value'] : title }}
-        </h2>
-        {{ content.field_text|render is not empty ? content.field_text : text_formatted }}
-      {% else %}
-        {{ content.field_title }}
-        {{ content.field_text }}
-      {% endif %}
+      {{ content|without('field_title', 'field_text', 'field_country_donors', 'field_presence_donors', 'field_url', 'field_figures_footnote') }}
 
-      {{ content.donors }}
-      {{ content|without('field_title', 'field_text', 'donors', 'field_url', 'field_figures_footnote') }}
-
-      {% if donor_type == 'oct_unearmarked_donors' %}
+      {% if donors['#type'] == 'oct_unearmarked_donors' %}
         <div class="uno-donors__footnote">
           {{ content.field_figures_footnote }}
           <p>
@@ -100,3 +101,4 @@
     {% endblock %}
   </div>
 {% endblock paragraph %}
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--donors.html.twig
@@ -48,11 +48,25 @@
 %}
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
+    {% set donor_type = content.field_country_donors.0['#type'] ?? content.field_presence_donors.0['#type'] %}
+    {% set title = 'Funding for OCHA'|t %}
+    {% set text = 'The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA\'s donors, please click the button below.'|t %}
+    {% set text_formatted %}<p class="uno-donors__description">{{ text }}</p>{% endset %}
     {% block content %}
-      {{ content.donors }}
-      {{ content|without('donors', 'field_url', 'field_figures_footnote') }}
 
-      {% set donor_type = content.field_country_donors.0['#type'] ?? content.field_presence_donors.0['#type'] %}
+      {% if donor_type == 'oct_top_donors' %}
+        <h2{{ title_attributes.addClass('uno-donors__title', 'cd-block-title') }}>
+          {{ content.field_title[0]['#context']['value'] ? content.field_title[0]['#context']['value'] : title }}
+        </h2>
+        {{ content.field_text|render is not empty ? content.field_text : text_formatted }}
+      {% else %}
+        {{ content.field_title }}
+        {{ content.field_text }}
+      {% endif %}
+
+      {{ content.donors }}
+      {{ content|without('field_title', 'field_text', 'donors', 'field_url', 'field_figures_footnote') }}
+
       {% if donor_type == 'oct_unearmarked_donors' %}
         <div class="uno-donors__footnote">
           {{ content.field_figures_footnote }}

--- a/html/themes/custom/common_design_subtheme/translations/ar-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/ar-common-design.po
@@ -202,10 +202,10 @@ msgstr ""
 msgid "OCHA donors"
 msgstr ""
 
-msgid "Unearmaked"
+msgid "Unearmarked"
 msgstr ""
 
-msgid "Earmaked"
+msgid "Earmarked"
 msgstr ""
 
 # common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig #

--- a/html/themes/custom/common_design_subtheme/translations/ar-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/ar-common-design.po
@@ -196,7 +196,7 @@ msgstr ""
 msgid "Show top 10 donors"
 msgstr ""
 
-msgid "OCHA donors in @year"
+msgid "Funding for OCHA in @year"
 msgstr ""
 
 msgid "OCHA donors"

--- a/html/themes/custom/common_design_subtheme/translations/es-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/es-common-design.po
@@ -197,10 +197,10 @@ msgstr ""
 msgid "OCHA donors"
 msgstr ""
 
-msgid "Unearmaked"
+msgid "Unearmarked"
 msgstr ""
 
-msgid "Earmaked"
+msgid "Earmarked"
 msgstr ""
 
 # common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig #

--- a/html/themes/custom/common_design_subtheme/translations/es-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/es-common-design.po
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Show top 10 donors"
 msgstr ""
 
-msgid "OCHA donors in @year"
+msgid "Funding for OCHA in @year"
 msgstr ""
 
 msgid "OCHA donors"

--- a/html/themes/custom/common_design_subtheme/translations/fr-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/fr-common-design.po
@@ -197,10 +197,10 @@ msgstr ""
 msgid "OCHA donors"
 msgstr ""
 
-msgid "Unearmaked"
+msgid "Unearmarked"
 msgstr ""
 
-msgid "Earmaked"
+msgid "Earmarked"
 msgstr ""
 
 # common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-unearmarked-donors.html.twig #

--- a/html/themes/custom/common_design_subtheme/translations/fr-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/fr-common-design.po
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Show top 10 donors"
 msgstr ""
 
-msgid "OCHA donors in @year"
+msgid "Funding for OCHA in @year"
 msgstr ""
 
 msgid "OCHA donors"


### PR DESCRIPTION
See UNO-780 for discussion

## To test
1. Checkout branch, clear cache, import config
2. Visit https://unocha-local.test/our-funding and take note of the Title and Description text and markup
3. Edit the existing Donors paragraph on https://unocha-local.test/our-funding, adding a custom Title and Text
4. Ensure the custom text displays instead of the default, and there is no significant visual changes, and the interaction continues to work as expected.