### PR TITLE
[UNO-807] Add text field to section paragraphs

### DIFF
--- a/config/core.entity_form_display.paragraph.section.default.yml
+++ b/config/core.entity_form_display.paragraph.section.default.yml
@@ -3,16 +3,26 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.section.field_text
     - field.field.paragraph.section.field_title
     - field.field.paragraph.section.paragraph_view_mode
     - paragraphs.paragraphs_type.section
   module:
     - paragraph_view_mode
+    - text
 id: paragraph.section.default
 targetEntityType: paragraph
 bundle: section
 mode: default
 content:
+  field_text:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_title:
     type: string_textfield
     weight: 1
@@ -35,13 +45,13 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 3
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_view_display.paragraph.section.container.yml
+++ b/config/core.entity_view_display.paragraph.section.container.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.paragraph.container
+    - field.field.paragraph.section.field_text
     - field.field.paragraph.section.field_title
     - field.field.paragraph.section.paragraph_view_mode
     - paragraphs.paragraphs_type.section
   module:
     - layout_builder
+    - text
 third_party_settings:
   layout_builder:
     enabled: false
@@ -17,7 +19,14 @@ id: paragraph.section.container
 targetEntityType: paragraph
 bundle: section
 mode: container
-content: {  }
+content:
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_title: true
   paragraph_view_mode: true

--- a/config/core.entity_view_display.paragraph.section.default.yml
+++ b/config/core.entity_view_display.paragraph.section.default.yml
@@ -3,14 +3,24 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.section.field_text
     - field.field.paragraph.section.field_title
     - field.field.paragraph.section.paragraph_view_mode
     - paragraphs.paragraphs_type.section
+  module:
+    - text
 id: paragraph.section.default
 targetEntityType: paragraph
 bundle: section
 mode: default
 content:
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_title:
     type: string
     label: hidden

--- a/config/core.entity_view_display.paragraph.section.tabs.yml
+++ b/config/core.entity_view_display.paragraph.section.tabs.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.paragraph.tabs
+    - field.field.paragraph.section.field_text
     - field.field.paragraph.section.field_title
     - field.field.paragraph.section.paragraph_view_mode
     - paragraphs.paragraphs_type.section
   module:
     - layout_builder
+    - text
 third_party_settings:
   layout_builder:
     enabled: false
@@ -18,6 +20,13 @@ targetEntityType: paragraph
 bundle: section
 mode: tabs
 content:
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_title:
     type: string
     label: hidden

--- a/config/field.field.paragraph.section.field_text.yml
+++ b/config/field.field.paragraph.section.field_text.yml
@@ -1,0 +1,27 @@
+uuid: cd232e97-c17c-4e86-a97f-339529fce8e6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.section
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - ckeditor
+id: paragraph.section.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: section
+label: Text
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section--default.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section--default.html.twig
@@ -49,7 +49,7 @@
 {% block paragraph %}
   <section{{ attributes.addClass(classes) }}>
     {% block content %}
-      {{ content }}see
+      {{ content }}
     {% endblock %}
   </section>
 {% endblock paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section--tabs.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section--tabs.html.twig
@@ -53,6 +53,7 @@
     {% block content %}
 
     {{ content.field_title }}
+    {{ content.field_text }}
       <ul class="uno-section-tabs__list">
       {% for section in content.regions.content %}
         {% set paragraph = section['#paragraph'] %}


### PR DESCRIPTION
Refs: UNO-807

This adds the common `field_text` to the `section` paragraph type and update the corresponding templates.

## Tests

1. Checkout the branch, clear the cache, import the config
2. Edit a response
3. Edit a section paragraph
4. Check that the text field appears
5. Enter some text
6. Save then save the node form
7. Confirm that the text appear above the content of the section
8. Repeat (5) to (7), using a different view mode for the section parapragh