### PR TITLE
[UNO-802] Better UX to select featured stories

### DIFF
--- a/PATCHES/entity_browser-php82-3350169.patch
+++ b/PATCHES/entity_browser-php82-3350169.patch
@@ -1,0 +1,26 @@
+From 236f7a71c2786ed7e4dd829f36153f69ef95a68a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juhani=20V=C3=A4=C3=A4t=C3=A4j=C3=A4?=
+ <juhani@koodijarivi.fi>
+Date: Fri, 24 Mar 2023 13:42:08 +0200
+Subject: [PATCH 1/5] Fix typo with $widget_ids
+
+---
+ src/WidgetSelectorBase.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/WidgetSelectorBase.php b/src/WidgetSelectorBase.php
+index b71687d..b5d44ad 100644
+--- a/src/WidgetSelectorBase.php
++++ b/src/WidgetSelectorBase.php
+@@ -25,7 +25,7 @@ abstract class WidgetSelectorBase extends PluginBase implements WidgetSelectorIn
+    *
+    * @var array
+    */
+-  protected $widgets_ids;
++  protected $widget_ids;
+ 
+   /**
+    * ID of the default widget.
+-- 
+GitLab
+

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "drupal/csp": "^1.17",
         "drupal/datetime_range_timezone": "^1.0@alpha",
         "drupal/double_field": "^4.1",
+        "drupal/entity_browser": "^2.9",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/environment_indicator": "^4.0",
         "drupal/geofield": "^1.53",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3d28e43fcefe9abe5611c3280afb5ad",
+    "content-hash": "a3c16d2f4107a4af3d4bd97ee698ba7f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3131,6 +3131,96 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/double_field",
                 "issues": "https://www.drupal.org/project/issues/double_field"
+            }
+        },
+        {
+            "name": "drupal/entity_browser",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_browser.git",
+                "reference": "8.x-2.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.9.zip",
+                "reference": "8.x-2.9",
+                "shasum": "251afad80cde9fa547501a8d9de5d94b9f5bacff"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/embed": "~1.0",
+                "drupal/entity_embed": "1.x-dev",
+                "drupal/entity_reference_revisions": "1.x-dev",
+                "drupal/entityqueue": "1.x-dev",
+                "drupal/inline_entity_form": "1.x-dev",
+                "drupal/paragraphs": "1.x-dev",
+                "drupal/token": "1.x-dev"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.9",
+                    "datestamp": "1674070933",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Janez Urevc",
+                    "homepage": "https://github.com/slashrsm",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Primoz Hmeljak",
+                    "homepage": "https://github.com/primsi",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "See other contributors",
+                    "homepage": "https://www.drupal.org/node/1943336/committers",
+                    "role": "contributor"
+                },
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "marcingy",
+                    "homepage": "https://www.drupal.org/user/77320"
+                },
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                },
+                {
+                    "name": "Primsi",
+                    "homepage": "https://www.drupal.org/user/282629"
+                },
+                {
+                    "name": "samuel.mortenson",
+                    "homepage": "https://www.drupal.org/user/2582268"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Entity browsing and selecting component.",
+            "homepage": "http://drupal.org/project/entity_browser",
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_browser",
+                "issues": "https://www.drupal.org/project/issues/entity_browser",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {
@@ -15908,5 +15998,5 @@
         "php": ">=8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -10,6 +10,9 @@
     "drupal/datetime_range_timezone": {
       "Views integration": "PATCHES/datetime_range_timezone-views-integration.patch"
     },
+    "drupal/entity_browser": {
+      "https://www.drupal.org/project/drupal/issues/3350169": "PATCHES/entity_browser-php82-3350169.patch"
+    },
     "drupal/imageapi_optimize_webp": {
       "Fix derivatives for webp source images": "PATCHES/imageapi_optimize_webp-webp-source-image.patch",
       "Support imagemagick toolkit": "PATCHES/imageapi_optimize_webp-imagemagick-toolkit.patch"

--- a/config/core.entity_form_display.paragraph.stories.default.yml
+++ b/config/core.entity_form_display.paragraph.stories.default.yml
@@ -30,12 +30,13 @@ content:
     region: content
     settings:
       entity_browser: stories
-      field_widget_display: label
+      field_widget_display: rendered_entity
       field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: true
-      field_widget_display_settings: {  }
+      field_widget_display_settings:
+        view_mode: card_preview
       selection_mode: selection_prepend
     third_party_settings: {  }
   field_title:

--- a/config/core.entity_form_display.paragraph.stories.default.yml
+++ b/config/core.entity_form_display.paragraph.stories.default.yml
@@ -34,7 +34,7 @@ content:
       field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
-      open: false
+      open: true
       field_widget_display_settings: {  }
       selection_mode: selection_prepend
     third_party_settings: {  }

--- a/config/core.entity_form_display.paragraph.stories.default.yml
+++ b/config/core.entity_form_display.paragraph.stories.default.yml
@@ -3,12 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.stories
     - field.field.paragraph.stories.field_limit
     - field.field.paragraph.stories.field_node
     - field.field.paragraph.stories.field_title
     - field.field.paragraph.stories.paragraph_view_mode
     - paragraphs.paragraphs_type.stories
   module:
+    - entity_browser
     - paragraph_view_mode
 id: paragraph.stories.default
 targetEntityType: paragraph
@@ -17,24 +19,28 @@ mode: default
 content:
   field_limit:
     type: number
-    weight: 1
+    weight: 2
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_node:
-    type: entity_reference_autocomplete
-    weight: 2
+    type: entity_browser_entity_reference
+    weight: 3
     region: content
     settings:
-      match_operator: STARTS_WITH
-      match_limit: 10
-      size: 60
-      placeholder: 'Enter story title...'
+      entity_browser: stories
+      field_widget_display: label
+      field_widget_edit: false
+      field_widget_remove: true
+      field_widget_replace: false
+      open: false
+      field_widget_display_settings: {  }
+      selection_mode: selection_prepend
     third_party_settings: {  }
   field_title:
     type: string_textfield
-    weight: 0
+    weight: 1
     region: content
     settings:
       size: 60
@@ -42,7 +48,7 @@ content:
     third_party_settings: {  }
   paragraph_view_mode:
     type: paragraph_view_mode
-    weight: -100
+    weight: 0
     region: content
     settings:
       view_modes:
@@ -54,13 +60,13 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 4
+    weight: 5
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_view_display.node.story.card_preview.yml
+++ b/config/core.entity_view_display.node.story.card_preview.yml
@@ -1,0 +1,53 @@
+uuid: d60d50f3-3d9b-45b5-8109-6b0455c3b128
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.card_preview
+    - field.field.node.story.body
+    - field.field.node.story.field_country
+    - field.field.node.story.field_custom_content
+    - field.field.node.story.field_regions
+    - field.field.node.story.field_responses
+    - field.field.node.story.field_story_image
+    - field.field.node.story.field_story_type
+    - field.field.node.story.field_theme
+    - node.type.story
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.story.card_preview
+targetEntityType: node
+bundle: story
+mode: card_preview
+content:
+  field_story_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_story_type:
+    type: entity_reference_label
+    label: inline
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  body: true
+  field_country: true
+  field_custom_content: true
+  field_regions: true
+  field_responses: true
+  field_theme: true
+  langcode: true
+  links: true

--- a/config/core.entity_view_mode.node.card_preview.yml
+++ b/config/core.entity_view_mode.node.card_preview.yml
@@ -1,0 +1,10 @@
+uuid: daa27860-b8c2-487a-ac0a-708551835f5f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.card_preview
+label: 'Card preview'
+targetEntityType: node
+cache: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -22,6 +22,7 @@ module:
   double_field: 0
   dynamic_page_cache: 0
   editor: 0
+  entity_browser: 0
   entity_reference_revisions: 0
   entity_usage: 0
   environment_indicator: 0

--- a/config/entity_browser.browser.stories.yml
+++ b/config/entity_browser.browser.stories.yml
@@ -1,0 +1,31 @@
+uuid: 29c5452a-d237-44f2-9ac9-e1581279caa3
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.entity_browser_stories
+  module:
+    - views
+name: stories
+label: Stories
+display: modal
+display_configuration:
+  width: ''
+  height: ''
+  link_text: 'Select stories'
+  auto_open: false
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: single
+widget_selector_configuration: {  }
+widgets:
+  fdf9991a-16e7-4e07-9c99-66a8c1b7930c:
+    id: view
+    uuid: fdf9991a-16e7-4e07-9c99-66a8c1b7930c
+    label: Stories
+    weight: 1
+    settings:
+      submit_text: 'Select stories'
+      auto_select: false
+      view: entity_browser_stories
+      view_display: entity_browser_stories

--- a/config/samlauth.authentication.yml
+++ b/config/samlauth.authentication.yml
@@ -30,8 +30,8 @@ map_users: false
 map_users_name: false
 map_users_mail: true
 map_users_roles:
-  administrator: 'administrator'
-  editor: 'editor'
+  administrator: administrator
+  editor: editor
 create_users: true
 sync_name: true
 sync_mail: true

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -24,6 +24,7 @@ dependencies:
   module:
     - content_moderation
     - content_translation
+    - entity_browser
     - filter
     - media
     - menu_link_content
@@ -48,6 +49,7 @@ permissions:
   - 'access content overview'
   - 'access content samples'
   - 'access media overview'
+  - 'access stories entity browser pages'
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'add new links to events menu'

--- a/config/views.view.entity_browser_stories.yml
+++ b/config/views.view.entity_browser_stories.yml
@@ -1,0 +1,600 @@
+uuid: 2b9baeed-4e04-4274-ac00-8a82511ad298
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.story
+  module:
+    - entity_browser
+    - node
+    - user
+id: entity_browser_stories
+label: 'Entity browser - Stories'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        entity_browser_select:
+          id: entity_browser_select
+          table: node
+          field: entity_browser_select
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_browser_select
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          use_field_cardinality: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: view
+          output_url_as_text: true
+          absolute: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="{{ view_node }}" target="_blank">{{ title__value }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: _blank
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: custom
+            custom_date_format: 'Y-m-d H:i'
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: node_type
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: entity_browser_widget_context
+          default_argument_options:
+            context_key: target_bundles
+            fallback: all
+            multiple: or
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            story: story
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            entity_browser_select: entity_browser_select
+            view_node: view_node
+            title: title
+            uid: uid
+            created: created
+          default: created
+          info:
+            entity_browser_select:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_node:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  entity_browser_stories:
+    id: entity_browser_stories
+    display_title: 'Entity browser'
+    display_plugin: entity_browser
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/html/themes/custom/common_design_claro/css/styles.css
+++ b/html/themes/custom/common_design_claro/css/styles.css
@@ -117,7 +117,7 @@ blockquote::before {
 /**
  * Style adjustments for the preview of the paragraphs.
  */
-
+form .entities-list,
 form .paragraph--view-mode--preview {
   /* Adjust typography from @claro/css/base/variables.css to be smaller. */
   --font-size-xl: 1.4rem; /* ~36px */
@@ -140,7 +140,7 @@ form .paragraph--view-mode--preview.unocha-response-map[data-map-enabled] .unoch
   padding: 0;
 }
 
-/* Stories. */
+/* Stories list. */
 form .paragraph--view-mode--preview.paragraph--type--news-and-stories .viewsreference--view-title {
   font-size: var(--font-size-h2);
   font-weight: bold;;
@@ -176,31 +176,39 @@ form .paragraph--view-mode--preview.paragraph--type--news-and-stories .uno-stori
   flex-wrap: wrap;
   gap: var(--uno-card-list-gap-size);
 }
+/* Latest news and stories. */
 form .paragraph--view-mode--preview.paragraph--type--stories .uno-stories__header {
   margin-bottom: 1rem;
 }
 form .paragraph--view-mode--preview.paragraph--type--stories .uno-stories__view_all {
   display: none;
 }
+form .entities-list article.node--type-story.node--view-mode-card-preview .node__content,
 form .paragraph--view-mode--preview.paragraph--type--stories article.node--type-story.node--view-mode-card .node__content {
   min-width: 220px;
 }
+form .entities-list article.node--type-story.node--view-mode-card-preview .uno-card__image,
 form .paragraph--view-mode--preview.paragraph--type--stories article.node--type-story.node--view-mode-featured .uno-card__image {
   flex: 0 1 35%;
 }
+form .entities-list article.node--type-story.node--view-mode-card-preview .cd-card__container,
 form .paragraph--view-mode--preview.paragraph--type--stories article.node--type-story.node--view-mode-featured .cd-card__container {
   display: block;
+  padding-inline-start: 0;
 }
+form .entities-list article.node--type-story.node--view-mode-card-preview .cd-card__container,
 form .paragraph--view-mode--preview.paragraph--type--stories article.node--type-story .cd-card__container {
   padding: 0;
 }
+form .entities-list article.node--type-story.node--view-mode-card-preview .cd-card__footer,
 form .paragraph--view-mode--preview.paragraph--type--news-and-stories article.node--type-story .cd-card__footer,
 form .paragraph--view-mode--preview.paragraph--type--stories article.node--type-story .cd-card__footer {
   padding: 0;
   font-size: var(--font-size-h5);
 }
+form .entities-list article.node--type-story.node--view-mode-card-preview .cd-read-more,
 form .paragraph--view-mode--preview.paragraph--type--news-and-stories article.node--type-story .cd-read-more,
-form .paragraph--view-mode--preview.paragraph--type--stories article.node--type-story .cd-read-more  {
+form .paragraph--view-mode--preview.paragraph--type--stories article.node--type-story .cd-read-more {
   display: none;
 }
 
@@ -297,7 +305,7 @@ form .paragraph--view-mode--preview.paragraph--type--media-centre .uno-media-cen
   display: none;
 }
 
-/* Samples module */
+/* Samples module. */
 /* Styles from common_design/components/cd-alert/cd-alert.css */
 .field--name-samples-status {
   --cd-orange: #db7b18;
@@ -316,8 +324,24 @@ form .paragraph--view-mode--preview.paragraph--type--media-centre .uno-media-cen
   margin-top: 3rem;
 }
 
-/* Increase the height of the Canto modal */
+/* Increase the height of the Canto modal. */
 .canto-library {
   height: auto;
   min-height: 75vh;
+}
+
+/* Entity browser form for Latest news and stories. */
+form .entities-list {
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--uno-card-list-gap-size);
+}
+
+form .entities-list .item-container.rendered-entity {
+  flex: 0 1 320px;
+  margin: 0;
+}
+
+form .entities-list .item-container.rendered-entity .button {
+  margin: 2rem 0 0;
 }

--- a/html/themes/custom/common_design_claro/templates/content/node--story--card-preview.html.twig
+++ b/html/themes/custom/common_design_claro/templates/content/node--story--card-preview.html.twig
@@ -1,0 +1,128 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{% embed '@common_design_subtheme/content/node--card.html.twig' %}
+
+  {% block card_image %}
+    {% set rendered_image = content.field_story_image|render %}
+    {% if rendered_image|striptags('<img>')|trim is not empty %}
+      <div class="uno-card__image">
+        {{ rendered_image }}
+      </div>
+    {% endif %}
+  {% endblock %}
+
+  {% block card_title %}
+    {% if attributes.hasClass('featured') %}
+      <span class="uno-featured uno-tag">{% trans %}Featured{% endtrans %}</span>
+    {% else %}
+      {% if content.field_story_type|render %}
+        <span class="uno-story-type uno-tag">{{ content.field_story_type[0]["#plain_text"] }}</span>
+      {% endif %}
+    {% endif %}
+    <h3 class="uno-card__title cd-card__title">
+      <a href="{{ url }}" target="_blank">{{ label }}</a>
+    </h3>
+  {% endblock %}
+
+  {% block card_content %}
+    {% block story_content %}
+      {{ content|without('field_story_image', 'body', 'field_story_type') }}
+    {% endblock %}
+
+    <div class="cd-card__footer">
+      {% block date %}
+        {% if display_submitted %}
+          <div class="cd-card__date">
+            <time datetime="{{ node.getCreatedTime|date('Y-m-d H:i:s') }}">{{ unochaDate }}</time>
+          </div>
+        {% endif %}
+      {% endblock %}
+
+      {% block read_more %}
+        <a href="{{ url }}" class="cd-card__link cd-read-more">
+          {% trans %}Read more{% endtrans %}
+          <svg class="cd-icon cd-icon--arrow-right" aria-hidden="true" focusable="false" width="16" height="16">
+            <use xlink:href="#cd-icon--arrow-right"></use>
+          </svg>
+        </a>
+      {% endblock %}
+    </div>
+
+  {% endblock %}
+
+  {# This is empty because we use its markup above instead #}
+  {% block card_footer %}
+  {% endblock %}
+
+{% endembed %}


### PR DESCRIPTION
Refs: UNO-802

This PR adds the `entity_browser` module and related view to offer somehow a better UX to select the featured stories:

<img width="2085" alt="Screenshot 2023-10-31 at 15 14 54" src="https://github.com/UN-OCHA/unocha-site/assets/696348/85fcd526-6584-4f2b-8657-7d50bfaf08db">

The display of the selected stories in the paragraph widget needs some styling however:
<img width="2043" alt="Screenshot 2023-10-31 at 15 15 05" src="https://github.com/UN-OCHA/unocha-site/assets/696348/ed9955ab-6cb3-40a0-995a-5c1f7ee2f544">

**Notes**

It's not possible to re-order the selected stories, they need to be removed and re-added one by one. Maybe that's fine if there are only 2 or 3 of them.

Currently the selected stories only show their label but they can be rendered with a view mode (widget setting in `/admin/structure/paragraphs_type/stories/form-display`) so we could define a new view mode (notably to have a template where we could add the  `target="_blank"` attribute to the links to not leave the form).

