### PR TITLE
[UNO-817] Paragraph view mode theme suggestion

### DIFF
--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -491,3 +491,20 @@ function unocha_paragraphs_form_node_form_alter(array &$form, FormStateInterface
     $form['sticky']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for 'paragraph'.
+ *
+ * Add a theme hook suggestion for the paragraph view mode field so that
+ * we can differentiate the paragraphs in the form when they are rendered as
+ * previews.
+ */
+function unocha_paragraphs_theme_suggestions_paragraph_alter(array &$suggestions, array $variables) {
+  if (isset($variables['elements']['#view_mode'], $variables['elements']['#paragraph'])) {
+    $viewmode = $variables['elements']['#view_mode'];
+    $paragraph = $variables['elements']['#paragraph'];
+    if (!empty($paragraph->paragraph_view_mode?->value)) {
+      $suggestions[] = 'paragraph__' . $paragraph->bundle() . '__' . $viewmode . '__' . $paragraph->paragraph_view_mode->value;
+    }
+  }
+}

--- a/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-river.html.twig
+++ b/html/themes/custom/common_design_claro/templates/paragraphs/paragraph--reliefweb-river.html.twig
@@ -1,1 +1,4 @@
-{% include '@common_design_subtheme/paragraphs/paragraph--reliefweb-river.html.twig' %}
+{% include '@common_design_subtheme/paragraphs/paragraph--reliefweb-river.html.twig' with {
+    'attributes': attributes.addClass('paragraph--view-mode--' ~ paragraph.paragraph_view_mode.value)
+  }
+%}


### PR DESCRIPTION
Refs: UNO-817

This does 2 things:

It adds a theme suggestion to have more granularity with the templates for the paragraph with a `view mode` field.

So for example, one could create a `paragraph--reliefweb-river--preview--resources.html.twig` template for "reliefweb river" paragraph types with the "resources" view mode to use when displayed in the form ("preview" view mode).

It also adds a class in the claro subtheme's "reliefweb river" paragraph template to help with the styling:

<img width="1027" alt="Screenshot 2024-01-24 at 11 18 45" src="https://github.com/UN-OCHA/unocha-site/assets/696348/a813f9f8-64fb-49cc-ae28-569c86a0ed9d">

**Note:** the class addition above applies to all the reliefweb river paragraphs. To only add the class to the `resources` view mode, one can create a `paragraph--reliefweb-river--preview--resources.html.twig` in the claro subtheme and copy the code from `paragraph--reliefweb-river.html.twig` and remove the change from https://github.com/UN-OCHA/unocha-site/pull/433/commits/8b0705428cd3ab693daff074c3355bd502322305.