### PR TITLE
fix: order menu links by weight and title

### DIFF
--- a/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
+++ b/html/modules/custom/unocha_paragraphs/unocha_paragraphs.module
@@ -380,7 +380,10 @@ function unocha_paragraphs_get_nodes_from_menu_links(array $menu_links) {
       !empty($menu_link->getRouteParameters()['node'])
     ) {
       $node_id = $menu_link->getRouteParameters()['node'];
-      $node_ids[$node_id] = $menu_link->getWeight();
+      // Store weighted titles so that the order of the nodes is the same as
+      // the order in the menu UI: weight > title.
+      // @see Drupal\Core\Menu\DefaultMenuLinkTreeManipulators::generateIndexAndSort()
+      $node_ids[$node_id] = (50000 + $menu_link->getWeight()) . ' ' . $menu_link->getTitle() . ' ' . $menu_link->getPluginId();
     }
   }
   if (!empty($node_ids)) {
@@ -392,6 +395,7 @@ function unocha_paragraphs_get_nodes_from_menu_links(array $menu_links) {
     uasort($nodes, function ($a, $b) use ($node_ids) {
       return $node_ids[$a->id()] <=> $node_ids[$b->id()];
     });
+
     return $nodes;
   }
 


### PR DESCRIPTION
Refs: UNO-827

This ensures the ordering of the menu links for example in the resources paragraphs is the same as the order in the menu UI: first ordered by weight then title if same weight.

### Tests

**Before checking out this branch**

1. Import recent dump
2. Visit `/west-and-central-africa` for example, take note of the order (see ticket as well), the order should show something like "Allocation..." then "About...".

**After checking out this branch**

1. Checkout the branch, clear the cache
2. Visit `/west-and-central-africa` and confirm that the order is as expected ("About..." before "Allocation...")