### PR TITLE
UNO-792 Prevent empty anchors on Cards

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/content/node--basic--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--basic--card.html.twig
@@ -70,9 +70,10 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    {% if content.field_basic_image|render %}
+    {% set rendered_image = content.field_basic_image|render %}
+    {% if rendered_image|striptags('<img>')|trim is not empty %}
       <div class="uno-card__image">
-        <a href="{{ url }}">{{ content.field_basic_image }}</a>
+        <a href="{{ url }}">{{ rendered_image }}</a>
       </div>
     {% endif %}
   {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--basic--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--basic--card.html.twig
@@ -70,7 +70,11 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    <a href="{{ url }}">{{ content.field_basic_image }}</a>
+    {% if content.field_basic_image|render %}
+      <div class="uno-card__image">
+        <a href="{{ url }}">{{ content.field_basic_image }}</a>
+      </div>
+    {% endif %}
   {% endblock %}
 
   {% block card_title %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--card.html.twig
@@ -87,11 +87,11 @@
 
 <article{{ attributes.addClass(classes) }}>
 
-  <div class="uno-card__image">
   {% block card_image %}
-    <a href="{{ url }}">{{ content.field_image }}</a>
+    <div class="uno-card__image">
+      <a href="{{ url }}">{{ content.field_image }}</a>
+    </div>
   {% endblock %}
-  </div>
 
   <div class="uno-card__content cd-card__container">
     {% block card_title %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--event--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--event--card.html.twig
@@ -70,7 +70,11 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    <a href="{{ url }}">{{ content.field_event_image }}</a>
+    {% if content.field_event_image|render %}
+      <div class="uno-card__image">
+        <a href="{{ url }}">{{ content.field_event_image }}</a>
+      </div>
+    {% endif %}
   {% endblock %}
 
   {% block card_content %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--event--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--event--card.html.twig
@@ -70,9 +70,10 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    {% if content.field_event_image|render %}
+    {% set rendered_image = content.field_event_image|render %}
+    {% if rendered_image|striptags('<img>')|trim is not empty %}
       <div class="uno-card__image">
-        <a href="{{ url }}">{{ content.field_event_image }}</a>
+        <a href="{{ url }}">{{ rendered_image }}</a>
       </div>
     {% endif %}
   {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--media-collection--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--media-collection--card.html.twig
@@ -70,13 +70,19 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-  {{ attach_library('common_design_subtheme/uno-media') }}
+    {{ attach_library('common_design_subtheme/uno-media') }}
 
     {% if content.field_media_video|render %}
       {{ content.field_media_video }}
     {% else %}
+
       {# Display first image #}
-      {{ content.field_media_image.0 }}
+      {% if content.field_media_image|render %}
+        <div class="uno-card__image">
+          <a href="{{ url }}"> {{ content.field_media_image.0 }}</a>
+        </div>
+      {% endif %}
+
     {% endif %}
   {% endblock %}
 

--- a/html/themes/custom/common_design_subtheme/templates/content/node--media-collection--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--media-collection--card.html.twig
@@ -72,14 +72,16 @@
   {% block card_image %}
     {{ attach_library('common_design_subtheme/uno-media') }}
 
-    {% if content.field_media_video|render %}
-      {{ content.field_media_video }}
+    {% set rendered_video = content.field_media_video|render %}
+    {% if rendered_video|striptags('<iframe>')|trim is not empty %}
+      {{ rendered_video }}
     {% else %}
 
       {# Display first image #}
-      {% if content.field_media_image|render %}
+      {% set rendered_image = content.field_media_image.0|render %}
+      {% if rendered_image|striptags('<img>')|trim is not empty %}
         <div class="uno-card__image">
-          <a href="{{ url }}"> {{ content.field_media_image.0 }}</a>
+          <a href="{{ url }}"> {{ rendered_image }}</a>
         </div>
       {% endif %}
 

--- a/html/themes/custom/common_design_subtheme/templates/content/node--region--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--region--card.html.twig
@@ -70,7 +70,11 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    <a href="{{ url }}">{{ content.field_region_image }}</a>
+    {% if content.field_region_image|render %}
+      <div class="uno-card__image">
+        <a href="{{ url }}">{{ content.field_region_image }}</a>
+      </div>
+    {% endif %}
   {% endblock %}
 
   {% block card_title %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--region--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--region--card.html.twig
@@ -70,9 +70,10 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    {% if content.field_region_image|render %}
+    {% set rendered_image = content.field_region_image|render %}
+    {% if rendered_image|striptags('<img>')|trim is not empty %}
       <div class="uno-card__image">
-        <a href="{{ url }}">{{ content.field_region_image }}</a>
+        <a href="{{ url }}">{{ rendered_image }}</a>
       </div>
     {% endif %}
   {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--response--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--response--card.html.twig
@@ -70,7 +70,11 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    <a href="{{ url }}">{{ content.field_response_image }}</a>
+    {% if content.field_response_image|render %}
+      <div class="uno-card__image">
+        <a href="{{ url }}">{{ content.field_response_image }}</a>
+      </div>
+    {% endif %}
   {% endblock %}
 
   {% block card_title %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--response--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--response--card.html.twig
@@ -70,9 +70,10 @@
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
   {% block card_image %}
-    {% if content.field_response_image|render %}
+    {% set rendered_image = content.field_response_image|render %}
+    {% if rendered_image|striptags('<img>')|trim is not empty %}
       <div class="uno-card__image">
-        <a href="{{ url }}">{{ content.field_response_image }}</a>
+        <a href="{{ url }}">{{ rendered_image }}</a>
       </div>
     {% endif %}
   {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--story--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--story--card.html.twig
@@ -75,9 +75,10 @@
 %}
 
   {% block card_image %}
-    {% if content.field_story_image|render %}
+    {% set rendered_image = content.field_story_image|render %}
+    {% if rendered_image|striptags('<img>')|trim is not empty %}
       <div class="uno-card__image">
-        <a href="{{ url }}">{{ content.field_story_image }}</a>
+        <a href="{{ url }}">{{ rendered_image }}</a>
       </div>
     {% endif %}
   {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/content/node--story--card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--story--card.html.twig
@@ -73,8 +73,13 @@
 
 {% embed '@common_design_subtheme/content/node--card.html.twig'
 %}
+
   {% block card_image %}
-    <a href="{{ url }}">{{ content.field_story_image }}</a>
+    {% if content.field_story_image|render %}
+      <div class="uno-card__image">
+        <a href="{{ url }}">{{ content.field_story_image }}</a>
+      </div>
+    {% endif %}
   {% endblock %}
 
   {% block card_title %}


### PR DESCRIPTION
See screenshot on UNO-792

Adjust Card template override so the card image div and anchor print only when the image is present.

### To test
1. Visit the Prod site https://www.unocha.org At the moment, there is an item present that does not have an image.
2. Notice the markup includes `.uno-card__image` div and an empty anchor within it.
3. Check out branch, clear cache.
4. Visit https://unocha-local.test/
5. Select a Story node that displays in the Latest News and Stories block and remove its image. Save the node and refresh the homepage.
6. Notice the markup not longer includes the `.uno-card__image` div or the anchor
7. Notice the other stories with image display as usual and the image is still linked.

All Content Types with Card template overrides have been adjusted. I've used the content examples found on these pages https://www.unocha.org/demo/content-lists, https://www.unocha.org/demo/page-components, https://www.unocha.org/demo/layouts or we can check them on the dev server.