### PR TITLE
[UNO-824] Update outdated field_custom_content config

### DIFF
--- a/config/field.field.node.basic.field_custom_content.yml
+++ b/config/field.field.node.basic.field_custom_content.yml
@@ -20,20 +20,23 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    target_bundles: {  }
+    target_bundles: null
     negate: 1
     target_bundles_drag_drop:
       call_to_action:
         weight: 19
         enabled: false
-      content_list:
-        weight: 21
+      campaign:
+        weight: 28
         enabled: false
-      datawrapper:
-        weight: 22
+      cbpf:
+        weight: 29
         enabled: false
-      embed:
-        weight: 2
+      donors:
+        weight: 30
+        enabled: false
+      events:
+        weight: 31
         enabled: false
       figures:
         weight: 24
@@ -44,8 +47,23 @@ settings:
       layout:
         weight: 7
         enabled: false
+      leader:
+        weight: 35
+        enabled: false
+      media_centre:
+        weight: 36
+        enabled: false
+      news_and_stories:
+        weight: 37
+        enabled: false
       node:
         weight: 27
+        enabled: false
+      ocha_datawrapper:
+        weight: 39
+        enabled: false
+      regions:
+        weight: 40
         enabled: false
       reliefweb_document:
         weight: 28
@@ -53,17 +71,26 @@ settings:
       reliefweb_river:
         weight: 29
         enabled: false
-      rss_feed:
-        weight: 30
+      reliefweb_river_curated:
+        weight: 43
         enabled: false
-      rw_key_figures:
-        weight: 31
+      resources:
+        weight: 44
         enabled: false
-      tab:
-        weight: 32
-        enabled: true
-      tabs:
-        weight: 33
+      response_map:
+        weight: 46
+        enabled: false
+      responses:
+        weight: 45
+        enabled: false
+      section:
+        weight: 47
+        enabled: false
+      stories:
+        weight: 48
+        enabled: false
+      subscribe:
+        weight: 49
         enabled: false
       text:
         weight: 8

--- a/config/field.field.node.event.field_custom_content.yml
+++ b/config/field.field.node.event.field_custom_content.yml
@@ -20,20 +20,23 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    target_bundles: {  }
+    target_bundles: null
     negate: 1
     target_bundles_drag_drop:
       call_to_action:
         weight: 19
         enabled: false
-      content_list:
-        weight: 21
+      campaign:
+        weight: 28
         enabled: false
-      datawrapper:
-        weight: 22
+      cbpf:
+        weight: 29
         enabled: false
-      embed:
-        weight: 8
+      donors:
+        weight: 30
+        enabled: false
+      events:
+        weight: 31
         enabled: false
       figures:
         weight: 24
@@ -44,8 +47,23 @@ settings:
       layout:
         weight: 11
         enabled: false
+      leader:
+        weight: 35
+        enabled: false
+      media_centre:
+        weight: 36
+        enabled: false
+      news_and_stories:
+        weight: 37
+        enabled: false
       node:
         weight: 27
+        enabled: false
+      ocha_datawrapper:
+        weight: 39
+        enabled: false
+      regions:
+        weight: 40
         enabled: false
       reliefweb_document:
         weight: 28
@@ -53,17 +71,26 @@ settings:
       reliefweb_river:
         weight: 29
         enabled: false
-      rss_feed:
-        weight: 30
+      reliefweb_river_curated:
+        weight: 43
         enabled: false
-      rw_key_figures:
-        weight: 31
+      resources:
+        weight: 44
         enabled: false
-      tab:
-        weight: 32
-        enabled: true
-      tabs:
-        weight: 33
+      response_map:
+        weight: 46
+        enabled: false
+      responses:
+        weight: 45
+        enabled: false
+      section:
+        weight: 47
+        enabled: false
+      stories:
+        weight: 48
+        enabled: false
+      subscribe:
+        weight: 49
         enabled: false
       text:
         weight: 12

--- a/config/field.field.node.media_collection.field_custom_content.yml
+++ b/config/field.field.node.media_collection.field_custom_content.yml
@@ -73,6 +73,9 @@ settings:
       node:
         weight: 32
         enabled: false
+      ocha_datawrapper:
+        weight: 39
+        enabled: false
       regions:
         weight: 33
         enabled: false

--- a/config/field.field.node.region.field_custom_content.yml
+++ b/config/field.field.node.region.field_custom_content.yml
@@ -20,20 +20,23 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    target_bundles: {  }
+    target_bundles: null
     negate: 1
     target_bundles_drag_drop:
       call_to_action:
         weight: 17
         enabled: false
-      content_list:
-        weight: 21
+      campaign:
+        weight: 28
         enabled: false
-      datawrapper:
-        weight: 21
+      cbpf:
+        weight: 29
         enabled: false
-      embed:
-        weight: 22
+      donors:
+        weight: 30
+        enabled: false
+      events:
+        weight: 31
         enabled: false
       figures:
         weight: 24
@@ -44,8 +47,23 @@ settings:
       layout:
         weight: 24
         enabled: false
+      leader:
+        weight: 35
+        enabled: false
+      media_centre:
+        weight: 36
+        enabled: false
+      news_and_stories:
+        weight: 37
+        enabled: false
       node:
         weight: 25
+        enabled: false
+      ocha_datawrapper:
+        weight: 39
+        enabled: false
+      regions:
+        weight: 40
         enabled: false
       reliefweb_document:
         weight: 27
@@ -53,17 +71,26 @@ settings:
       reliefweb_river:
         weight: 28
         enabled: false
-      rss_feed:
-        weight: 29
+      reliefweb_river_curated:
+        weight: 43
         enabled: false
-      rw_key_figures:
-        weight: 30
+      resources:
+        weight: 44
         enabled: false
-      tab:
-        weight: 32
-        enabled: true
-      tabs:
-        weight: 33
+      response_map:
+        weight: 46
+        enabled: false
+      responses:
+        weight: 45
+        enabled: false
+      section:
+        weight: 47
+        enabled: false
+      stories:
+        weight: 48
+        enabled: false
+      subscribe:
+        weight: 49
         enabled: false
       text:
         weight: 31

--- a/config/field.field.node.resource.field_custom_content.yml
+++ b/config/field.field.node.resource.field_custom_content.yml
@@ -29,14 +29,14 @@ settings:
       campaign:
         weight: 20
         enabled: false
-      content_list:
-        weight: 22
+      cbpf:
+        weight: 29
         enabled: false
-      datawrapper:
-        weight: 23
+      donors:
+        weight: 30
         enabled: false
-      embed:
-        weight: 24
+      events:
+        weight: 31
         enabled: false
       figures:
         weight: 25
@@ -47,8 +47,23 @@ settings:
       layout:
         weight: 27
         enabled: false
+      leader:
+        weight: 35
+        enabled: false
+      media_centre:
+        weight: 36
+        enabled: false
+      news_and_stories:
+        weight: 37
+        enabled: false
       node:
         weight: 28
+        enabled: false
+      ocha_datawrapper:
+        weight: 39
+        enabled: false
+      regions:
+        weight: 40
         enabled: false
       reliefweb_document:
         weight: 29
@@ -56,14 +71,26 @@ settings:
       reliefweb_river:
         weight: 30
         enabled: false
-      rss_feed:
-        weight: 31
+      reliefweb_river_curated:
+        weight: 43
         enabled: false
-      rw_key_figures:
-        weight: 32
+      resources:
+        weight: 44
+        enabled: false
+      response_map:
+        weight: 46
+        enabled: false
+      responses:
+        weight: 45
         enabled: false
       section:
         weight: 33
+        enabled: false
+      stories:
+        weight: 48
+        enabled: false
+      subscribe:
+        weight: 49
         enabled: false
       text:
         weight: 34

--- a/config/field.field.node.response.field_custom_content.yml
+++ b/config/field.field.node.response.field_custom_content.yml
@@ -20,20 +20,23 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    target_bundles: {  }
+    target_bundles: null
     negate: 1
     target_bundles_drag_drop:
       call_to_action:
         weight: 17
         enabled: false
-      content_list:
-        weight: 21
+      campaign:
+        weight: 28
         enabled: false
-      datawrapper:
-        weight: 21
+      cbpf:
+        weight: 29
         enabled: false
-      embed:
-        weight: 22
+      donors:
+        weight: 30
+        enabled: false
+      events:
+        weight: 31
         enabled: false
       figures:
         weight: 24
@@ -44,8 +47,23 @@ settings:
       layout:
         weight: 24
         enabled: false
+      leader:
+        weight: 35
+        enabled: false
+      media_centre:
+        weight: 36
+        enabled: false
+      news_and_stories:
+        weight: 37
+        enabled: false
       node:
         weight: 25
+        enabled: false
+      ocha_datawrapper:
+        weight: 39
+        enabled: false
+      regions:
+        weight: 40
         enabled: false
       reliefweb_document:
         weight: 27
@@ -53,17 +71,26 @@ settings:
       reliefweb_river:
         weight: 28
         enabled: false
-      rss_feed:
-        weight: 29
+      reliefweb_river_curated:
+        weight: 43
         enabled: false
-      rw_key_figures:
-        weight: 30
+      resources:
+        weight: 44
         enabled: false
-      tab:
-        weight: 32
-        enabled: true
-      tabs:
-        weight: 33
+      response_map:
+        weight: 46
+        enabled: false
+      responses:
+        weight: 45
+        enabled: false
+      section:
+        weight: 47
+        enabled: false
+      stories:
+        weight: 48
+        enabled: false
+      subscribe:
+        weight: 49
         enabled: false
       text:
         weight: 31

--- a/config/field.field.node.story.field_custom_content.yml
+++ b/config/field.field.node.story.field_custom_content.yml
@@ -20,20 +20,23 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    target_bundles: {  }
+    target_bundles: null
     negate: 1
     target_bundles_drag_drop:
       call_to_action:
         weight: 16
         enabled: false
-      content_list:
-        weight: 21
+      campaign:
+        weight: 28
         enabled: false
-      datawrapper:
-        weight: 19
+      cbpf:
+        weight: 29
         enabled: false
-      embed:
-        weight: 20
+      donors:
+        weight: 30
+        enabled: false
+      events:
+        weight: 31
         enabled: false
       figures:
         weight: 24
@@ -44,8 +47,23 @@ settings:
       layout:
         weight: 22
         enabled: false
+      leader:
+        weight: 35
+        enabled: false
+      media_centre:
+        weight: 36
+        enabled: false
+      news_and_stories:
+        weight: 37
+        enabled: false
       node:
         weight: 23
+        enabled: false
+      ocha_datawrapper:
+        weight: 39
+        enabled: false
+      regions:
+        weight: 40
         enabled: false
       reliefweb_document:
         weight: 25
@@ -53,17 +71,26 @@ settings:
       reliefweb_river:
         weight: 26
         enabled: false
-      rss_feed:
-        weight: 27
+      reliefweb_river_curated:
+        weight: 43
         enabled: false
-      rw_key_figures:
-        weight: 28
+      resources:
+        weight: 44
         enabled: false
-      tab:
-        weight: 32
-        enabled: true
-      tabs:
-        weight: 33
+      response_map:
+        weight: 46
+        enabled: false
+      responses:
+        weight: 45
+        enabled: false
+      section:
+        weight: 47
+        enabled: false
+      stories:
+        weight: 48
+        enabled: false
+      subscribe:
+        weight: 49
         enabled: false
       text:
         weight: 29


### PR DESCRIPTION
Refs: UNO-824

No change in functionality. This simply sync the field_custom_content config from DB to code. It mostly updates the list of paragraph types that can be include/excluded. The config files contained old paragraph types from the dev stage. Only the media collection node type actually limits the selection of paragraph types. 