### PR TITLE
Deploy 21-02-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [2.3.1](https://github.com/UN-OCHA/unocha-site/compare/v2.3.0...v2.3.1) (2025-02-20)
+
+### Chores
+
+* Remove unused module ([724a2b](https://github.com/UN-OCHA/unocha-site/commit/724a2beaf7f8ca38bf6295464db1ca912ae7b868))
+* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([609816](https://github.com/UN-OCHA/unocha-site/commit/6098167952cc0fb9a613d04ee1e53e3d4da16af7))
+
 ## [2.3.0](https://github.com/UN-OCHA/unocha-site/compare/v2.2.2...v2.3.0) (2025-02-18)
 
 ### Features

--- a/composer.json
+++ b/composer.json
@@ -265,5 +265,5 @@
             "scripts\\composer\\DrupalLenientRequirement::changeVersionConstraint"
         ]
     },
-    "version": "2.3.0"
+    "version": "2.3.1"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "660eb4a69cdcd426769a0cf9ceaf28e1",
+    "content-hash": "f860bcc59c1bbd733430d358b6284bd4",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [2.3.1](https://github.com/UN-OCHA/unocha-site/compare/v2.3.0...v2.3.1) (2025-02-20)

### Chores

* Remove unused module ([724a2b](https://github.com/UN-OCHA/unocha-site/commit/724a2beaf7f8ca38bf6295464db1ca912ae7b868))
* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([609816](https://github.com/UN-OCHA/unocha-site/commit/6098167952cc0fb9a613d04ee1e53e3d4da16af7))

## Composer changes

| Production Changes             | From         | To           | Compare                                                                                               |
|--------------------------------|--------------|--------------|-------------------------------------------------------------------------------------------------------|
| aws/aws-sdk-php                | 3.339.12     | 3.339.17     | [...](https://github.com/aws/aws-sdk-php/compare/3.339.12...3.339.17)                                 |
| drupal/allowed_formats         | 3.0.1        | REMOVED      |                                                                                                       |
| drupal/amazon_ses              | 3.1.0        | 3.1.1        | [...](https://git.drupalcode.org/project/amazon_ses/compare/3.1.0...3.1.1)                            |
| drupal/core                    | 10.4.2       | 10.4.3       | [...](https://github.com/drupal/core/compare/10.4.2...10.4.3)                                         |
| drupal/core-composer-scaffold  | 10.4.2       | 10.4.3       | [...](https://github.com/drupal/core-composer-scaffold/compare/10.4.2...10.4.3)                       |
| drupal/core-dev                | 10.4.2       | 10.4.3       | [...](https://github.com/drupal/core-dev/compare/10.4.2...10.4.3)                                     |
| drupal/core-recommended        | 10.4.2       | 10.4.3       | [...](https://github.com/drupal/core-recommended/compare/10.4.2...10.4.3)                             |
| drupal/datetime_range_timezone | 1.0.0-alpha4 | 1.0.0-alpha5 | [...](https://git.drupalcode.org/project/datetime_range_timezone/compare/1.0.0-alpha4...1.0.0-alpha5) |
| drupal/entity_browser          | 2.12.0       | 2.13.0       | [...](https://git.drupalcode.org/project/entity_browser/compare/2.12.0...2.13.0)                      |
| drupal/entity_usage            | 2.0.0-beta17 | 2.0.0-beta19 | [...](https://git.drupalcode.org/project/entity_usage/compare/2.0.0-beta17...2.0.0-beta19)            |
| drupal/honeypot                | 2.2.1        | 2.2.2        | [...](https://git.drupalcode.org/project/honeypot/compare/2.2.1...2.2.2)                              |
| drupal/monitoring              | 1.15.0       | 1.16.0       | [...](https://git.drupalcode.org/project/monitoring/compare/1.15.0...1.16.0)                          |
| drupal/openid_connect          | 3.0.0-alpha5 | 3.0.0-alpha6 | [...](https://git.drupalcode.org/project/openid_connect/compare/3.0.0-alpha5...3.0.0-alpha6)          |
| phpstan/phpstan                | 1.12.17      | 1.12.19      | [...](https://github.com/phpstan/phpstan/compare/1.12.17...1.12.19)                                   |

