### PR TITLE
Deploy 14-08-2024

### DIFF
--- a/config/seckit.settings.yml
+++ b/config/seckit.settings.yml
@@ -8,7 +8,7 @@ seckit_xss:
       webkit: false
     report-only: false
     default-src: "'self'"
-    script-src: "'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com https://cdn.popupsmart.com  https://cdnjs.cloudflare.com"
+    script-src: "'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com https://cdn.popupsmart.com  https://cdnjs.cloudflare.com https://cbpfgms.github.io"
     object-src: "'none'"
     style-src: "'self' 'unsafe-inline' https://googletagmanager.com https://tagmanager.google.com fonts.googleapis.com https://www.google.com https://cdnjs.cloudflare.com"
     img-src: "'self' data: https://*"

--- a/html/modules/custom/ocha_mediavalet/ocha_mediavalet.module
+++ b/html/modules/custom/ocha_mediavalet/ocha_mediavalet.module
@@ -61,6 +61,7 @@ function ocha_mediavalet_oembed_resource_url_alter(array &$parsed_url, Provider 
       $oembed_base_url = \Drupal::request()->getSchemeAndHttpHost();
     }
 
+    $oembed_base_url = rtrim($oembed_base_url, '/');
     $parsed_url['path'] = $oembed_base_url . '/mediavalet/oembed';
   }
 }


### PR DESCRIPTION
## Features
UNO-842 - Add MediaValet

## Chores
OPS-10638 - Updates including to Drupal Core 10.3
OPS-13098 - add and configure seckit 

## Updates
| Production Changes                 | From         | To           | Compare                                                                                      |
|------------------------------------|--------------|--------------|----------------------------------------------------------------------------------------------|
| drupal/admin_denied                | 2.0.0        | 2.0.1        | [...](https://git.drupalcode.org/project/admin_denied/compare/2.0.0...2.0.1)                 |
| drupal/allowed_formats             | 3.0.0        | 3.0.1        | [...](https://git.drupalcode.org/project/allowed_formats/compare/3.0.0...3.0.1)              |
| drupal/core                        | 10.2.7       | 10.3.2       | [...](https://github.com/drupal/core/compare/10.2.7...10.3.2)                                |
| drupal/core-composer-scaffold      | 10.2.7       | 10.3.2       | [...](https://github.com/drupal/core-composer-scaffold/compare/10.2.7...10.3.2)              |
| drupal/core-dev                    | 10.2.7       | 10.3.2       | [...](https://github.com/drupal/core-dev/compare/10.2.7...10.3.2)                            |
| drupal/core-recommended            | 10.2.7       | 10.3.2       | [...](https://github.com/drupal/core-recommended/compare/10.2.7...10.3.2)                    |
| drupal/csp                         | 1.31.0       | 1.33.0       | [...](https://git.drupalcode.org/project/csp/compare/1.31.0...1.33.0)                        |
| drupal/entity_reference_revisions  | 1.11.0       | 1.12.0       | [...](https://git.drupalcode.org/project/entity_reference_revisions/compare/1.11.0...1.12.0) |
| drupal/entity_usage                | 2.0.0-beta12 | 2.0.0-beta13 | [...](https://git.drupalcode.org/project/entity_usage/compare/2.0.0-beta12...2.0.0-beta13)   |
| drupal/environment_indicator       | 4.0.18       | 4.0.19       | [...](https://git.drupalcode.org/project/environment_indicator/compare/4.0.18...4.0.19)      |
| drupal/externalauth                | 2.0.5        | 2.0.6        | [...](https://git.drupalcode.org/project/externalauth/compare/2.0.5...2.0.6)                 |
| drupal/file_mdm                    | 3.0.0        | 3.1.0        | [...](https://git.drupalcode.org/project/file_mdm/compare/3.0.0...3.1.0)                     |
| drupal/geofield                    | 1.57.0       | 1.60.0       | [...](https://git.drupalcode.org/project/geofield/compare/1.57.0...1.60.0)                   |
| drupal/key                         | 1.18.0       | 1.19.0       | [...](https://git.drupalcode.org/project/key/compare/1.18.0...1.19.0)                        |
| drupal/layout_paragraphs           | 2.0.5        | 2.0.8        | [...](https://git.drupalcode.org/project/layout_paragraphs/compare/2.0.5...2.0.8)            |
| drupal/memcache                    | 2.5.0        | 2.6.0        | [...](https://git.drupalcode.org/project/memcache/compare/2.5.0...2.6.0)                     |
| drupal/metatag                     | 2.0.0        | 2.0.2        | [...](https://git.drupalcode.org/project/metatag/compare/2.0.0...2.0.2)                      |
| drupal/paragraphs                  | 1.17.0       | 1.18.0       | [...](https://git.drupalcode.org/project/paragraphs/compare/1.17.0...1.18.0)                 |
| drupal/pathauto                    | 1.12.0       | 1.13.0       | [...](https://git.drupalcode.org/project/pathauto/compare/1.12.0...1.13.0)                   |
| drupal/samlauth                    | 3.9.0        | 3.10.0       | [...](https://git.drupalcode.org/project/samlauth/compare/3.9.0...3.10.0)                    |
| drupal/stable                      | 2.0.0        | 2.1.0        | [...](https://git.drupalcode.org/project/stable/compare/2.0.0...2.1.0)                       |
| drupal/stage_file_proxy            | 2.1.4        | 3.1.0        | [...](https://git.drupalcode.org/project/stage_file_proxy/compare/2.1.4...3.1.0)             |
| drupal/token                       | 1.14.0       | 1.15.0       | [...](https://git.drupalcode.org/project/token/compare/1.14.0...1.15.0)                      |
| drupal/user_expire                 | 1.1.0        | 1.2.0        | [...](https://git.drupalcode.org/project/user_expire/compare/1.1.0...1.2.0)                  |
| drupal/viewsreference              | 2.0.0-beta8  | 2.0.0-beta9  | [...](https://git.drupalcode.org/project/viewsreference/compare/2.0.0-beta8...2.0.0-beta9)   |
| unocha/common_design               | v9.4.1       | v9.4.3       | [...](https://github.com/UN-OCHA/common_design/compare/v9.4.1...v9.4.3)                      |
| unocha/gtm_barebones               | 1.1.2        | 1.1.3        | [...](https://github.com/UN-OCHA/gtm_barebones/compare/1.1.2...1.1.3)                        |
| unocha/ocha_monitoring             | 1.0.17       | 1.0.18       | [...](https://github.com/UN-OCHA/ocha_monitoring/compare/1.0.17...1.0.18)                    |
| dompdf/php-font-lib                | NEW          | 1.0.0        |                                                                                              |
| drupal/google_tag                  | NEW          | 2.0.6        |                                                                                              |
| drupal/media_library_extend        | NEW          | 2.1.0-alpha1 |                                                                                              |
| drupal/seckit                      | NEW          | 2.0.1        |                                                                                              |
| drupal/select_a11y                 | NEW          | 6941944      |                                                                                              |
