### PR TITLE
UNO-800 Sample content should be managed by admin role only

### DIFF
--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -57,7 +57,6 @@ permissions:
   - 'add new links to take-action menu'
   - 'add new links to what-we-do menu'
   - 'add new links to where-we-work menu'
-  - 'administer content samples'
   - 'administer menu'
   - 'administer nodes'
   - 'administer redirects'


### PR DESCRIPTION
Reduce Editor role access to Sample content. They can view and edit, but not manage which means Editors never have to see the checkbox.
This is complimentary to the styling here https://github.com/UN-OCHA/unocha-site/pull/369

Refs: UNO-800