### PR TITLE
[UNO-807] Adjust bottom margin of text field inside section paragraph

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-node/uno-node.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-node/uno-node.css
@@ -50,6 +50,26 @@
   }
 }
 
+.node--view-mode-full .paragraph.paragraph--type--section .field--name-field-text {
+  margin-bottom: 2rem;
+}
+
+@media screen and (min-width: 768px) {
+  .node--view-mode-full .paragraph.paragraph--type--section .field--name-field-text {
+    margin-bottom: 1rem;
+  }
+}
+
+.node--view-mode-full .paragraph.paragraph--type--section .paragraph--type--section .field--name-field-text {
+  margin-bottom: 1rem;
+}
+
+@media screen and (min-width: 768px) {
+  .node--view-mode-full .paragraph.paragraph--type--section .paragraph--type--section .field--name-field-text {
+    margin-bottom: 0;
+  }
+}
+
 .node--view-mode-full .layout .paragraph .field--name-field-text {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Refs: UNO-807

Adjust the margin bottom for the text field inside a section paragraph type. Handle nested section paragraphs as well.

**Before**

<img width="1124" alt="Screenshot 2023-11-12 at 8 50 39" src="https://github.com/UN-OCHA/unocha-site/assets/696348/84df9a09-2949-4d96-968e-825daa7522d9">

**After**

<img width="1091" alt="Screenshot 2023-11-12 at 8 51 00" src="https://github.com/UN-OCHA/unocha-site/assets/696348/964db7e5-c510-4ede-9cbd-6c71c5a83e94">

### Tests

1. Checkout the branch, clear the cache
2. Edit the `/afghanistan` for example, add a text to the `Overview of the Humanitarian Response in Afghanistan` section paragraph.
3. Add a text to the `Humanitarian Needs Overview` sub section
4. Save
5. Confirm that the result is like in the screenshot.