### PR TITLE
UNO-784 Colour contrast for tags in RW river when on grey background

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-response-map/uno-response-map.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-response-map/uno-response-map.css
@@ -11,7 +11,7 @@
 .js .unocha-response-map[data-map-enabled] .unocha-response-map__title {
   margin-bottom: 0;
   padding: 4px 8px 4px 8px;
-  background: var(--brand-highlight-contrast);
+  /* background: var(--brand-highlight-contrast); */
   font-size: 18px;
 }
 .js .unocha-response-map[data-map-enabled] .unocha-response-map__header {

--- a/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
@@ -153,6 +153,11 @@
   color: var(--brand-highlight);
 }
 
+.layout--twocol-sidebar .paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-river-article .uno-tag,
+.layout--twocol-sidebar .paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river-article .uno-tag {
+  color: var(--brand-highlight-contrast);
+}
+
 .paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-river-article .rw-river-article__footer,
 .paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-river-article .rw-river-article__footer {
   display: flex;

--- a/html/themes/custom/common_design_subtheme/css/brand.css
+++ b/html/themes/custom/common_design_subtheme/css/brand.css
@@ -15,9 +15,8 @@
   /* Dark blue is two colour ramps darker than brand blue */
   --brand-primary--dark: #144372;
   --brand-highlight: #E56A54;
-  /* https: //polypane.app/color-contrast/#fg=%23fff&bg=%23E56A54&level=aa&format=hex&algo=WCAG2&filter=none */
-  /* --brand-highlight: #d64200; */
-  --brand-highlight-contrast: #000;
+  /* https://polypane.app/color-contrast/#fg=%23E56A54&bg=%23f5f5f5&level=aa&format=hex&algo=WCAG2&filter=none */
+  --brand-highlight-contrast: #cc3e00;
   --brand-grey: #f5f5f5;
   --brand-grey--border: #ccc;
   --brand-grey--text: #767676;


### PR DESCRIPTION
![Selection_006](https://github.com/UN-OCHA/unocha-site/assets/1835923/dbc7e299-ed73-4908-8e34-18086b0e5dfe)


I searched the files and markup for `.unocha-response-map__title` and I get the impression this selector is not in use, so I think the declaration I commented out will not have any negative repercussions. It was the only place `--brand-highlight-contrast: #000;` was being used.