### PR TITLE
UNO-789 Content Editor UI improvements

### DIFF
--- a/html/themes/custom/common_design_claro/css/styles.css
+++ b/html/themes/custom/common_design_claro/css/styles.css
@@ -296,3 +296,22 @@ form .paragraph--view-mode--preview.paragraph--type--media-centre article.node--
 form .paragraph--view-mode--preview.paragraph--type--media-centre .uno-media-centre__view_all {
   display: none;
 }
+
+/* Samples module */
+/* Styles from common_design/components/cd-alert/cd-alert.css */
+.field--name-samples-status {
+  --cd-orange: #db7b18;
+  --cd-orange--light: #fae6d1;
+  --cd-alert-color: var(--cd-orange);
+  --cd-alert-color-bg: var(--cd-orange--light);
+  margin: 1rem 0 2rem;
+  padding: 1rem;
+  color: var(--cd-grey--dark);
+  border: 1px solid var(--cd-alert-color);
+  border-radius: 0.25rem;
+  background-color: var(--cd-alert-color-bg);
+  box-shadow: -8px 0 0 var(--cd-alert-color);
+}
+.layout-node-form .field--name-samples-status {
+  margin-top: 3rem;
+}

--- a/html/themes/custom/common_design_claro/css/styles.css
+++ b/html/themes/custom/common_design_claro/css/styles.css
@@ -315,3 +315,9 @@ form .paragraph--view-mode--preview.paragraph--type--media-centre .uno-media-cen
 .layout-node-form .field--name-samples-status {
   margin-top: 3rem;
 }
+
+/* Increase the height of the Canto modal */
+.canto-library {
+  height: auto;
+  min-height: 75vh;
+}


### PR DESCRIPTION
See UNO-789 for screenshots

1. Increase height of modal for Canto
2. Style the "Sample content" checkbox from Samples module - see also https://github.com/UN-OCHA/unocha-site/pull/384