### PR TITLE
UNO-796 Title should display full width even if it is short

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/uno-stories/uno-stories.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-stories/uno-stories.css
@@ -49,6 +49,10 @@
     padding-top: 2rem;
   }
 
+  .uno-stories__content .node--type-story.node--view-mode-featured .cd-card__title {
+    flex: 1 0 100%;
+  }
+
   .uno-stories__content .node--type-story.node--view-mode-featured .cd-card__title a {
     font-size: var(--cd-font-size--medium);
   }


### PR DESCRIPTION
chore: set flex on title for full width display when title is short
Refs: UNO-796

To test:
See UNO-796 for before screenshot.
Check out branch and clear cache.
Visit the homepage and edit the title of the first item in Latest News and Stories to reduce the number of words to just a few.
Notice the title element takes up the available width, no longer dependent on the specific content.

Expected result:
![Selection_088](https://github.com/UN-OCHA/unocha-site/assets/1835923/f2972511-eb85-414d-a0d8-0a158d899a73)
