### PR TITLE
fix(bug): Avoid a deprecation warning by never comparing floats with integers.

### DIFF
--- a/html/modules/custom/unocha_utility/src/Helpers/NumberFormatter.php
+++ b/html/modules/custom/unocha_utility/src/Helpers/NumberFormatter.php
@@ -448,10 +448,10 @@ class NumberFormatter {
         elseif ($n === 2) {
           return 'two';
         }
-        elseif (($n % 100 >= 3) && ($n % 100 <= 10)) {
+        elseif (($i % 100 >= 3) && ($i % 100 <= 10)) {
           return 'few';
         }
-        elseif (($n % 100 >= 11) && ($n % 100 <= 99)) {
+        elseif (($i % 100 >= 11) && ($i % 100 <= 99)) {
           return 'many';
         }
         return 'other';


### PR DESCRIPTION
Because we use the modulo anyway, we can simply use the integer digits.

Refs: UNO-903