### PR TITLE
Deploy 21-03-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [2.4.1](https://github.com/UN-OCHA/unocha-site/compare/v2.4.0...v2.4.1) (2025-03-20)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([72b711](https://github.com/UN-OCHA/unocha-site/commit/72b7115cb24544190d3b867fe408d322b4605f86))
+
 ## [2.4.0](https://github.com/UN-OCHA/unocha-site/compare/v2.3.1...v2.4.0) (2025-03-18)
 
 ### Features

--- a/composer.json
+++ b/composer.json
@@ -265,5 +265,5 @@
             "scripts\\composer\\DrupalLenientRequirement::changeVersionConstraint"
         ]
     },
-    "version": "2.4.0"
+    "version": "2.4.1"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e31ebab3a27ab8b438ac6e80da49d7e4",
+    "content-hash": "be031ecbaf6dfa428633591b322d50c7",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [2.4.1](https://github.com/UN-OCHA/unocha-site/compare/v2.4.0...v2.4.1) (2025-03-20)

### Chores

* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([72b711](https://github.com/UN-OCHA/unocha-site/commit/72b7115cb24544190d3b867fe408d322b4605f86))

## Composer changes

| Production Changes            | From    | To      | Compare                                                                         |
|-------------------------------|---------|---------|---------------------------------------------------------------------------------|
| aws/aws-sdk-php               | 3.342.4 | 3.342.9 | [...](https://github.com/aws/aws-sdk-php/compare/3.342.4...3.342.9)             |
| drupal/core                   | 10.4.4  | 10.4.5  | [...](https://github.com/drupal/core/compare/10.4.4...10.4.5)                   |
| drupal/core-composer-scaffold | 10.4.4  | 10.4.5  | [...](https://github.com/drupal/core-composer-scaffold/compare/10.4.4...10.4.5) |
| drupal/core-recommended       | 10.4.4  | 10.4.5  | [...](https://github.com/drupal/core-recommended/compare/10.4.4...10.4.5)       |
| psy/psysh                     | v0.12.7 | v0.12.8 | [...](https://github.com/bobthecow/psysh/compare/v0.12.7...v0.12.8)             |
| unocha/ocha_monitoring        | 1.1.0   | 1.1.1   | [...](https://github.com/UN-OCHA/ocha_monitoring/compare/1.1.0...1.1.1)         |

