### PR TITLE
OPS-9695 Fix site name display in Google search results

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -257,7 +257,7 @@ function common_design_subtheme_page_attachments_alter(array &$attachments) {
         '#value' => '{
             "@context" : "https://schema.org",
             "@type" : "WebSite",
-            "name" : "UN OCHA",
+            "name" : "UNOCHA",
             "url" : "https://www.unocha.org"
           }',
         '#attributes' => ['type' => 'application/ld+json'],

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -240,3 +240,29 @@ function common_design_subtheme_preprocess_html(&$vars) {
     'manifest',
   ];
 }
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function common_design_subtheme_page_attachments_alter(array &$attachments) {
+  $is_front = \Drupal::service('path.matcher')->isFrontPage();
+
+  // Required on homepage only.
+  // https://developers.google.com/search/docs/appearance/site-names#json-ld.
+  if ($is_front) {
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'script',
+        '#value' =>'{
+            "@context" : "https://schema.org",
+            "@type" : "WebSite",
+            "name" : "UN OCHA",
+            "url" : "https://www.unocha.org"
+          }',
+        '#attributes' => ['type' => 'application/ld+json'],
+      ],
+      'json_ld',
+    ];
+  }
+}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -254,7 +254,7 @@ function common_design_subtheme_page_attachments_alter(array &$attachments) {
       [
         '#type' => 'html_tag',
         '#tag' => 'script',
-        '#value' =>'{
+        '#value' => '{
             "@context" : "https://schema.org",
             "@type" : "WebSite",
             "name" : "UN OCHA",


### PR DESCRIPTION
fix: json linked data script to set WebSite name

See OPS-9695

### To test:
1. Check out branch, clear cache
2. Visit homepage https://unocha-local.test/ and confirm the following script appears in the`<head>`:
3. `<script type="application/ld+json">{"@context" : "https://schema.org", "@type" : "WebSite", "name" : "UN OCHA", "url" : "https://www.unocha.org"}</script>`
4. Visit an internal page and confirm the script does not load on internal pages.

