### PR TITLE
[UNO-807] Add icon after external links

### DIFF
--- a/config/filter.format.ckeditor.yml
+++ b/config/filter.format.ckeditor.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - linkit
+    - unocha_utility
 name: CKEditor
 format: ckeditor
 weight: 0
@@ -43,3 +44,9 @@ filters:
     weight: 0
     settings:
       title: true
+  unocha_external_link_filter:
+    id: unocha_external_link_filter
+    provider: unocha_utility
+    status: true
+    weight: 0
+    settings: {  }

--- a/html/modules/custom/unocha_utility/src/Plugin/Filter/ExternalLinkFilter.php
+++ b/html/modules/custom/unocha_utility/src/Plugin/Filter/ExternalLinkFilter.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\unocha_utility\Plugin\Filter;
+
+use Drupal\Component\Render\MarkupInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Provides a filter to add attributes to external links to open in a new tab.
+ *
+ * @Filter(
+ *   id = "unocha_external_link_filter",
+ *   title = @Translation("Open external Links in new tab."),
+ *   description = @Translation("Add target and rel attributes to external links so they open in a new tab."),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_IRREVERSIBLE,
+ * )
+ */
+class ExternalLinkFilter extends FilterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Internal host pattern.
+   *
+   * @var string
+   */
+  protected $internalHostPattern;
+
+  /**
+   * Constructs a markdown filter plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode) {
+    if (is_string($text) || $text instanceof MarkupInterface) {
+      $html = trim($text);
+      if ($html !== '') {
+        // Adding this meta tag is necessary to tell \DOMDocument we are dealing
+        // with UTF-8 encoded html.
+        $flags = LIBXML_NONET | LIBXML_NOBLANKS | LIBXML_NOERROR | LIBXML_NOWARNING;
+        $meta = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
+        $prefix = '<!DOCTYPE html><html><head>' . $meta . '</head><body>';
+        $suffix = '</body></html>';
+        $dom = new \DOMDocument();
+        $dom->loadHTML($prefix . $text . $suffix, $flags);
+
+        // Process the links.
+        $links = $dom->getElementsByTagName('a');
+        foreach ($links as $link) {
+          $this->handleLink($link);
+        }
+
+        // Get the modified html.
+        $html = $dom->saveHTML();
+
+        // Search for the body tag and return its content.
+        $start = mb_strpos($html, '<body>');
+        $end = mb_strrpos($html, '</body>');
+        if ($start !== FALSE && $end !== FALSE) {
+          $start += 6;
+          $text = trim(mb_substr($html, $start, $end - $start));
+        }
+      }
+    }
+    return new FilterProcessResult($text);
+  }
+
+  /**
+   * Check if a URL is an UNOCHA URL.
+   *
+   * @param string $url
+   *   URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is internal.
+   */
+  protected function isInternalUrl($url) {
+    if (empty($url)) {
+      return TRUE;
+    }
+
+    if (!isset($this->internalHostPattern)) {
+      $internal_hosts = [
+        preg_quote($this->requestStack->getCurrentRequest()->getHost()),
+        preg_quote('unocha.org'),
+        preg_quote('www.unocha.org'),
+      ];
+
+      $this->internalHostPattern = '#^https?://(' . implode('|', $internal_hosts) . ')(/|$)#';
+    }
+
+    return preg_match('#^https?://#', $url) !== 1 ||
+      preg_match($this->internalHostPattern, $url) === 1;
+  }
+
+  /**
+   * Add the target and rel attributes to external links to open in a new tab.
+   *
+   * @param \DOMNode $node
+   *   Link node.
+   */
+  protected function handleLink(\DOMNode $node) {
+    $url = $node->getAttribute('href');
+
+    if (!$this->isInternalUrl($url)) {
+      $node->setAttribute('target', '_blank');
+      $node->setAttribute('rel', 'noreferrer noopener');
+    }
+  }
+
+}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -16,6 +16,7 @@ global-styling:
     - common_design_subtheme/cd
     - common_design_subtheme/rw-icons
     - common_design_subtheme/uno-card-list
+    - common_design_subtheme/uno-external-links
     - common_design_subtheme/uno-node
 
 ###
@@ -127,6 +128,13 @@ uno-event-date:
   css:
     theme:
       components/uno-event-date/uno-event-date.css: {}
+
+uno-external-links:
+  css:
+    theme:
+      components/uno-external-links/uno-external-links.css: {}
+  dependencies:
+    - common_design_subtheme/rw-icons
 
 uno-figures:
   css:

--- a/html/themes/custom/common_design_subtheme/components/uno-external-links/README.md
+++ b/html/themes/custom/common_design_subtheme/components/uno-external-links/README.md
@@ -1,0 +1,4 @@
+UNOCHA External Links
+=====================
+
+This component provides styling for external links, adding an icon after the link text.

--- a/html/themes/custom/common_design_subtheme/components/uno-external-links/uno-external-links.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-external-links/uno-external-links.css
@@ -1,0 +1,12 @@
+/* External links. Display an icon after the link. */
+.cd-layout__content a[target="_blank"][rel~="noopener"]:after {
+  display: inline-block;
+  overflow: hidden;
+  width: 12px;
+  height: 12px;
+  /* The top margin is to have a better vertical alignment. */
+  margin: -2px 0 0 6px;
+  content: "";
+  vertical-align: middle;
+  background: var(--rw-icons--common--external-link--12--dark-blue);
+}


### PR DESCRIPTION
Refs: UNO-807

This adds text filter that adds the `target` and `rel` attibutes to external links. It also adds the library to style those external links.

Note: this is against the UNO-807 branch.

### Tests

1. Checkout the branch, clear the cache, import the config
2. Edit a response for example, add a text paragraph type
3. Enter a link to an external site
4. Enter an internal link (either with the domain of your local instance or unocha.org or www.unocha.org)
5. Save then save the node
6. Check that the link from (3) has an icon and the link from (4) doesn't.