### PR TITLE
UNO-784 Accessibility improvements

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/cd/cd.css
+++ b/html/themes/custom/common_design_subtheme/components/cd/cd.css
@@ -24,7 +24,7 @@ a:focus {
 
 /* The nav h2 is visually-hidden. Setting its colour prevents contrast issues in
   accessibility scans */
-.cd-global-header nav h2 {
+.cd-global-header nav h2[id] {
   color: white;
 }
 

--- a/html/themes/custom/common_design_subtheme/components/cd/cd.css
+++ b/html/themes/custom/common_design_subtheme/components/cd/cd.css
@@ -22,6 +22,12 @@ a:focus {
   background: var(--brand-primary--dark);
 }
 
+/* The nav h2 is visually-hidden. Setting its colour prevents contrast issues in
+  accessibility scans */
+.cd-global-header nav h2 {
+  color: white;
+}
+
 .cd-global-header__inner {
   /* OCHA Services is removed so we adjust this */
   justify-content: flex-end;

--- a/html/themes/custom/common_design_subtheme/templates/blocks/block--system-branding-block.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/blocks/block--system-branding-block.html.twig
@@ -5,6 +5,6 @@
  */
 #}
 <a href="{{ path('<front>') }}" title="{{ 'Front page'|t }}" rel="home" class="cd-site-logo">
-  <img src="{{ site_logo }}" alt="{{ site_name }}" aria-hidden="true" width="186" height="60">
+  <img src="{{ site_logo }}" alt="{{ site_name }} logo" aria-hidden="true" width="186" height="60">
   <span class="visually-hidden">{{ site_name }}</span>
 </a>

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-footer.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-footer.html.twig
@@ -5,7 +5,7 @@
 <footer class="cd-footer" aria-label="{{ 'Site footer'|t }}">
   <div class="cd-container cd-footer__inner">
 
-  {% include '@common_design_subtheme/uno/subscribe.html.twig' %}
+  {% include '@common_design_subtheme/uno/subscribe--global.html.twig' %}
 
   {% block footer_menu %}
     {% include '@common_design/cd/cd-footer/cd-footer-menu.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/uno/subscribe--global.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/uno/subscribe--global.html.twig
@@ -24,8 +24,8 @@
           <input type="submit" value="{{ submit }}" name="subscribe" id="mc-embedded-subscribe--global" class="button cd-button cd-button--wide cd-button--bold cd-button--uppercase">
         </div>
         <div id="mce-responses--global" class="clear">
-          <div class="response" id="mce-error-response" style="display:none"></div>
-          <div class="response" id="mce-success-response" style="display:none"></div>
+          <div class="response" id="mce-error-response--global" style="display:none"></div>
+          <div class="response" id="mce-success-response--global" style="display:none"></div>
         </div>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px;" aria-hidden="true">

--- a/html/themes/custom/common_design_subtheme/templates/uno/subscribe--global.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/uno/subscribe--global.html.twig
@@ -1,0 +1,40 @@
+{{ attach_library('common_design_subtheme/uno-subscribe') }}
+
+{# Default to the global OCHA mailing list if values are not provided. #}
+{% set url = url ?? 'https://unocha.us2.list-manage.com/subscribe/post?u=83487eb1105d72ff2427e4bd7&id=fdc5b4f7e9' %}
+{% set title = title ?? 'Subscribe to UNOCHA mailing list'|t %}
+{% set submit = submit ?? 'Subscribe to our newsletter'|t %}
+{% set logo = logo ?? 'yes' %}
+
+<!-- Begin Mailchimp Signup Form -->
+<div class="uno-subscribe">
+  <div id="mc_embed_signup">
+    <form action="{{ url }}" method="post" id="mc-embedded-subscribe-form--global" name="mc-embedded-subscribe-form--global" class="validate" target="_blank" novalidate="">
+      {% if logo is not empty %}
+      <span class="uno-subscribe__logo">
+        <span class="visually-hidden">{{ 'United Nations Office for the Coordination of Humanitarian Affairs'|t }}</span>
+        {{ source('@common_design_subtheme/img/logos/ocha-lockup.svg')|replace({'<?xml version="1.0" encoding="UTF-8"?>':''})|raw }}
+      </span>
+      {% endif %}
+      <div id="mc_embed_signup_scroll--global">
+        <h2 class="visually-hidden">{% trans %}Subscribe{% endtrans %}</h2>
+        <div class="mc-field-group">
+          <label for="mce-EMAIL" class="visually-hidden">{{ title }}</label>
+          <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL--global" placeholder="{{ 'Enter your email address'|t }}">
+          <input type="submit" value="{{ submit }}" name="subscribe" id="mc-embedded-subscribe--global" class="button cd-button cd-button--wide cd-button--bold cd-button--uppercase">
+        </div>
+        <div id="mce-responses--global" class="clear">
+          <div class="response" id="mce-error-response" style="display:none"></div>
+          <div class="response" id="mce-success-response" style="display:none"></div>
+        </div>
+        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+        <div style="position: absolute; left: -5000px;" aria-hidden="true">
+          <label for="mce-HONEYPOT--global">{% trans %}Do not fill in this field{% endtrans %}</label>
+          {# @todo does name needs to be different for each form? #}
+          <input id="mce-HONEYPOT--global" type="text" name="83487eb1105d72ff2427e4bd7" tabindex="-1" value="">
+        </div>
+      </div>
+    </form>
+  </div>
+  <!--End mc_embed_signup-->
+</div>


### PR DESCRIPTION
See UNO-784

1. Prevent Duplicate IDs on Response and Region pages that have their own Mailchimp subscription form, by copying the subscribe twig partial and appending `--global` to IDs.
2. Add "logo" to logo alt text
3. Set nav h2 colour to avoid colour contrast issues in Check1st scans
