### PR TITLE
UNO-806 Prevent i is not defined when keying through section tabs

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-section-tabs/uno-section-tabs.js
+++ b/html/themes/custom/common_design_subtheme/components/uno-section-tabs/uno-section-tabs.js
@@ -35,7 +35,7 @@
         tablist.setAttribute('role', 'tablist');
 
         // Add semantics to remove user focusability for each tab.
-        Array.prototype.forEach.call(tabs, tab => {
+        Array.prototype.forEach.call(tabs, (tab, i) => {
           tab.setAttribute('role', 'tab');
           tab.setAttribute('id', tab.id);
           tab.setAttribute('tabindex', '-1');


### PR DESCRIPTION
As mentioned here https://github.com/UN-OCHA/unocha-site/pull/291#pullrequestreview-1705790743

chore: prevent i is not defined when keying through section tabs

Refs: UNO-806