### PR TITLE
OPS-9689 Samples module for demo content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "drupal/pathauto": "^1.8",
         "drupal/redirect": "^1.8",
         "drupal/samlauth": "^3.8",
+        "drupal/samples": "^1.0@beta",
         "drupal/simple_menu_permissions": "^2.0",
         "drupal/social_auth_hid": "^3.2",
         "drupal/stable": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "389611e641c58c31a4ee7c6179a1b918",
+    "content-hash": "b3d28e43fcefe9abe5611c3280afb5ad",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4759,6 +4759,64 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/samlauth",
                 "issues": "http://drupal.org/project/samlauth"
+            }
+        },
+        {
+            "name": "drupal/samples",
+            "version": "1.0.0-beta3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/samples.git",
+                "reference": "1.0.0-beta3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/samples-1.0.0-beta3.zip",
+                "reference": "1.0.0-beta3",
+                "shasum": "c86136661817dcf52ac105f6157ce4ed6bd3e23a"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+                "drupal/coder": "^8.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-beta3",
+                    "datestamp": "1696235111",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "scripts": {
+                "phpcs": [
+                    "vendor/bin/phpcs --standard=\"Drupal,DrupalPractice\" -n --extensions=\"php,module,inc,install,test\" src tests samples.*"
+                ]
+            },
+            "license": [
+                "GPLv2"
+            ],
+            "authors": [
+                {
+                    "name": "Gabriel Sullice",
+                    "homepage": "https://www.drupal.org/user/2287430",
+                    "email": "gabriel@sullice.com"
+                },
+                {
+                    "name": "zrpnr",
+                    "homepage": "https://www.drupal.org/user/1448368"
+                }
+            ],
+            "description": "Create restricted content in production for demonstration and development purposes.",
+            "homepage": "https://www.drupal.org/project/samples",
+            "support": {
+                "source": "https://git.drupalcode.org/project/samples"
             }
         },
         {
@@ -15831,6 +15889,7 @@
         "drupal/linkit": 5,
         "drupal/menu_breadcrumb": 15,
         "drupal/openid_connect_windows_aad": 10,
+        "drupal/samples": 10,
         "drupal/viewsreference": 10
     },
     "prefer-stable": true,
@@ -15839,5 +15898,5 @@
         "php": ">=8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -71,6 +71,7 @@ module:
   redirect: 0
   responsive_image: 0
   samlauth: 0
+  samples: 0
   serialization: 0
   simple_menu_permissions: 0
   social_api: 0

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -31,6 +31,7 @@ dependencies:
     - paragraphs
     - path
     - redirect
+    - samples
     - simple_menu_permissions
     - system
     - taxonomy
@@ -45,6 +46,7 @@ permissions:
   - 'access administration pages'
   - 'access canto api'
   - 'access content overview'
+  - 'access content samples'
   - 'access media overview'
   - 'access taxonomy overview'
   - 'access toolbar'
@@ -55,6 +57,7 @@ permissions:
   - 'add new links to take-action menu'
   - 'add new links to what-we-do menu'
   - 'add new links to where-we-work menu'
+  - 'administer content samples'
   - 'administer menu'
   - 'administer nodes'
   - 'administer redirects'


### PR DESCRIPTION
feat: samples module for demo content, install, enable, set perms

See OPS-9689

Refs: OPS-9689 UNO-762

### To test:

1. Check out the branch, run composer install, and import config to install and enable the module. You might need to rebuild permissions `https://unocha-local.test//admin/reports/status/rebuild`
2. Visit a sample content page Eg. https://unocha-local.test/demo - Notice it is unpublished.
3. Edit it. Check the "Use as a sample" checkbox and also Publish
![Selection_360](https://github.com/UN-OCHA/unocha-site/assets/1835923/adf4d98a-4666-491d-9076-606a90dcdff0)
4. Visit the page in a private browser or logged out and you should get an Access denied message.