### PR TITLE
[OPS-9693] Deployment fix

### DIFF
--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.deploy.php
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.deploy.php
@@ -6,11 +6,11 @@
  */
 
 /**
- * Implements hook_post_update_NAME().
+ * Implements hook_deploy_NAME().
  *
  * Change the view mode of the stories paragraphs.
  */
-function unocha_paragraphs_post_update_stories_paragraph_view_mode(&$sandbox) {
+function unocha_paragraphs_deploy_stories_paragraph_view_mode(&$sandbox) {
   $paragraphs = \Drupal::entityTypeManager()
     ->getStorage('paragraph')
     ->loadByProperties([


### PR DESCRIPTION
Refs: OPS-9693

Use hook_deploy_NAME instead of hook_post_update_NAME since we use drush deploy for deployments otherwise the config import is done too late and the paragraph view mode field cannot be initialized.

See: https://www.drush.org/12.x/deploycommand/

### Tests.

1. Checkout the branch 
2. Import a DB dump (`drush sqlc < dump.sql`)
3. Clear the cache (`drush cr`)
4. Deploy (`drush deploy`)
5. There should be something like:
```
 ------------------- --------------- ------------------------------------------ 
  Module              Hook            Description                               
 ------------------- --------------- ------------------------------------------ 
  unocha_paragraphs   stories_parag   Implements hook_deploy_NAME().   Change   
                      raph_view_mod   the view mode of the stories paragraphs.  
                      e                                                         
 ------------------- --------------- ------------------------------------------ 


 Do you wish to run the specified pending deploy hooks? (yes/no) [yes]:
 > >  [info] Executing: /srv/www/vendor/bin/drush deploy:batch-process 113 --uri=https://unocha-local.test --root=/srv/www/html
> >  [notice] Deploy hook started: unocha_paragraphs_deploy_stories_paragraph_view_mode
> >  [notice] Updated view mode of 43 stories paragraphs
```
6. Run `drush sql-query "SELECT * FROM paragraph__paragraph_view_mode WHERE bundle = 'stories'"` to confirm the paragraph view mode for stories is set properly.