### PR TITLE
[UNO-809] Add honeypot to contact form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/environment_indicator": "^4.0",
         "drupal/geofield": "^1.53",
         "drupal/google_tag": "^1.6",
+        "drupal/honeypot": "^2.1",
         "drupal/imageapi_optimize_binaries": "^1.0@beta",
         "drupal/imageapi_optimize_webp": "^2.0",
         "drupal/imagemagick": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5048ff880de3c7323fbb47551ed50648",
+    "content-hash": "32ddff2c9da0ffd65cbb848aeb5f328c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3630,6 +3630,75 @@
             "homepage": "https://www.drupal.org/project/google_tag",
             "support": {
                 "source": "https://git.drupalcode.org/project/google_tag"
+            }
+        },
+        {
+            "name": "drupal/honeypot",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/honeypot.git",
+                "reference": "2.1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.3.zip",
+                "reference": "2.1.3",
+                "shasum": "101105029a10a574ef6017824182500ab9905856"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/rules": "^3.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.1.3",
+                    "datestamp": "1695604754",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Geerling",
+                    "homepage": "https://www.drupal.org/user/389011",
+                    "email": "geerlingguy@mac.com"
+                },
+                {
+                    "name": "Manuel Garcia",
+                    "homepage": "https://www.drupal.org/user/213194"
+                },
+                {
+                    "name": "TR",
+                    "homepage": "https://www.drupal.org/user/202830"
+                },
+                {
+                    "name": "vijaycs85",
+                    "homepage": "https://www.drupal.org/user/93488"
+                }
+            ],
+            "description": "Mitigates spam form submissions using the honeypot method.",
+            "homepage": "https://www.drupal.org/project/honeypot",
+            "keywords": [
+                "deterrent",
+                "form",
+                "honeypot",
+                "honeytrap",
+                "php",
+                "spam"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/honeypot",
+                "issues": "https://www.drupal.org/project/issues/honeypot"
             }
         },
         {

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -34,6 +34,7 @@ module:
   filter: 0
   geofield: 0
   google_tag: 0
+  honeypot: 0
   image: 0
   imageapi_optimize: 0
   imageapi_optimize_binaries: 0

--- a/config/honeypot.settings.yml
+++ b/config/honeypot.settings.yml
@@ -1,0 +1,26 @@
+_core:
+  default_config_hash: 9bVDfWSa_In6VzTXmy04jJ_3ZQobihKjO9isuuUCPaw
+protect_all_forms: false
+unprotected_forms:
+  - user_login_form
+  - search_form
+  - search_block_form
+  - views_exposed_form
+  - honeypot_settings_form
+log: true
+element_name: url
+time_limit: 5
+expire: 300
+form_settings:
+  user_register_form: false
+  user_pass: false
+  contact_message_contact_form: true
+  contact_message_personal_form: false
+  node_basic_form: false
+  node_event_form: false
+  node_leader_form: false
+  node_media_collection_form: false
+  node_region_form: false
+  node_resource_form: false
+  node_response_form: false
+  node_story_form: false


### PR DESCRIPTION
Refs: UNO-809

This adds the honeypot module and configures it for the contact us form.

### Tests

1. Checkout the branch, rebuild the image, clear the cache and import the config
2. Go to the contact us page and inspect the page to confirm the `honeypot_time` fields is there
3. Fill in the form, send and check mailpit (ex: http://mail.unocha-local.test) to confirm the email was sent
4. Return to the contact us form, inspect the page, search for the `form-wrapper` element with `style="display: none !important;"`, remove the style attribute to reveal the honeypot input field
5. Fill in the form including the field above
6. Send and confirm there is an error message and and a log message in the DB logs