### PR TITLE
[UNO-785] Fix stories caching

### DIFF
--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -125,8 +125,12 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       $keys = Element::children($variables['content']['stories']);
       $first = reset($keys);
       if ($first !== FALSE && isset($variables['content']['stories'][$first]['#node'])) {
+        // Update the view mode, theme and cache key.
         $variables['content']['stories'][$first]['#view_mode'] = 'featured';
         $variables['content']['stories'][$first]['#theme'] = 'node__story__card__featured';
+        $variables['content']['stories'][$first]['#cache']['keys'] = array_map(function ($key) {
+          return $key === 'card' ? 'featured' : $key;
+        }, $variables['content']['stories'][$first]['#cache']['keys'] ?? []);
       }
     }
   }


### PR DESCRIPTION
Refs: UNO-785

Ensure we use a different cache key based on the story view mode.

## Tests

**Before checking out**

1. Enable caching for your local (edit the `./local/shared/settings/settings.local.php`, replace `$no_cache = TRUE;` with `$no_cache = FALSE;`)
2. Import dump (`unocha-prod-2023-10-05.2048.sql.gz`)
3. Clear the cache
4. Visit `/latin-america-and-caribbean` (this will cache the `Today's top news: Sudan, Ukraine, CERF allocation, Syria` rendered as `featured` (large card))
5. Visit the `/asia-and-pacific`, the same story will still be rendered as featured while it should not.
6. Clear the cache
7. Do the opposite and visit `/asia-and-pacific` first, the story should be rendered as a small card
8. Visit  `/latin-america-and-caribbean`, should also be rendered as a small card instead of the large card

**After checking out the branch**

1. Clear the cache
2. Repeat (4) and (5) from above. This time the story should appear as a small card on the `/asia-and-pacific`.
3. Clear the cache
4. Repeat (7) and (8) from above. This time the story should appear as a large card on the `/latin-america-and-caribbean`.

Revert (1) from above to disable caching after testing.