### PR TITLE
[UNO-785] Stories paragraph view mode in forms

### DIFF
--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -120,8 +120,17 @@ function unocha_paragraphs_preprocess_paragraph__stories(array &$variables) {
       ->getViewBuilder('node')
       ->viewMultiple($stories, 'card');
 
+    $view_mode = $variables['view_mode'] ?? '';
+    $cards_with_featured = $view_mode === 'cards_with_featured';
+
+    // Special case for the forms where the paragraph is rendered with the
+    // preview view mode.
+    if ($view_mode === 'preview') {
+      $cards_with_featured = $paragraph->paragraph_view_mode?->value === 'cards_with_featured';
+    }
+
     // Change the view mode of the story based on the paragraph view mode.
-    if (isset($variables['view_mode']) && $variables['view_mode'] === 'cards_with_featured') {
+    if ($cards_with_featured) {
       $keys = Element::children($variables['content']['stories']);
       $first = reset($keys);
       if ($first !== FALSE && isset($variables['content']['stories'][$first]['#node'])) {


### PR DESCRIPTION
Refs: UNO-785

In forms, paragraphs are rendered with the `preview` view mode. This alters the logic for the stories paragraphs to check the `paragraph_view_mode` field to determine how to render the first node when the paragraph view mode is `preview`.

Note: this is a PR against the branch of https://github.com/UN-OCHA/unocha-site/pull/367.

## Tests.

1. Checkout the branch, clear the cache.
2. Repeat the `tests` from https://github.com/UN-OCHA/unocha-site/pull/365 to confirm that there are no regressions
3. Edit a for example, **in the form** check that the first story uses the `featured` view mode when the stories paragraph view mode is `cards with featured` and uses the `card` view mode when the paragraph view mode is `cards`.