### PR TITLE
UNO-784 Prevent duplicate IDs on Section Tabs

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-section-tabs/uno-section-tabs.js
+++ b/html/themes/custom/common_design_subtheme/components/uno-section-tabs/uno-section-tabs.js
@@ -34,10 +34,10 @@
         // Add the tablist role to the first <ul> in the .uno-section-tabs container.
         tablist.setAttribute('role', 'tablist');
 
-        // Add semantics are remove user focusability for each tab.
-        Array.prototype.forEach.call(tabs, (tab, i) => {
+        // Add semantics to remove user focusability for each tab.
+        Array.prototype.forEach.call(tabs, tab => {
           tab.setAttribute('role', 'tab');
-          tab.setAttribute('id', 'tab' + (i + 1));
+          tab.setAttribute('id', tab.id);
           tab.setAttribute('tabindex', '-1');
           tab.parentNode.setAttribute('role', 'presentation');
 


### PR DESCRIPTION
chore: use id from anchor for tab to prevent duplicate IDs when multiple tab sets are on the same page

This came up during recent accessibility testing.

Before: Each Section Tabs has Tabs (anchor elements) with IDs 1, 2, 3 etc

![Selection_328](https://github.com/UN-OCHA/unocha-site/assets/1835923/8dd214da-cc39-499c-8757-c85cc4bef8f8)

After: Each Section Tabs has unique IDs using the `paragraph.id()`

![Selection_329](https://github.com/UN-OCHA/unocha-site/assets/1835923/cf4c6e99-69ae-4f47-80a0-dc3efb630eaa)

## To test:
1. Before checking out this branch, visit a page with multiple Section Tabs paragraphs, like a Response.
2. Notice the markup for the anchors, specifically the ID: `<a href="#section--84" id="tab1" role="tab" aria-selected="true">Overview</a>`
4. Searching the markup for the ID `tab1` should return multiple IDs.
5. Check out this branch, clear cache.
6. Look at the Section Tabs again and notice the change in markup, where the ID is now unique: <a href="#section--84" id="#tab--84" role="tab" aria-selected="true">Overview</a>`
8. Search the markup again for the ID to ensure it only appears once as an ID value.


Refs: UNO-784