### PR TITLE
[UNO-810] User management

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -94,6 +94,7 @@ module:
   unocha_paragraphs: 0
   unocha_reliefweb: 0
   unocha_sitemap: 0
+  unocha_users: 0
   unocha_utility: 0
   update: 0
   user: 0

--- a/config/language/ar/views.view.user_admin_people.yml
+++ b/config/language/ar/views.view.user_admin_people.yml
@@ -53,9 +53,6 @@ display:
         roles_target_id:
           expose:
             label: الدور
-        permission:
-          expose:
-            label: الصلاحية
       use_more_text: المزيد
   page_1:
     display_title: الصفحة

--- a/config/language/es/views.view.user_admin_people.yml
+++ b/config/language/es/views.view.user_admin_people.yml
@@ -6,8 +6,6 @@ display:
     display_options:
       title: Usuarios
       fields:
-        user_bulk_form:
-          label: 'Actualización masiva'
         name:
           label: 'Nombre de usuario'
         status:
@@ -67,9 +65,6 @@ display:
         roles_target_id:
           expose:
             label: Rol
-        permission:
-          expose:
-            label: Permiso
       use_more_text: más
   page_1:
     display_title: Página

--- a/config/language/fr/views.view.user_admin_people.yml
+++ b/config/language/fr/views.view.user_admin_people.yml
@@ -6,8 +6,6 @@ display:
     display_options:
       title: Personnes
       fields:
-        user_bulk_form:
-          label: 'Mise à jour en masse'
         name:
           label: "Nom d'utilisateur"
         status:
@@ -67,9 +65,6 @@ display:
         roles_target_id:
           expose:
             label: Rôle
-        permission:
-          expose:
-            label: Droit
       use_more_text: plus
   page_1:
     display_title: Page

--- a/config/language/ru/views.view.user_admin_people.yml
+++ b/config/language/ru/views.view.user_admin_people.yml
@@ -6,8 +6,6 @@ display:
     display_options:
       title: Пользователи
       fields:
-        user_bulk_form:
-          label: 'Массовое обновление'
         name:
           label: 'Имя пользователя'
         status:
@@ -67,9 +65,6 @@ display:
         roles_target_id:
           expose:
             label: Роль
-        permission:
-          expose:
-            label: 'Право доступа'
       use_more_text: ещё
   page_1:
     display_title: Страница

--- a/config/language/zh-hans/views.view.user_admin_people.yml
+++ b/config/language/zh-hans/views.view.user_admin_people.yml
@@ -6,8 +6,6 @@ display:
     display_options:
       title: 人员
       fields:
-        user_bulk_form:
-          label: 批量更新
         name:
           label: 用户名
         status:
@@ -63,9 +61,6 @@ display:
         roles_target_id:
           expose:
             label: 角色
-        permission:
-          expose:
-            label: 权限
       use_more_text: 更多
   page_1:
     display_title: 页面

--- a/config/system.action.user_add_role_action.user_manager.yml
+++ b/config/system.action.user_add_role_action.user_manager.yml
@@ -1,0 +1,14 @@
+uuid: 516cab6f-fcdf-4ac5-a5a0-8bfe9c82ea11
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.user_manager
+  module:
+    - user
+id: user_add_role_action.user_manager
+label: 'Add the User manager role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: user_manager

--- a/config/system.action.user_remove_role_action.user_manager.yml
+++ b/config/system.action.user_remove_role_action.user_manager.yml
@@ -1,0 +1,14 @@
+uuid: c45c53cc-ba94-43a4-96f1-fc6ee60c6314
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.user_manager
+  module:
+    - user
+id: user_remove_role_action.user_manager
+label: 'Remove the User manager role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: user_manager

--- a/config/user.role.user_manager.yml
+++ b/config/user.role.user_manager.yml
@@ -1,0 +1,17 @@
+uuid: 73fed079-3165-4401-8104-b447f37ca03b
+langcode: en
+status: true
+dependencies:
+  module:
+    - unocha_users
+id: user_manager
+label: 'User manager'
+weight: 4
+is_admin: null
+permissions:
+  - 'access user profiles'
+  - 'administer users'
+  - 'assign editor role'
+  - 'assign user_manager role'
+  - 'block other user account'
+  - 'manage other user acount roles'

--- a/config/views.view.user_admin_people.yml
+++ b/config/views.view.user_admin_people.yml
@@ -22,56 +22,6 @@ display:
     display_options:
       title: People
       fields:
-        user_bulk_form:
-          id: user_bulk_form
-          table: users
-          field: user_bulk_form
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: user
-          plugin_id: user_bulk_form
-          label: 'Bulk update'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
         name:
           id: name
           table: users_field_data
@@ -660,48 +610,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-        permission:
-          id: permission
-          table: user__roles
-          field: permission
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: user_permissions
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: permission_op
-            label: Permission
-            description: ''
-            use_operator: false
-            operator: permission_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: permission
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
         default_langcode:
           id: default_langcode
           table: users_field_data
@@ -884,7 +792,7 @@ display:
       hide_attachment_summary: false
       display_extenders: {  }
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -917,7 +825,7 @@ display:
         weight: 0
         menu_name: admin
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/html/modules/custom/unocha_users/README.md
+++ b/html/modules/custom/unocha_users/README.md
@@ -1,0 +1,4 @@
+UNOCHA - Users module
+=====================
+
+This module handlers permissions to assign roles.

--- a/html/modules/custom/unocha_users/src/UserPermissions.php
+++ b/html/modules/custom/unocha_users/src/UserPermissions.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\unocha_users;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * UNOCHA Users permission provider.
+ */
+class UserPermissions implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Get permissions to assign roles.
+   *
+   * @return array
+   *   Associative array with the permissions as keys and an array with the
+   *   permission title and description as values.
+   */
+  public function permissions() {
+    $permissions = [];
+
+    $roles = $this->entityTypeManager->getStorage('user_role')->loadMultiple();
+    foreach ($roles as $id => $role) {
+      if ($id === $role::ANONYMOUS_ID || $id === $role::AUTHENTICATED_ID) {
+        continue;
+      }
+
+      $permissions['assign ' . $id . ' role'] = [
+        'title' => $this->t('Assign @label role.', [
+          '@label' => $role->label(),
+        ]),
+        'description' => $this->t('Allow users to assign the @label role to other accounts.', [
+          '@label' => $role->label(),
+        ]),
+      ];
+    }
+
+    return $permissions;
+  }
+
+}

--- a/html/modules/custom/unocha_users/unocha_users.info.yml
+++ b/html/modules/custom/unocha_users/unocha_users.info.yml
@@ -1,0 +1,7 @@
+type: module
+name: UNOCHA users
+description: 'Handles assigning user roles.'
+package: unocha
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:user

--- a/html/modules/custom/unocha_users/unocha_users.module
+++ b/html/modules/custom/unocha_users/unocha_users.module
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * Module file for the unocha_users module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\RoleInterface;
+
+/**
+ * Implements hook_form_user_form_alter().
+ */
+function unocha_users_form_user_form_alter(array &$form, FormStateInterface $form_state) {
+  $current_user = \Drupal::currentUser();
+  $same_user = $current_user->id() === $form_state->getFormObject()->getEntity()->id();
+
+  // Disable access to fields if not on own form and no permission to edit them.
+  if (!$same_user && !$current_user->hasPermission('edit other user account details')) {
+    $form['account']['mail']['#access'] = FALSE;
+    $form['account']['name']['#access'] = FALSE;
+    $form['account']['pass']['#access'] = FALSE;
+    $form['account']['notify']['#access'] = FALSE;
+
+    $form['contact']['#access'] = FALSE;
+    $form['display_name']['#access'] = FALSE;
+    $form['language']['#access'] = FALSE;
+    $form['timezone']['#access'] = FALSE;
+  }
+
+  // Disable option to cancel account without proper permission.
+  if (!$same_user && !$current_user->hasPermission('block other user account')) {
+    $form['account']['status']['#access'] = FALSE;
+  }
+
+  // Disable option to cancel account without proper permission.
+  if (!$same_user && !$current_user->hasPermission('cancel other user account')) {
+    $form['actions']['delete']['#access'] = FALSE;
+  }
+
+  // Check if the user is allowed to assign roles.
+  if ($current_user->hasPermission('manage other user acount roles') && !empty($form['account']['roles']['#options'])) {
+    $form['account']['roles']['#access'] = TRUE;
+
+    $default_roles = $form['account']['roles']['#default_value'] ?? [];
+
+    foreach ($form['account']['roles']['#options'] as $role => $label) {
+      if ($role === RoleInterface::ANONYMOUS_ID) {
+        continue;
+      }
+      // No need to display the authenticated role.
+      elseif ($role === RoleInterface::AUTHENTICATED_ID) {
+        $form['account']['roles'][$role]['#access'] = FALSE;
+      }
+      // Only display the roles that can be assigned by the current user.
+      elseif (!$current_user->hasPermission('assign ' . $role . ' role')) {
+        $form['account']['roles'][$role]['#access'] = FALSE;
+        $form['account']['roles'][$role]['#disabled'] = TRUE;
+        $form['account']['roles'][$role]['#default_value'] = in_array($role, $default_roles);
+      }
+    }
+  }
+  else {
+    $form['account']['roles']['#access'] = FALSE;
+  }
+}

--- a/html/modules/custom/unocha_users/unocha_users.permissions.yml
+++ b/html/modules/custom/unocha_users/unocha_users.permissions.yml
@@ -1,0 +1,18 @@
+block other user account:
+  title: 'Block other user account'
+  description: 'Allow users to block other user accounts.'
+
+cancel other user account:
+  title: 'Cancel other user account'
+  description: 'Allow users to cancel other user accounts.'
+
+edit other user account details:
+  title: 'Edit other user account details'
+  description: 'Allow users to edit fields of other user accounts.'
+
+manage other user acount roles:
+  title: 'Manage other user acount roles'
+  description: 'Allow users to manage roles of other user accounts.'
+
+permission_callbacks:
+  - Drupal\unocha_users\UserPermissions::permissions


### PR DESCRIPTION
Refs: UNO-810

This PR adds a module with granular permissions to manager user accounts and a `User manager` role that can change roles and block user accounts.

A person with the `User manager` role can see the list of people (`/admin/people` page), edit their accounts and change the account status and the roles:

<img width="340" alt="Screenshot 2023-11-29 at 13 10 45" src="https://github.com/UN-OCHA/unocha-site/assets/696348/928b4dde-84a9-4a94-aa9e-ace71c15edc4">

### Tests

1. Checkout the branch, import the config, clear the cache
2. Log in as an `authenticated` user, check you cannot access `/admin/people` and check you cannot access another account's form (ex: `user/5/edit`)
3. Log in as an editor, check it's the same as (2)
4. Log in as a `Administrator`, check that you have access to `/admin/people` and can edit another account's form and can see all the fields (display name, mail etc.)
5. Assign the `User manager` role to a non-administrator account
6. Log in with that account, check that you have access to `/admin/people` and can edit another account's form but only the `status` and `roles` fields and that the roles are limited to `Editor` and `User manager`.
