### PR TITLE
UNO-787 RW Report template override refactor

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-entity-meta/rw-entity-meta.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-entity-meta/rw-entity-meta.css
@@ -183,11 +183,3 @@
   float: left;
   margin: 0 4px 0 0;
 }
-
-/* UNO display rules */
-.rw-entity-meta--core dt.rw-entity-meta__tag-label--format,
-.rw-entity-meta--core dd.rw-entity-meta__tag-value--format,
-.rw-entity-meta--core dt.rw-entity-meta__tag-label--posted,
-.rw-entity-meta--core dd.rw-entity-meta__tag-value--posted {
-  display: none;
-}

--- a/html/themes/custom/common_design_subtheme/components/uno-document/uno-document.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-document/uno-document.css
@@ -73,13 +73,13 @@
   display: none;
 }
 
-.paragraph--type--reliefweb-document.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--posted,
-.paragraph--type--reliefweb-document.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--posted {
+.paragraph--type--reliefweb-document.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--published,
+.paragraph--type--reliefweb-document.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--published {
   display: inline-block;
 }
 
-.paragraph--type--reliefweb-document.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--posted,
-.paragraph--type--reliefweb-document.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--posted,
+.paragraph--type--reliefweb-document.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--published,
+.paragraph--type--reliefweb-document.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--published,
 .paragraph--type--reliefweb-document.paragraph--view-mode--teasers .cd-read-more,
 .paragraph--type--reliefweb-document.paragraph--view-mode--cards .cd-read-more {
   font-size: var(--cd-font-size--small);

--- a/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
+++ b/html/themes/custom/common_design_subtheme/components/uno-river/uno-river.css
@@ -130,13 +130,13 @@
   display: none;
 }
 
-.paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--posted,
-.paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--posted {
+.paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--published,
+.paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--published {
   display: inline-block;
 }
 
-.paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--posted,
-.paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--posted,
+.paragraph--type--reliefweb-river.paragraph--view-mode--teasers .rw-entity-meta .rw-entity-meta__tag-value--published,
+.paragraph--type--reliefweb-river.paragraph--view-mode--cards .rw-entity-meta .rw-entity-meta__tag-value--published,
 .paragraph--type--reliefweb-river.paragraph--view-mode--teasers .cd-read-more,
 .paragraph--type--reliefweb-river.paragraph--view-mode--cards .cd-read-more {
   font-size: var(--cd-font-size--small);

--- a/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-river-article--report.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/modules/unocha_reliefweb/unocha-reliefweb-river-article--report.html.twig
@@ -77,20 +77,6 @@
       '#theme': 'unocha_reliefweb_entity_meta',
       '#attributes': meta_attributes,
       '#meta': {
-        'format': {
-          'type': 'simple',
-          'label': 'Format'|t,
-          'value': entity.format,
-          'label_attributes': create_attribute()
-            .addClass('visually-hidden'),
-          'value_attributes': create_attribute()
-            .addClass('rw-entity-meta__tag-value--format--' ~ entity.format|clean_class),
-        },
-        'posted': {
-          'type': 'date',
-          'label': 'Posted'|t,
-          'value': entity.posted,
-        },
         'published': {
           'type': 'date',
           'label': 'Originally published'|t,


### PR DESCRIPTION
UNO-787

I've removed Format and Posted data from the template overrides and also the CSS rules that hid them.
We should be using Published for the date, so this replaces Posted in some cases, so the CSS selectors are updated to suit.

### To Test
After checking out this branch, compare any pages that have Reliefweb Document or River Paragraphs. All elements in the Document or Report items should appear unchanged as this is a refactor.

Example pages:
- https://demo.unocha-org.ahconu.org/demo/reliefweb-rivers
- https://demo.unocha-org.ahconu.org/demo/page-components
- https://demo.unocha-org.ahconu.org/ocha
- Any Response page https://demo.unocha-org.ahconu.org/myanmar

I ran VRT between my local with this branch and the demo site and all good.