### PR TITLE
[UNO-790] Return nodes associated with menu links in the menu links order

### DIFF
--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -339,14 +339,21 @@ function unocha_paragraphs_get_nodes_from_menu_links(array $menu_links) {
       !empty($menu_link->getRouteParameters()['node'])
     ) {
       $node_id = $menu_link->getRouteParameters()['node'];
-      $node_ids[$node_id] = $node_id;
+      $node_ids[$node_id] = $menu_link->getWeight();
     }
   }
   if (!empty($node_ids)) {
-    return \Drupal::entityTypeManager()
+    $nodes = \Drupal::entityTypeManager()
       ->getStorage('node')
-      ->loadMultiple($node_ids);
+      ->loadMultiple(array_keys($node_ids));
+
+    // Preserve the order of the menu links.
+    uasort($nodes, function ($a, $b) use ($node_ids) {
+      return $node_ids[$a->id()] <=> $node_ids[$b->id()];
+    });
+    return $nodes;
   }
+
   return [];
 }
 


### PR DESCRIPTION
Refs: UNO-790

This ensures that the nodes associated with menu links are returned in the order of the menu links.

## Tests.

**Before checking out**

1. Go to `/admin/structure/menu/manage/main`
2. Change the order of the menu items under `Somalia`, for example by putting the node with the highest ID first (ex: `contacts`)
3. Check the `Resources` tab in the `/somalia` page and confirm the order doesn't reflect the order of the menu items

**After checking out**

1. Clear the cache
2. Repeat (2) and (3) above, this time the order of the resources should match the order in the menu.