### PR TITLE
[UNO-780] Use base FTS URL which redirects to the current year page

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_donors/unocha-donors-list--oct-top-donors.html.twig
@@ -28,7 +28,7 @@
 {% set list_id = id ~ '-list' %}
 {# We use t() for the URL so that, in theory, we could have different URLs for
    different languages. #}
-{% set url = 'https://fts.unocha.org/home/@year/donors/view'|t({'@year': year}) %}
+{% set url = 'https://fts.unocha.org'|t %}
 {% set link = link(url, url)|render %}
 
 <section{{ attributes.addClass('uno-donors', 'uno-donors--' ~ type|clean_class, 'uno-donors--collapsible').setAttribute('id', id) }}>

--- a/html/themes/custom/common_design_subtheme/translations/ar-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/ar-common-design.po
@@ -190,7 +190,7 @@ msgstr ""
 msgid "The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA's donors, please click the button below. For a comprehensive overview of humanitarian funding, visit: @link"
 msgstr ""
 
-msgid "https://fts.unocha.org/home/@year/donors/view"
+msgid "https://fts.unocha.org"
 msgstr ""
 
 msgid "Show all donors"

--- a/html/themes/custom/common_design_subtheme/translations/es-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/es-common-design.po
@@ -185,7 +185,7 @@ msgstr ""
 msgid "The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA's donors, please click the button below. For a comprehensive overview of humanitarian funding, visit: @link"
 msgstr ""
 
-msgid "https://fts.unocha.org/home/@year/donors/view"
+msgid "https://fts.unocha.org"
 msgstr ""
 
 msgid "Show all donors"

--- a/html/themes/custom/common_design_subtheme/translations/fr-common-design.po
+++ b/html/themes/custom/common_design_subtheme/translations/fr-common-design.po
@@ -185,7 +185,7 @@ msgstr ""
 msgid "The graphic below shows the top 10 OCHA donors for this year. The bar represents the percentage of earmarked vs. unearmarked funds per donor. For a complete listing of OCHA's donors, please click the button below. For a comprehensive overview of humanitarian funding, visit: @link"
 msgstr ""
 
-msgid "https://fts.unocha.org/home/@year/donors/view"
+msgid "https://fts.unocha.org"
 msgstr ""
 
 msgid "Show all donors"


### PR DESCRIPTION
Refs: UNO-780

Apparently the base FTS url redirects to the current year's funding page (https://fts.unocha.org --> https://fts.unocha.org/home/2023/donors/view).